### PR TITLE
[WAVE] Updated wave speculativde decode as per the latest flashinfer kernel updates

### DIFF
--- a/tests/kernel/wave/speculative_decode_test.py
+++ b/tests/kernel/wave/speculative_decode_test.py
@@ -188,6 +188,7 @@ def tree_speculative_sampling_target_only(
     retrive_next_token,  # [batch_size, num_draft_tokens]
     retrive_next_sibling,  # [batch_size, num_draft_tokens]
     uniform_samples,  # [batch_size, num_draft_tokens]
+    uniform_samples_for_final_sampling,  # [batch_size]
     target_probs,  # [batch_size, num_draft_tokens, vocab_size]
     draft_probs,  # [batch_size, num_draft_tokens, vocab_size]
     batch_size,
@@ -246,7 +247,7 @@ def tree_speculative_sampling_target_only(
         target_probs,
         draft_probs,
         cur_prob_offset_vec,
-        updated_coins_vec,
+        uniform_samples_for_final_sampling,
         last_accepted_retrive_idx_vec,
         accept_token_num,
         num_speculative_tokens,
@@ -349,6 +350,9 @@ def testReferenceSpeculativeDecoding(
     draft_probs = torch.full_like(target_probs, 0, dtype=torch.float32, device=device)
     coins = torch.rand(bs, num_draft_tokens, device=device, dtype=torch.float32)
 
+    # based on updated speculative decode kernel from sglang
+    coins_for_final_sampling = torch.rand((bs,), dtype=torch.float32, device=device)
+
     vocab_size = target_probs.shape[2]
 
     tree_speculative_sampling_target_only(
@@ -360,6 +364,7 @@ def testReferenceSpeculativeDecoding(
         retrive_next_token=retrive_next_token,
         retrive_next_sibling=retrive_next_sibling,
         uniform_samples=coins,
+        uniform_samples_for_final_sampling=coins_for_final_sampling,
         target_probs=target_probs,
         draft_probs=draft_probs,
         batch_size=bs,

--- a/wave_lang/kernel/wave/templates/speculative_decoding.py
+++ b/wave_lang/kernel/wave/templates/speculative_decoding.py
@@ -34,20 +34,24 @@ def get_speculative_decoding_kernel(
         SEQ_LEN: seq_len,
         BLOCK_BATCH_SIZE: 1,
         BLOCK_NUM_DRAFT_TOK: 1,
-        BLOCK_VOCAB_SIZE: 64,
+        BLOCK_VOCAB_SIZE: vocab_size,
     }
 
     dynamic_symbols = []
 
     constraints = [tkw.WorkgroupConstraint(VOCAB_SIZE, VOCAB_SIZE, 0)]
-    constraints += [tkw.WaveConstraint(VOCAB_SIZE, VOCAB_SIZE)]
     constraints += [tkw.WorkgroupConstraint(BATCH_SIZE, BLOCK_BATCH_SIZE, 1)]
+    constraints += [tkw.WaveConstraint(VOCAB_SIZE, VOCAB_SIZE)]
 
     constraints += [
         tkw.HardwareConstraint(
             threads_per_wave=64,
             waves_per_block=(1, 1, 1),
-            vector_shapes={BATCH_SIZE: 0, NUM_DRAFT_TOKENS: 0, VOCAB_SIZE: VOCAB_SIZE},
+            vector_shapes={
+                BATCH_SIZE: 0,
+                NUM_DRAFT_TOKENS: 0,
+                VOCAB_SIZE: BLOCK_VOCAB_SIZE,
+            },
         )
     ]
 
@@ -82,7 +86,9 @@ def get_speculative_decoding_kernel(
             BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32
         ],
         cur_prob_offset: tkl.Memory[BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.i32],
-        updated_coins_vec: tkl.Memory[BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        uniform_samples_for_final_sampling: tkl.Memory[
+            BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32
+        ],
         last_accepted_retrive_idx_vec: tkl.Memory[
             BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.i32
         ],
@@ -116,7 +122,7 @@ def get_speculative_decoding_kernel(
         )
         draft_probs_reg = tkw.select(condition, draft_probs_reg, zero)
 
-        coin = tkw.read(updated_coins_vec)
+        coin = tkw.read(uniform_samples_for_final_sampling)
         coin = tkw.broadcast(coin, target_shape=[BATCH_SIZE, NUM_DRAFT_TOKENS])
 
         diff = target_probs_reg - draft_probs_reg
@@ -128,7 +134,10 @@ def get_speculative_decoding_kernel(
         threshold_dist_u = tkw.broadcast(
             coin * sum_relu, target_shape=[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE]
         )
-        greater_than_u = cdf > threshold_dist_u
+
+        # TODO: Ideally we should be having this condition: greater_than_u = cdf > threshold_dist_u
+        # But as per the flashinfer.ai kernel, we are using the below fix to align with it.
+        greater_than_u = cdf > zero
 
         # Initializing `pad_token` to the last token in the vocabulary to be default
         # and within bounds.
@@ -188,6 +197,7 @@ def get_speculative_sampling_kernel(
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
             threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
             vector_shapes={
                 NUM_DRAFT_TOKENS: num_draft_tokens,
                 J: 0,

--- a/wave_lang/kernel/wave/templates/speculative_decoding.py
+++ b/wave_lang/kernel/wave/templates/speculative_decoding.py
@@ -46,7 +46,6 @@ def get_speculative_decoding_kernel(
     constraints += [
         tkw.HardwareConstraint(
             threads_per_wave=64,
-            waves_per_block=(1, 1, 1),
             vector_shapes={
                 BATCH_SIZE: 0,
                 NUM_DRAFT_TOKENS: 0,
@@ -197,7 +196,6 @@ def get_speculative_sampling_kernel(
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
             threads_per_wave=64,
-            waves_per_block=(1, 1, 1),
             vector_shapes={
                 NUM_DRAFT_TOKENS: num_draft_tokens,
                 J: 0,


### PR DESCRIPTION
- updated as per the latest commits in the sglang/flashinfer speculative kernel. 
- this is without `top-p top-k`. That will be a part of the performance. 