### PR TITLE
[Wave] Update documentation page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
-# IREE Turbine Documentation
+# Wave Documentation
 
 This directory uses Sphinx to build documentation that is hosted at
-https://iree-turbine.readthedocs.io/.
+https://wave-lang.readthedocs.io/.
 
 ## Publishing on Read the Docs
 
 The project dashboard is here:
-https://app.readthedocs.org/projects/iree-turbine/.
+https://app.readthedocs.org/projects/wave-lang/.
 
-A webhook is configured in the iree-turbine GitHub repository to notify
+A webhook is configured in the wave GitHub repository to notify
 readthedocs when new changes are pushed, at which point it automatically starts
 a website build and publishes the latest content.
 
@@ -26,7 +26,7 @@ source .venv/bin/activate
 python -m pip install -r requirements.txt
 python -m pip install -r ../pytorch-cpu-requirements.txt
 
-# Install iree-turbine itself.
+# Install wave itself.
 # Editable so you can make local changes and preview them easily.
 python -m pip install -e ..
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ except ImportError:
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "IREE Turbine"
+project = "Wave"
 copyright = "2025, The IREE Authors"
 author = "The IREE Authors"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
-IREE Turbine documentation
+Wave documentation
 ==========================
 
-Welcome to the documentation for https://github.com/iree-org/iree-turbine!
+Welcome to the documentation for https://github.com/iree-org/wave!
 
 API reference material
 ======================


### PR DESCRIPTION
This PR updates the titles of the docs and the links to the documentation for wave. A new read the docs site has been created that can be used to host all wave related documentation.