### PR TITLE
pytorch 2.8

### DIFF
--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,4 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<2.8
+torch>=2.6,<2.9
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,4 +1,4 @@
 --index-url https://download.pytorch.org/whl/rocm6.3
-torch>=2.6,<2.8
+torch>=2.6,<2.9
 torchaudio
 torchvision


### PR DESCRIPTION
Tracking the pytorch 2.8 release planned for 7/30/2025

This PR is mostly for tracking CI status.

copy of https://github.com/iree-org/iree-turbine/pull/1029