### PR TITLE
[Wave] Fix builds on OSX & Windows

### DIFF
--- a/iree/turbine/kernel/wave/runtime/CMakeLists.txt
+++ b/iree/turbine/kernel/wave/runtime/CMakeLists.txt
@@ -6,6 +6,12 @@
 cmake_minimum_required(VERSION 3.19...3.27)
 project(wave_runtime)
 
+# Skip building on macOS and Windows
+if(APPLE OR WIN32)
+  message(STATUS "Skipping wave_runtime build on ${CMAKE_SYSTEM_NAME}")
+  return()
+endif()
+
 # Set the C++ standard (for nanobind)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
If users attempted to wave on OSX or Windows, the install would crash with an unsupported platform error. This PR skips the cmake build for those platforms so that the package can still be installed and lit tests can still be run.