### PR TITLE
[Wave] Use pytest fixtures to get perf options instead of doing it manually each time

### DIFF
--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -42,7 +42,6 @@ class WaveCompileOptions:
     benchmark_results_file: str = None
     capture_trace: bool = False
     bench_with_constant_weights: bool = False
-    bench_file: str = None
 
     # === Cache options ===
     kernel_hash: str = None

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -176,7 +176,7 @@ def invoke_vmfb(
             options.func_name,
             **benchmark_flags,
         )
-        _print_bench_result(benchmark_results, options.bench_file)
+        _print_bench_result(benchmark_results, options.benchmark_results_file)
 
 
 def invoke_with_wave_runtime(

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -162,6 +162,7 @@ def invoke_vmfb(
         func,
         kernel_inputs,
         kernel_outputs,
+        dynamic_symbols,
         scalar_args,
         dynamic_symbols,
     )

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -162,7 +162,6 @@ def invoke_vmfb(
         func,
         kernel_inputs,
         kernel_outputs,
-        dynamic_symbols,
         scalar_args,
         dynamic_symbols,
     )
@@ -172,6 +171,7 @@ def invoke_vmfb(
             options,
             kernel_inputs,
             kernel_outputs,
+            dynamic_symbols,
             vmfb,
             options.func_name,
             **benchmark_flags,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,44 @@ def seed_torch():
     torch.manual_seed(0)
 
 
+@pytest.fixture
+def run_bench(request):
+    return request.config.getoption("--runperf")
+
+
+@pytest.fixture
+def dump_perf_path(request):
+    return request.config.getoption("--dump-perf-files-path")
+
+
+@pytest.fixture
+def perf_filename_tk(dump_perf_path, request):
+    if dump_perf_path is None:
+        return None
+
+    return os.path.join(dump_perf_path, "tk_" + request.node.name + ".json")
+
+
+@pytest.fixture
+def perf_filename_tk2(dump_perf_path, request):
+    if dump_perf_path is None:
+        return (None, None)
+
+    name = request.node.name
+    return (
+        os.path.join(dump_perf_path, "tk_" + name + "_1.json"),
+        os.path.join(dump_perf_path, "tk_" + name + "_2.json"),
+    )
+
+
+@pytest.fixture
+def perf_filename_iree(dump_perf_path, request):
+    if dump_perf_path is None:
+        return None
+
+    return os.path.join(dump_perf_path, "iree_" + request.node.name + ".json")
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-e2e", action="store_true", default=False, help="run e2e tests"

--- a/tests/kernel/wave/attention/alibi_attention_test.py
+++ b/tests/kernel/wave/attention/alibi_attention_test.py
@@ -115,7 +115,8 @@ def test_alibi_attention(
     shape: tuple[int],
     dtype: torch.dtype,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     shape = AttentionShape(
         num_query_heads=shape[0],
@@ -134,8 +135,6 @@ def test_alibi_attention(
     output_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
 
     hyperparams.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
 
     log2e = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)
@@ -148,11 +147,7 @@ def test_alibi_attention(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     alibi_attention = wave_compile(options, alibi_attention)

--- a/tests/kernel/wave/attention/chained_gemm_test.py
+++ b/tests/kernel/wave/attention/chained_gemm_test.py
@@ -53,10 +53,9 @@ def testChainedGemm(
     shape: tuple[int],
     enable_scheduling: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -142,7 +141,6 @@ def testChainedGemm(
     }
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -150,9 +148,7 @@ def testChainedGemm(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     chained_gemm = wave_compile(options, chained_gemm)
@@ -200,10 +196,9 @@ def testChainedGemmF8(
     shape: tuple[int],
     enable_scheduling: bool,
     mfma_variant: tuple[MMAType, MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -299,11 +294,7 @@ def testChainedGemmF8(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     chained_gemm_f8 = wave_compile(options, chained_gemm_f8)

--- a/tests/kernel/wave/attention/decode_attention_test.py
+++ b/tests/kernel/wave/attention/decode_attention_test.py
@@ -59,7 +59,7 @@ def testFlashDecoding(
     dynamic_dims: bool,
     mfma_variant: MMAType,
     run_bench,
-    perf_filename_tk,
+    perf_filename_tk2,
 ):
     (
         phase_0,
@@ -92,11 +92,7 @@ def testFlashDecoding(
         dynamic_symbols=dynamic_symbols_0,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[0],
     )
     options = set_default_run_config(options)
     phase_0 = wave_compile(options, phase_0)
@@ -119,11 +115,7 @@ def testFlashDecoding(
         dynamic_symbols=dynamic_symbols_1,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[1],
     )
     options = set_default_run_config(options)
     phase_1 = wave_compile(options, phase_1)

--- a/tests/kernel/wave/attention/decode_attention_test.py
+++ b/tests/kernel/wave/attention/decode_attention_test.py
@@ -58,10 +58,9 @@ def testFlashDecoding(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     (
         phase_0,
         phase_1,
@@ -161,11 +160,9 @@ def testGqaFlashDecoding(
     shape: AttentionShape,
     enable_scheduling: SchedulingType,
     mfma_variant: tuple[MMAType, MMAType],
-    request,
+    run_bench,
+    perf_filename_tk2,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-
     num_kv_splits = 8
     k_shape = (shape.num_seqs, shape.kv_seq_len, shape.num_kv_heads, shape.head_size)
     v_shape = (shape.num_seqs, shape.kv_seq_len, shape.num_kv_heads, shape.head_size_kv)
@@ -209,11 +206,7 @@ def testGqaFlashDecoding(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[0],
     )
     options = set_default_run_config(options)
     phase_0 = wave_compile(options, phase_0)
@@ -228,11 +221,7 @@ def testGqaFlashDecoding(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[1],
     )
     options = set_default_run_config(options)
     phase_1 = wave_compile(options, phase_1)

--- a/tests/kernel/wave/attention/evoformer_test.py
+++ b/tests/kernel/wave/attention/evoformer_test.py
@@ -85,10 +85,9 @@ def testEvoformerAttentionForward(
     enable_scheduling: bool,
     mfma_variant: MMAType,
     dtype: DataType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shapes_and_tile_sizes = [(x, y) for x, y in zip(shape, tile_sizes)]
     evoformer_fwd, symbols = get_evoformer_kernel(
         *shapes_and_tile_sizes, mfma_variant, dtype
@@ -106,11 +105,7 @@ def testEvoformerAttentionForward(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=1000,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     evoformer_fwd = wave_compile(options, evoformer_fwd)

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -339,7 +339,8 @@ def testExtendAttention(
     use_wave_runtime: bool,
     use_custom_mask: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     if is_causal and use_custom_mask:
         pytest.skip(
@@ -396,11 +397,6 @@ def testExtendAttention(
         use_custom_mask=use_custom_mask,
     )
     hyperparams.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-    perf_filename = construct_test_name(
-        "wave_extend_attention", mfma_variant, is_causal, shape
-    )
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -412,9 +408,7 @@ def testExtendAttention(
         use_buffer_store_ops=use_buffer_ops,
         benchmark_batch_size=1000,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
         dump_intermediates="./inter",
         gpu_native_math_precision=True,
         wave_runtime=(True if use_wave_runtime else False),
@@ -497,7 +491,8 @@ def testExtendRpeAttention(
     enable_scheduling: SchedulingType,
     is_causal: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     assert shape.num_query_heads % shape.num_kv_heads == 0
     (
@@ -550,11 +545,6 @@ def testExtendRpeAttention(
         max_rpe_context_length=max_rpe_context_length,
     )
     hyperparams.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-    perf_filename = construct_test_name(
-        "wave_extend_attention", mfma_variant, is_causal, shape
-    )
 
     options = WaveCompileOptions(
         subs=hyperparams,
@@ -565,9 +555,7 @@ def testExtendRpeAttention(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=1000,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     extend_attention_rpe = wave_compile(options, extend_attention_rpe)

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -10,7 +10,6 @@ import torch
 from torch.nn import functional as F
 from dataclasses import replace
 
-import iree.turbine.kernel as tk
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.utils.general_utils import (
     get_default_scheduling_params,
@@ -34,14 +33,10 @@ from iree.turbine.kernel.wave.templates.extend_attention import (
 from iree.turbine.kernel.wave.templates.extend_attention_rpe import (
     get_extend_attention_rpe_kernel,
 )
-from iree.turbine.kernel.wave.templates.prefill_attention import (
-    get_prefill_attention_kernel,
-)
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
 from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
-import os
 from enum import Enum
 from torch.testing import assert_close
 
@@ -52,9 +47,7 @@ from ..common.utils import (
     dump_generated_mlir,
     param_bool,
 )
-from ..common.shapes import get_test_shapes, construct_test_name
-from torch.nn.attention.flex_attention import flex_attention
-from torch.nn.attention.flex_attention import create_block_mask
+from ..common.shapes import get_test_shapes
 
 
 def t5_rpe_masked_cond(

--- a/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
@@ -58,11 +58,9 @@ def testGQABSHDAttention(
     causal: bool,
     sliding_window: int,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-
     if not causal:
         sliding_window = -1
 
@@ -86,7 +84,6 @@ def testGQABSHDAttention(
     k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
     v_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -97,9 +94,7 @@ def testGQABSHDAttention(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     base_attention = wave_compile(options, base_attention_func)
@@ -156,11 +151,9 @@ def testCausalGQABSHDAttentionF8(
     enable_scheduling: SchedulingType,
     sliding_window: int,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-
     # Sample tensor scaling from Brevitas SDXL-FP8.
     q_scale = 0.02578124962747097
     k_scale = 0.02363281324505806
@@ -189,7 +182,6 @@ def testCausalGQABSHDAttentionF8(
     k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
     v_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -200,9 +192,7 @@ def testCausalGQABSHDAttentionF8(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     base_attention = wave_compile(options, base_attention_func)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -201,7 +201,8 @@ def testPagedFlashDecoding(
     num_kv_splits: int,
     mfma_variant: MMAType,
     use_wave_runtime: bool,
-    request,
+    run_bench,
+    perf_filename_tk2,
 ):
     kv_lens = shape[6]
     shape = paged_decode_attention_shape(
@@ -268,8 +269,6 @@ def testPagedFlashDecoding(
     )
     hyperparams_0.update(get_default_scheduling_params())
     hyperparams_1.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
 
     phase_0_output_shape, phase_0_output_max_shape = (
         get_paged_decode_intermediate_arrays_shapes(shape, num_kv_splits)
@@ -291,11 +290,7 @@ def testPagedFlashDecoding(
         wave_runtime=use_wave_runtime,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[0],
     )
     options = set_default_run_config(options)
     phase_0 = wave_compile(options, phase_0)
@@ -321,11 +316,7 @@ def testPagedFlashDecoding(
         wave_runtime=use_wave_runtime,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[1],
     )
     options = set_default_run_config(options)
     phase_1 = wave_compile(options, phase_1)
@@ -387,7 +378,8 @@ def testPagedFlashDecodingMHA(
     enable_scheduling: SchedulingType,
     num_kv_splits: int,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk2,
 ):
     kv_lens = shape[5]
     shape = paged_decode_attention_shape(
@@ -451,8 +443,6 @@ def testPagedFlashDecodingMHA(
     )
     hyperparams_0.update(get_default_scheduling_params())
     hyperparams_1.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
 
     phase_0_output_shape, phase_0_output_max_shape = (
         get_paged_decode_intermediate_arrays_shapes(shape, num_kv_splits)
@@ -473,11 +463,7 @@ def testPagedFlashDecodingMHA(
         dynamic_symbols=dynamic_symbols_0,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[0],
     )
     options = set_default_run_config(options)
     phase_0 = wave_compile(options, phase_0)
@@ -502,11 +488,7 @@ def testPagedFlashDecodingMHA(
         dynamic_symbols=dynamic_symbols_1,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk2[1],
     )
     options = set_default_run_config(options)
     phase_1 = wave_compile(options, phase_1)

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -112,7 +112,8 @@ def testPrefillAttention(
     dtype: torch.dtype,
     enable_scheduling: SchedulingType,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     seq_lens = shape[4]
     shape = AttentionShape(
@@ -140,8 +141,6 @@ def testPrefillAttention(
     )
 
     hyperparams.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
 
     log2e = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)
@@ -154,11 +153,7 @@ def testPrefillAttention(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     prefill = wave_compile(options, prefill)

--- a/tests/kernel/wave/attention/quantized_attention_test.py
+++ b/tests/kernel/wave/attention/quantized_attention_test.py
@@ -55,10 +55,9 @@ def testAttentionPure(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
         num_query_heads=input_shape[0],
         num_kv_heads=input_shape[0],
@@ -84,7 +83,6 @@ def testAttentionPure(
     o_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -95,9 +93,7 @@ def testAttentionPure(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)

--- a/tests/kernel/wave/attention/t5_rpe_attention_test.py
+++ b/tests/kernel/wave/attention/t5_rpe_attention_test.py
@@ -111,7 +111,8 @@ def test_t5_rpe_attention(
     max_rpe_context_length: int,
     dtype: torch.dtype,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     shape = AttentionShape(
         num_query_heads=shape[0],
@@ -133,8 +134,6 @@ def test_t5_rpe_attention(
     output_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
 
     hyperparams.update(get_default_scheduling_params())
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
 
     log2e = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)
@@ -150,11 +149,7 @@ def test_t5_rpe_attention(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     t5_rpe_attention = wave_compile(options, t5_rpe_attention)

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -418,6 +418,7 @@ def testAttentionBHSDCausal(
     perf_filename_tk,
 ):
     shape = AttentionShape(
+        batch_size=shape[0],
         num_query_heads=shape[1],
         num_kv_heads=shape[1],
         query_seq_len=shape[2],

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -70,10 +70,9 @@ def testTransposedVAttentionPure(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
         num_query_heads=input_shape[0],
         num_kv_heads=input_shape[0],
@@ -95,7 +94,6 @@ def testTransposedVAttentionPure(
     o_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -106,9 +104,7 @@ def testTransposedVAttentionPure(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)
@@ -149,10 +145,9 @@ def testAttentionPure(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
         num_query_heads=input_shape[0],
         num_kv_heads=input_shape[0],
@@ -172,7 +167,6 @@ def testAttentionPure(
     o_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -183,9 +177,7 @@ def testAttentionPure(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)
@@ -226,10 +218,9 @@ def testAttentionCausal(
     sliding_window: int,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
         num_query_heads=shape[0],
         num_kv_heads=shape[0],
@@ -256,7 +247,6 @@ def testAttentionCausal(
     o_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -267,9 +257,7 @@ def testAttentionCausal(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     base_attention = wave_compile(options, base_attention)
@@ -318,10 +306,9 @@ def testAttentionBSHD(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
         num_query_heads=shape[0],
         num_kv_heads=shape[0],
@@ -354,7 +341,6 @@ def testAttentionBSHD(
     k_shape = (1, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
     v_shape = (1, shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         schedule=enable_scheduling,
@@ -365,9 +351,7 @@ def testAttentionBSHD(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     base_attention = wave_compile(options, base_attention_func)
@@ -430,10 +414,10 @@ def testAttentionBHSDCausal(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
     shape = AttentionShape(
-        batch_size=shape[0],
         num_query_heads=shape[1],
         num_kv_heads=shape[1],
         query_seq_len=shape[2],
@@ -487,6 +471,10 @@ def testAttentionBHSDCausal(
         dynamic_symbols=dynamic_symbols,
         waves_per_eu=2,
         denorm_fp_math_f32="preserve-sign",
+        run_bench=run_bench,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     base_attention = wave_compile(options, base_attention_func)
@@ -554,10 +542,9 @@ def testAttentionBias(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -690,11 +677,7 @@ def testAttentionBias(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)
@@ -746,10 +729,9 @@ def testAttentionSoftCap(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -884,11 +866,7 @@ def testAttentionSoftCap(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)
@@ -940,10 +918,9 @@ def testAttentionF8(
     shape: tuple[int],
     enable_scheduling: SchedulingType,
     mfma_variant: tuple[MMAType],
-    request,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -1055,11 +1032,7 @@ def testAttentionF8(
         denorm_fp_math_f32="preserve-sign",
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
 
     options = set_default_run_config(options)

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -114,19 +114,6 @@ _perf_test_shapes["extend"] = [
 ]
 
 
-def construct_test_name(
-    base_name: str,
-    mfma_variant: tuple[MMAType],
-    is_causal: bool,
-    shape: AttentionShape | Sequence[int],
-):
-    test_name = base_name
-    test_name += mfma_variant[0].name + "_" + mfma_variant[1].name + "_"
-    test_name += "causal" if is_causal else "noncausal"
-    test_name += "_" + "x".join([str(s) for s in shape])
-    return test_name + ".json"
-
-
 def make_shape_param(shape: Sequence[int], is_perf: bool):
     name = "x".join(map(str, shape))
     if is_perf:

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -607,9 +607,7 @@ def testGemmDumpOverrideSchedule(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
         dump_schedule="./schedule.txt",
     )
     options = set_default_run_config(options)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -92,10 +92,10 @@ def testPureGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -170,7 +170,6 @@ def testPureGemm(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -180,9 +179,7 @@ def testPureGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -198,10 +195,8 @@ def testPureGemm(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -231,11 +226,11 @@ def testGemmSmallTiles(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
     # Test gemm with tiles smaller than MMA vector sizes.
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -310,7 +305,6 @@ def testGemmSmallTiles(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -322,9 +316,7 @@ def testGemmSmallTiles(
         benchmark_repetitions=3,
         use_buffer_load_ops=True,
         use_buffer_store_ops=True,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -340,10 +332,8 @@ def testGemmSmallTiles(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -373,10 +363,10 @@ def testNonTransposeGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -446,7 +436,6 @@ def testNonTransposeGemm(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -456,9 +445,7 @@ def testNonTransposeGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -473,10 +460,8 @@ def testNonTransposeGemm(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     # TODO: switch to comparison against generated iree_ref
     torch_ref = torch.matmul(a, b)
     assert_close(
@@ -496,10 +481,10 @@ def testNonTransposeGemm(
 def testPingPongGemm(
     shape: tuple[int],
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -560,7 +545,6 @@ def testPingPongGemm(
     }
     hyperparams.update(get_default_scheduling_params())
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -570,9 +554,7 @@ def testPingPongGemm(
         dynamic_symbols=[],
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -588,10 +570,8 @@ def testPingPongGemm(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -610,16 +590,14 @@ def testGemmDumpOverrideSchedule(
     dynamic_dims: bool,
     mfma_variant: MMAType,
     datatype: DataType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
-
     dtype = tkl.f16 if datatype == torch.float16 else tkl.bf16
     gemm, hyperparams, dynamic_symbols = get_gemm_kernel(
         shape, dynamic_dims, mfma_variant, dtype
     )
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -648,10 +626,8 @@ def testGemmDumpOverrideSchedule(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -670,9 +646,7 @@ def testGemmDumpOverrideSchedule(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
         override_schedule="./schedule.txt",
     )
     options = set_default_run_config(options)
@@ -709,10 +683,10 @@ def testGemmDot(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -782,7 +756,6 @@ def testGemmDot(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -792,9 +765,7 @@ def testGemmDot(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -812,10 +783,8 @@ def testGemmDot(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False, atol=1e-3, rtol=1e-3)
@@ -840,10 +809,10 @@ def testVMFMAGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -927,11 +896,7 @@ def testVMFMAGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -946,10 +911,9 @@ def testVMFMAGemm(
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, atol=2e-4, rtol=3e-4, check_device=False)
@@ -975,10 +939,10 @@ def testCDNA2IntGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1062,11 +1026,7 @@ def testCDNA2IntGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1082,10 +1042,9 @@ def testCDNA2IntGemm(
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.int32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1106,10 +1065,13 @@ def testCDNA2IntGemm(
     ],
 )
 def testCDNA3IntGemm(
-    shape: tuple[int], enable_scheduling: SchedulingType, mfma_variant: MMAType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    mfma_variant: MMAType,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1171,11 +1133,7 @@ def testCDNA3IntGemm(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1191,10 +1149,9 @@ def testCDNA3IntGemm(
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.int32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1216,10 +1173,13 @@ def testCDNA3IntGemm(
     ],
 )
 def testF8Gemm(
-    shape: tuple[int], enable_scheduling: SchedulingType, mfma_variant: MMAType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    mfma_variant: MMAType,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1278,11 +1238,7 @@ def testF8Gemm(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1297,10 +1253,9 @@ def testF8Gemm(
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt_f8", [a, b], [iree_ref])
     assert_close(c, iree_ref, atol=3e-5, rtol=3e-4, check_device=False)
@@ -1327,11 +1282,11 @@ def testPackedGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
     # TODO: Convert this to i8 -> bitcast f16 gemm
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1401,7 +1356,6 @@ def testPackedGemm(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -1411,9 +1365,7 @@ def testPackedGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1429,10 +1381,8 @@ def testPackedGemm(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1459,11 +1409,11 @@ def testPackedNonTransposeGemm(
     enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
-    request,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
     # TODO: Convert this to i8 -> bitcast f16 gemm
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1540,7 +1490,6 @@ def testPackedNonTransposeGemm(
         del hyperparams[N]
         del hyperparams[K]
 
-    perf_filename = request.node.name + ".json"
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -1550,9 +1499,7 @@ def testPackedNonTransposeGemm(
         dynamic_symbols=dynamic_symbols,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1568,10 +1515,8 @@ def testPackedNonTransposeGemm(
             f.write(asm)
 
     if run_bench:
-        if dump_perf is not None:
-            options.benchmark_results_file = os.path.join(
-                dump_perf, "iree_" + perf_filename
-            )
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1583,9 +1528,13 @@ def testPackedNonTransposeGemm(
     "enable_scheduling",
     [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.MODULO_MULTI_BUFFERED],
 )
-def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, request):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
+def testBatchedGemm(
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
+):
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -1649,11 +1598,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, reques
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     batched_gemm = wave_compile(options, batched_gemm)
@@ -1668,10 +1613,9 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, reques
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
     generate_iree_ref("bmmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1687,10 +1631,12 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, reques
     [SchedulingType.NONE],
 )
 def testSequentialBatchedGemm(
-    shape: tuple[int], enable_scheduling: SchedulingType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -1756,11 +1702,7 @@ def testSequentialBatchedGemm(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     batched_gemm = wave_compile(options, batched_gemm)
@@ -1775,10 +1717,9 @@ def testSequentialBatchedGemm(
         with open(filename, "w") as f:
             f.write(asm)
 
-    if run_bench and dump_perf is not None:
-        options.benchmark_results_file = os.path.join(
-            dump_perf, "iree_" + request.node.name + ".json"
-        )
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
     iree_ref = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
     generate_iree_ref("bmmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
@@ -1795,10 +1736,11 @@ def testSequentialBatchedGemm(
     [SchedulingType.NONE],
 )
 def testSequentialBatchedGemmWhile(
-    shape: tuple[int], enable_scheduling: SchedulingType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -1870,11 +1812,7 @@ def testSequentialBatchedGemmWhile(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
         wave_runtime=True,
     )
     options = set_default_run_config(options)
@@ -1902,10 +1840,11 @@ def testSequentialBatchedGemmWhile(
     [SchedulingType.NONE],
 )
 def testSequentialBatchedGemmWhileWithOutputSum(
-    shape: tuple[int], enable_scheduling: SchedulingType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -1986,11 +1925,7 @@ def testSequentialBatchedGemmWhileWithOutputSum(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
         wave_runtime=True,
     )
     options = set_default_run_config(options)
@@ -2019,10 +1954,11 @@ def testSequentialBatchedGemmWhileWithOutputSum(
     [SchedulingType.NONE],
 )
 def testBatchedGemmWithPermute(
-    shape: tuple[int], enable_scheduling: SchedulingType, request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    run_bench,
+    perf_filename_tk,
 ):
-    run_bench = request.config.getoption("--runperf")
-    dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
     B = tkl.sym.B
     M = tkl.sym.M
@@ -2092,11 +2028,7 @@ def testBatchedGemmWithPermute(
         use_scheduling_barriers=enable_scheduling_barriers,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
-        benchmark_results_file=(
-            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
-            if dump_perf
-            else None
-        ),
+        benchmark_results_file=perf_filename_tk,
     )
     options = set_default_run_config(options)
     batched_gemm_with_permute = wave_compile(options, batched_gemm_with_permute)


### PR DESCRIPTION
Also, `generate_iree_ref` benchmarking is currently broken due to unrelated reasons, but I will fix it later.