### PR TITLE
[Wave] add thread_printf op

### DIFF
--- a/wave_lang/kernel/wave/utils/graph_utils.py
+++ b/wave_lang/kernel/wave/utils/graph_utils.py
@@ -190,8 +190,7 @@ def get_users(
             else:
                 subgraph = custom.get_root_graph().subgraphs[custom.subgraph_name]
                 var = custom.get_captured_fx_node(subgraph, node)
-                assert var is not None, "Invalid captured var"
-                for u in var.users:
+                for u in getattr(var, "users", []):
                     users.append(u)
 
             continue


### PR DESCRIPTION
Before merging this, I want some feedback on extract.

To write a semi-realistic test that matched what I was trying to do manually, I needed something like extract.  But (1) extract is broken and (2) I believe I'm using it wrong.

The extract op currently has no users, and it is broken because it accesses the index field during type inference before the index field is set.

I am using it to reduce a 2-d matrix twice to get to a scalar, but I think it is intended to just reduce a 1-d vector to a scalar.  Also, since it returns a vector (though it may be a 1-d vector), I added extract_scalar to produce a non-vector value.  Perhaps I should handle this in thread_printf by checking for vector types and extracting them there.  But I wanted to get some feedback about what to do about extraction at all before doing that.

Do we want any way to target a single value from our wave-level types so that thread_printf can target individual elements in wave registers?

Anyway, I can drop the changes to extract (and addition of extract_scalar) and simplify the test to something more trivial, but it remains to be seen whether this thread-level printf can really be useful.

This PR depends on the gpu.printf lowering in iree in https://github.com/iree-org/iree/pull/21360

This PR depends on the DCE fix in https://github.com/iree-org/wave/pull/5
