### PR TITLE
[Wave] Fix lit tests

### DIFF
--- a/lit_tests/kernel/wave/scaled_gemm.py
+++ b/lit_tests/kernel/wave/scaled_gemm.py
@@ -83,6 +83,7 @@ def test_scaled_gemm_mxfp4():
         schedule=SchedulingType.NONE,
         backend="rocm",
         target="gfx950",
+        compile_to_mlir=True,
     )
 
     scaled_gemm = wave_compile(options, scaled_gemm)
@@ -181,6 +182,7 @@ def test_scaled_gemm_mxfp8():
         schedule=SchedulingType.NONE,
         backend="rocm",
         target="gfx950",
+        compile_to_mlir=True,
     )
 
     scaled_gemm = wave_compile(options, scaled_gemm)

--- a/lit_tests/kernel/wave/scaled_mma.py
+++ b/lit_tests/kernel/wave/scaled_mma.py
@@ -72,6 +72,7 @@ def test_mxfp4_scaled_mma_16x16x128():
         canonicalize=True,
         backend="rocm",
         target="gfx950",
+        compile_to_mlir=True,
     )
     scaled_mma = wave_compile(options, scaled_mma)
     print(scaled_mma.asm)
@@ -196,6 +197,7 @@ def test_mxfp8_scaled_mma_16x16x128():
         canonicalize=True,
         backend="rocm",
         target="gfx950",
+        compile_to_mlir=True,
     )
     scaled_mma = wave_compile(options, scaled_mma)
     print(scaled_mma.asm)
@@ -347,6 +349,7 @@ def test_mxfp4_scaled_mma_256x256x256():
         canonicalize=True,
         backend="rocm",
         target="gfx950",
+        compile_to_mlir=True,
     )
     scaled_mma = wave_compile(options, scaled_mma)
     print(scaled_mma.asm)


### PR DESCRIPTION
Recent lit tests did not specify the compile_to_mlir option to be true, which meant that we were compiling the entire vmfb for the lit tests. This PR fixes that.