### PR TITLE
[Wave] fix tutorial ref to tkl

### DIFF
--- a/docs/wave/gemm_tutorial.rst
+++ b/docs/wave/gemm_tutorial.rst
@@ -26,7 +26,7 @@ First, we need to import the necessary modules and define our symbolic dimension
     from wave_lang.kernel.lang.wave_types import *
     from wave_lang.kernel.lang.global_symbols import *
     from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
-    import wave_lang.kernel as tkl
+    import wave_lang.kernel.lang as tkl
     import wave_lang.kernel.wave as tkw
     from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
     import torch


### PR DESCRIPTION
The tkl import is actually unused in this example, so an alternative is to just remove it.  However, since going from a tutorial kernel to a custom kernel is going to be a common use-case, and you are going to reach for tkl, it may be helpful to have it (especially since other tutorials that reference tkl don't specify the actual import).  But if we have it it should be correct.