### PR TITLE
[Wave] Make thread trace documentation visible in docs

### DIFF
--- a/docs/wave/wave.rst
+++ b/docs/wave/wave.rst
@@ -71,3 +71,4 @@ For more detailed information about Wave's architecture and optimization passes,
    fused_softmax
    aplp
    gather_to_shared
+   trace


### PR DESCRIPTION
In order to make docs visible, they need to be listed in the wave.rst. The trace document was not listed. This PR fixes that.