### PR TITLE
[Wave] Fix visualization test

### DIFF
--- a/tests/kernel/wave/visualization_test.py
+++ b/tests/kernel/wave/visualization_test.py
@@ -83,7 +83,9 @@ def test_gemm():
     constraints += [tkw.TilingConstraint(K, BLOCK_K, ARGK)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M / 2, THREAD_0 / 64)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N / 2, THREAD_1)]
-    constraints += [tkw.HardwareConstraint(threads_per_wave=64)]
+    constraints += [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(2, 2, 1))
+    ]
     with tk.gen.TestLaunchContext(
         {
             BLOCK_M: 32,


### PR DESCRIPTION
With the recent removal of waves_per_block, the visualization test was failing since it requires the waves_per_block to be specified. This PR fixes that.