### PR TITLE
[Wave] add debug_log_write op

### DIFF
--- a/wave_lang/kernel/lang/wave_types.py
+++ b/wave_lang/kernel/lang/wave_types.py
@@ -66,7 +66,10 @@ class Memory(metaclass=KernelBufferMeta):
     def __class_getitem__(
         cls, shape_and_dtype: tuple[IndexExpr | DataType, ...]
     ) -> Type["Memory"]:
-        """Syntax: `Memory[shape1, ...., shapeN, addressSpace, dtype, Optional[usage]]"""
+        """
+        Syntax: `Memory[shape1, ...., shapeN, addressSpace, dtype, Optional[usage]]`
+        or `Memory[(shape1, ..., shapeN), addressSpace, dtype, Optional[usage]]`
+        """
         if len(shape_and_dtype) < 3:
             raise TypeError(f"Expected at least 3 arguments, got: {shape_and_dtype}")
 
@@ -80,6 +83,9 @@ class Memory(metaclass=KernelBufferMeta):
         dtype = shape_and_dtype.pop()
         addressSpace = shape_and_dtype.pop()
         shape = tuple(shape_and_dtype)
+        # allow shape to be provided as a tuple instead of as individual elements, to work around lack of unpacking in subscripts for Python 3.10
+        if len(shape) == 1 and isinstance(shape[0], tuple):
+            shape = shape[0]
 
         # Allow constant int expressions in shape
         shape = tuple(IndexExpr(s) if isinstance(s, int) else s for s in shape)

--- a/wave_lang/kernel/wave/debug_log_hoist.py
+++ b/wave_lang/kernel/wave/debug_log_hoist.py
@@ -1,0 +1,96 @@
+# Copyright 2025 The IREE Authors
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .._support.tracing import CapturedTrace
+from ..lang.global_symbols import *
+from ..ops.wave_ops import (
+    get_custom,
+    Write,
+    Placeholder,
+    DebugLogWrite,
+)
+from .._support.dtype import DataType
+from .._support.indexing import IndexSymbol
+from typing import TypedDict
+
+
+class DebugArgInfo(TypedDict):
+    symbol_name: str
+    debug_output_arg_id: int
+    dtype: DataType
+    symbolic_shape: tuple[IndexSymbol, ...]
+
+
+def is_debug_log_transformer(node):
+    return isinstance(get_custom(node), DebugLogWrite)
+
+
+def debug_log_hoist(trace: CapturedTrace):
+    """
+    Finds debug log ops and hoists kernel inputs for them.
+    Must be run near the very beginning of the compilation pipeline.
+
+    The idea of this feature is that there are debug_log_transformer ops that are logically writes to global memory.
+    However, these debug ops are intended to conveniently transform the kernel and the launcher code to automatically insert the extra global memory arguments and possibly process them (eg. printing logged data in the launcher).
+    So the user can add a single debug print op to a Wave kernel on one line without changing any other lines of code to get rich printing functionality handled by a mix of kernel and python code.
+    """
+    root = trace.get_root_graph()
+    with root.inserting_before(None):
+        debug_log_ops = trace.walk(is_debug_log_transformer)
+        for index, debug_op in enumerate(debug_log_ops):
+            custom = get_custom(debug_op)
+            placeholder_name = custom.log_name or f"debug_log_output_{index}"
+            type_expr = None
+            placeholder = Placeholder(placeholder_name, type_expr).add_to_graph(root)
+            custom.fx_node.memory = placeholder
+            placeholder.meta["debug_output_arg_id"] = index
+            placeholder.meta["symbol_name"] = placeholder_name
+
+
+def debug_log_write_replace(trace: CapturedTrace, debug_arg_info: list[DebugArgInfo]):
+    """
+    This pass has 3 jobs:
+
+    * Replace all debug_log_transformers with write operations.
+    * Set metadata on the debug output Placeholder objects (created in debug_log_hoist pass).
+    * Collect debug_arg_info so that the kernel invoke method can be massaged to automatically handle debug log outputs.  It mutates the input argument so that the data can be passed to the WaveKernel object.
+
+    Must be run after type checking, but before indexing.
+    """
+    root = trace.get_root_graph()
+
+    # Part 1: replace debug log transformers with write operations.
+    debug_log_ops = trace.walk(is_debug_log_transformer)
+    for index, debug_op in enumerate(debug_log_ops):
+        graph = debug_op.graph
+        doc = get_custom(debug_op)
+        with graph.inserting_before(debug_op):
+            new_write = Write(
+                doc.register_,
+                doc.memory,
+            ).add_to_graph(graph)
+            get_custom(new_write).infer_type()
+        doc.erase()
+
+    # Part 2: add metadata to debug output Placeholders
+    def is_debug_log_placeholder(node):
+        return isinstance(get_custom(node), Placeholder) and (
+            node.meta.get("debug_output_arg_id", None) != None
+        )
+
+    def is_arg_placeholder(node):
+        return isinstance(get_custom(node), Placeholder) and ("arg_id" in node.meta)
+
+    root = trace.get_root_graph()
+    arg_placeholders = trace.walk(is_arg_placeholder)
+    debug_placeholder_ops = trace.walk(is_debug_log_placeholder)
+    for debug_placeholder_op in debug_placeholder_ops:
+        debug_placeholder_op.meta["arg_id"] = (
+            len(arg_placeholders) + debug_placeholder_op.meta["debug_output_arg_id"]
+        )
+        custom = get_custom(debug_placeholder_op)
+        debug_placeholder_op.meta["dtype"] = custom.type.dtype
+        debug_placeholder_op.meta["symbolic_shape"] = custom.type.symbolic_shape
+        debug_arg_info.append(debug_placeholder_op.meta)

--- a/wave_lang/kernel/wave/utils/general_utils.py
+++ b/wave_lang/kernel/wave/utils/general_utils.py
@@ -392,6 +392,8 @@ TORCH_DTYPE_TO_WAVE = {
     torch.bool: tkl.bool,
 }
 
+WAVE_DTYPE_TO_TORCH = {value: key for key, value in TORCH_DTYPE_TO_WAVE.items()}
+
 TORCH_DTYPE_RANGE = {
     torch.bfloat16: [-3.3895313892515355e38, 3.3895313892515355e38],
     torch.float8_e5m2: [-57344.0, 57344.0],
@@ -412,6 +414,13 @@ def torch_dtype_to_wave(torch_dtype: torch.dtype) -> Any:
         return TORCH_DTYPE_TO_WAVE[torch_dtype]
     except KeyError:
         raise ValueError(f"Unable to map torch dtype {torch_dtype} to Wave.")
+
+
+def wave_dtype_to_torch(wave_dtype: Any) -> torch.dtype:
+    try:
+        return WAVE_DTYPE_TO_TORCH[wave_dtype]
+    except KeyError:
+        raise ValueError(f"Unable to map Wave dtype {wave_dtype} to Torch.")
 
 
 def torch_dtype_range(torch_dtype: torch.dtype) -> Any:


### PR DESCRIPTION
This is a first step to having a convenient print op for Wave. It implicitly adds global memory kernel arguments, while also adding those memory arguments automatically in the kernel's invoke method.