### PR TITLE
[Wave] Add schedule reordering support for BMK,NK->BMN

### DIFF
--- a/lit_tests/kernel/wave/scaled_gemm.py
+++ b/lit_tests/kernel/wave/scaled_gemm.py
@@ -358,3 +358,151 @@ def packed_mxfp4_test():
 
     # Epilogue MFMA
     # CHECK-COUNT-64: amdgpu.scaled_mfma
+
+
+@run_test
+def batched_prefetch_mxfp4_test():
+    mfma_variant = tkw.ScaledMMAType.F32_16x16x128_F8F6F4
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, vector_shapes={B: 0}, mma_type=mfma_variant
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def batched_gemm_mxfp4_prefetch(
+        a: tkl.Memory[B, M, K / 2, ADDRESS_SPACE, tkl.i8],
+        a_scale: tkl.Memory[B, M, K / 32, ADDRESS_SPACE, tkl.i8],
+        b: tkl.Memory[N, K / 2, ADDRESS_SPACE, tkl.i8],
+        b_scale: tkl.Memory[N, K / 32, ADDRESS_SPACE, tkl.i8],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(
+            acc: tkl.Register[B, M, N, tkl.f32],
+        ) -> tkl.Register[B, M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            a_reg = tkw.bitcast(a_reg, tkl.f4e2m1fn)
+            a_scale_reg = tkw.read(a_scale)
+            a_scale_reg = tkw.bitcast(a_scale_reg, tkl.f8e8m0fnu)
+            b_reg = tkw.read(b)
+            b_reg = tkw.bitcast(b_reg, tkl.f4e2m1fn)
+            b_scale_reg = tkw.read(b_scale)
+            b_scale_reg = tkw.bitcast(b_scale_reg, tkl.f8e8m0fnu)
+            acc = tkw.scaled_mma(a_reg, a_scale_reg, b_reg, b_scale_reg, acc)
+            return acc
+
+        tkw.write(repeat, c)
+
+    shape = (8, 1024, 1024, 1024)
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_B: 1,
+        BLOCK_M: 256,
+        BLOCK_N: 256,
+        BLOCK_K: 256,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K: shape[3],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 8,
+        SHUFFLE_UNITS: 8,
+    }
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        schedule=SchedulingType.PREFETCH,
+        compile_to_mlir=True,
+    )
+    batched_gemm_mxfp4_prefetch = wave_compile(options, batched_gemm_mxfp4_prefetch)
+    print(batched_gemm_mxfp4_prefetch.asm)
+
+    # CHECK-LABEL:    batched_gemm_mxfp4_prefetch
+
+    # Prologue Global Read
+    # CHECK-COUNT-4:  vector.load {{.*}} : memref<8x1024x512xi8, strided<[524288, 512, 1], offset: ?>>, vector<16xi8>
+    # CHECK:          vector.load {{.*}} : memref<8x1024x32xi8, strided<[32768, 32, 1], offset: ?>>, vector<4xi8>
+    # CHECK-COUNT-4:  vector.load {{.*}} : memref<1024x512xi8, strided<[512, 1], offset: ?>>, vector<16xi8>
+    # CHECK:          vector.load {{.*}} : memref<1024x32xi8, strided<[32, 1], offset: ?>>, vector<4xi8>
+
+    # Prologue Local Write
+    # CHECK-COUNT-4:  vector.store {{.*}} : memref<1x256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+    # CHECK:          vector.store {{.*}} : memref<1x256x16xi8, #gpu.address_space<workgroup>>, vector<4xi8>
+    # CHECK-COUNT-4:  vector.store {{.*}} : memref<256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+    # CHECK:          vector.store {{.*}} : memref<256x16xi8, #gpu.address_space<workgroup>>, vector<4xi8>
+
+    # Steady State
+    # CHECK:          scf.for
+
+    # Steady State global_load_rhs_scale
+    # CHECK:            vector.load %{{.*}} : memref<1024x32xi8, strided<[32, 1], offset: ?>>, vector<4xi8>
+    # Steady State local_load_rhs_scale
+    # CHECK=COUNT-16:   vector.load %{{.*}} : memref<256x16xi8, #gpu.address_space<workgroup>>, vector<1xi8>
+
+    # Steady State global_load_lhs_scale
+    # CHECK:            vector.load %{{.*}} : memref<8x1024x32xi8, strided<[32768, 32, 1], offset: ?>>, vector<4xi8>
+    # Steady State local_load_lhs_scale
+    # CHECK=COUNT-16:   vector.load %{{.*}} : memref<1x256x16xi8, #gpu.address_space<workgroup>>, vector<1xi8>
+
+    # Steady State global_load_rhs
+    # CHECK-COUNT-4:    vector.load %{{.*}} : memref<1024x512xi8, strided<[512, 1], offset: ?>>, vector<16xi8>
+    # Steady State local_load_rhs
+    # CHECK=COUNT-16:   vector.load %{{.*}} : memref<256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+
+    # Steady State global_load_lhs
+    # CHECK-COUNT-4:    vector.load %{{.*}} : memref<8x1024x512xi8, strided<[524288, 512, 1], offset: ?>>, vector<16xi8>
+    # Steady State local_load_lhs
+    # CHECK=COUNT-16:   vector.load %{{.*}} : memref<1x256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+
+    # Steady State MFMA
+    # CHECK-COUNT-64:   amdgpu.scaled_mfma
+
+    # Steady State Local Write (lhs_scale, rhs_scale, lhs, rhs)
+    # CHECK:            vector.store {{.*}} : memref<1x256x16xi8, #gpu.address_space<workgroup>>, vector<4xi8>
+    # CHECK:            vector.store {{.*}} : memref<256x16xi8, #gpu.address_space<workgroup>>, vector<4xi8>
+    # CHECK-COUNT-4:    vector.store {{.*}} : memref<1x256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+    # CHECK-COUNT-4:    vector.store {{.*}} : memref<256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+    # CHECK:            scf.yield
+    # CHECK:          }
+
+    # Epilogue Local Read
+    # CHECK-COUNT-16: vector.load {{.*}} : memref<256x16xi8, #gpu.address_space<workgroup>>, vector<1xi8>
+    # CHECK-COUNT-16: vector.load {{.*}} : memref<256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+    # CHECK-COUNT-8:  vector.load {{.*}} : memref<1x256x16xi8, #gpu.address_space<workgroup>>, vector<1xi8>
+    # CHECK-COUNT-8:  vector.load {{.*}} : memref<1x256x136xi8, #gpu.address_space<workgroup>>, vector<16xi8>
+
+    # Epilogue MFMA
+    # CHECK-COUNT-64: amdgpu.scaled_mfma

--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -228,7 +228,7 @@ def testScaledGemmMXFP4(
         ScaledMMAType.F32_16x16x128_F8F6F4,
     ],
 )
-@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.PREFETCH])
 def testScaledBatchedGemmMXFP4(
     batch: int,
     shape: tuple[int],


### PR DESCRIPTION
Linear layers are typically of this format BMK,NK->BMN, previously we would have failed to determine batch dim because rhs do not have B, but with this patch, we implemented a batch filtering dimension by checking the vector_shapes from hw_constraint.