### PR TITLE
[Wave] Teach compiler to do masking properly on scaled dims.

### DIFF
--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -43,6 +43,7 @@ from ..utils.general_utils import (
     get_largest_index_and_size,
     get_workgroup_constraints,
     infer_dim,
+    is_scaled_dim,
     partial,
 )
 from ..utils.mma_utils import (
@@ -107,22 +108,6 @@ def set_derived_index(trace):
         for inp in get_inputs(current)[0]:
             new_index = custom.transform_index_backwards(custom.index, inp)
             worklist.append((inp, new_index))
-
-
-def is_scaled_dim(expr: sympy.Expr):
-    """
-    Function that checks if expression is a scaled sympy expression.
-    """
-    # Skip for cases where it is a single symbol or number.
-    if expr.is_Symbol or expr.is_Number:
-        return False
-    # Unhandled case where expression is multiple operations.
-    if sympy.count_ops(expr) != 1:
-        return False
-    # Skip if cannot find a multiply which represents a scale
-    if not isinstance(expr, sympy.Mul):
-        return False
-    return True
 
 
 def has_scaled_indices(node: fx.Node):

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -160,6 +160,22 @@ def is_shared_mem_access(custom: "CustomOp") -> bool:
     return custom.memory_type.address_space == SHARED_ADDRESS_SPACE
 
 
+def is_scaled_dim(expr: sympy.Expr):
+    """
+    Function that checks if expression is a scaled sympy expression.
+    """
+    # Skip for cases where it is a single symbol or number.
+    if expr.is_Symbol or expr.is_Number:
+        return False
+    # Unhandled case where expression is multiple operations.
+    if sympy.count_ops(expr) != 1:
+        return False
+    # Skip if cannot find a multiply which represents a scale
+    if not isinstance(expr, sympy.Mul):
+        return False
+    return True
+
+
 def find_index_bounds(
     constraints: list[Constraint],
     index: dict[IndexExpr, IndexExpr],

--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -220,7 +220,8 @@ def testScaledGemmMXFP4(
 @require_cdna4
 @pytest.mark.parametrize("batch", [4, 8])
 @pytest.mark.parametrize(
-    "shape", [(1024, 1024, 1024), (8192, 8192, 8192), (16384, 16384, 16384)]
+    "shape",
+    [(1024, 1024, 1024), (8192, 8192, 8192), (16384, 16384, 16384), (1, 16384, 1664)],
 )
 @pytest.mark.parametrize(
     "mfma_variant",


### PR DESCRIPTION
Currently scaled dimensions such as K/32 or K/2 only works on aligned shape(wrt block_k). In order to add masking/unaligned support for this we add feature to check that we have indeed scaled bound and try to scale the bound. This is most useful for handling K dims that are not power of 2 for Llama3. Main changes are:


1. Moving of `is_scaled_dim` into general_utils.py for reusability.
2. Before setting bounds, we build a map to keep all the "scaled dims", then we go through the bounds
    /dim one by one, and if we find any of the dim is scaled, we apply the scaling to the bound.