### PR TITLE
SchedulingType.FOUR_STAGE: GEMM Full Software Pipelining with Initiation Interval 1, Via Multibuffering

### DIFF
--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1274,7 +1274,7 @@ def test_gemm_prefetch():
 
 
 @run_test
-def test_gemm_gemm_four_stage():
+def test_gemm_four_stage():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K)]
@@ -1329,7 +1329,7 @@ def test_gemm_gemm_four_stage():
             SHUFFLE_UNITS: 8,
         },
         canonicalize=True,
-        schedule=SchedulingType.GEMM_FOUR_STAGE,
+        schedule=SchedulingType.FOUR_STAGE,
         use_scheduling_barriers=True,
         compile_to_mlir=True,
         use_multi_buffering=True,

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1274,6 +1274,102 @@ def test_gemm_prefetch():
 
 
 @run_test
+def test_gemm_gemm_four_stage():
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def gemm_four_stage(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c)
+
+    options = WaveCompileOptions(
+        subs={
+            M: 128,
+            N: 128,
+            K: 256,
+            BLOCK_M: 64,
+            BLOCK_N: 64,
+            BLOCK_K: 32,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+            READ_SHARED_DELAY: 1,
+            WRITE_SHARED_DELAY: 1,
+            READ_GLOBAL_DELAY: 2,
+            WRITE_GLOBAL_DELAY: 2,
+            MMA_DELAY: 1,
+            VALU_DELAY: 1,
+            SHUFFLE_DELAY: 1,
+            SHARED_MEMORY_UNITS: 4,
+            GLOBAL_MEMORY_UNITS: 4,
+            MMA_UNITS: 4,
+            VALU_UNITS: 8,
+            SHUFFLE_UNITS: 8,
+        },
+        canonicalize=True,
+        schedule=SchedulingType.GEMM_FOUR_STAGE,
+        use_scheduling_barriers=True,
+        compile_to_mlir=True,
+    )
+
+    gemm_four_stage = wave_compile(options, gemm_four_stage)
+    print(gemm_four_stage.asm)
+    # CHECK-LABEL: func.func @gemm_four_stage
+    # Test multibuffering: verify shared memory views are correctly allocated
+    # CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<18432xi8
+    # CHECK: %[[VIEW0:.*]] = memref.view %[[ALLOC]][%c0][] : memref<18432xi8
+    # CHECK: %[[VIEW1:.*]] = memref.view %[[ALLOC]][%c9216][] : memref<18432xi8
+
+    # Prologue
+    # Verify prologue stores to shared memory
+    # CHECK: %[[STORE_IDX:.*]] = affine.apply #map[0-9]+()[%thread_id_x, %thread_id_y]
+    # CHECK: vector.store %{{.*}}, %[[VIEW1]][%[[STORE_IDX]], %{{.*}}] : memref<128x36xf16
+    # CHECK: vector.store %{{.*}}, %[[VIEW0]][%[[STORE_IDX]], %{{.*}}] : memref<128x36xf16
+
+    # Verify prologue loads from shared memory
+    # CHECK: %[[LOAD_IDX1:.*]] = affine.apply #map[0-9]+()[%thread_id_x, %thread_id_y]
+    # CHECK: %[[LOAD_IDX2:.*]] = affine.apply #map[0-9]+()[%thread_id_x]
+    # CHECK: vector.load %[[VIEW0]][%[[LOAD_IDX1]], %[[LOAD_IDX2]]] : memref<128x36xf16
+
+    # Main Loop:
+    # Verify Pipelined Loop, iter_args should contain vector values from prologue
+    # CHECK: scf.for %[[ARG3:.*]] = %c0 to %c5 step %c1 iter_args(%{{.*}} = %cst, %{{.*}} = %cst, %{{.*}} = %cst, %{{.*}} = %cst, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}})
+
+    # Verify MFMA exists
+    # CHECK: amdgpu.mfma %{{.*}} * %{{.*}} + %{{.*}}
+
+    # Verify that affine maps using iter_arg %[[ARG3]] are used for pipelined indexing
+    # CHECK: %[[PIPE_IDX1:.*]] = affine.apply #map[0-9]+()[%thread_id_x, %[[ARG3]], %thread_id_y]
+    # CHECK: vector.load %[[VIEW0]][%[[PIPE_IDX1]], %{{.*}}] : memref<128x36xf16
+
+    # Verify that stores use iter arg for indexing as well
+    # CHECK: %[[STORE_PIPE_IDX:.*]] = affine.apply #map[0-9]+()[%thread_id_x, %thread_id_y, %[[ARG3]]]
+    # CHECK: vector.store %{{.*}}, %[[VIEW1]][%[[STORE_PIPE_IDX]], %{{.*}}] : memref<128x36xf16
+
+
+@run_test
 def test_dynamic_gemm_pipelined():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1332,7 +1332,6 @@ def test_gemm_four_stage():
         schedule=SchedulingType.FOUR_STAGE,
         use_scheduling_barriers=True,
         compile_to_mlir=True,
-        use_multi_buffering=True,
         multi_buffer_count=2,
     )
 

--- a/lit_tests/kernel/wave/multi_buffering.py
+++ b/lit_tests/kernel/wave/multi_buffering.py
@@ -133,7 +133,8 @@ def test_gemm_multibuffering():
             trace,
             constraints,
             True,
-            scheduling_type=SchedulingType.MODULO_MULTI_BUFFERED,
+            scheduling_type=SchedulingType.MODULO,
+            multi_buffer_count=2,
         )
 
     def print_affected_node(node: fx.Node):
@@ -154,40 +155,40 @@ def test_gemm_multibuffering():
     for node in trace.get_root_graph().nodes:
         print_affected_node(node)
 
-    # CHECK: allocate(shape=(2*N, K), distributed_shape=(2*BLOCK_N, BLOCK_K + 4)
-    # CHECK-NEXT: allocate(shape=(2*M, K), distributed_shape=(2*BLOCK_M, BLOCK_K + 4)
-    # CHECK-NEXT: write(register_=read_21,
-    # CHECK-NEXT: write(register_=read_22,
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK: reduction begin
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-SAME: {N: BLOCK_N*(Mod($ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-SAME: index={M: BLOCK_M*(Mod($ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-SAME: {N: BLOCK_N*(Mod($ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-SAME: {N: BLOCK_N*(Mod($ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
-    # CHECK-NEXT: write(register_=read_21,
-    # CHECK-SAME: index={M: xor(BLOCK_M*(Mod($ARGK, 2)), BLOCK_M) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
-    # CHECK-NEXT: write(register_=read_22,
-    # CHECK-SAME: index={N: BLOCK_N/2 + xor(BLOCK_N*(Mod($ARGK, 2)), BLOCK_N) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-SAME: index={M: xor(BLOCK_M*(Mod($ARGK, 2)), BLOCK_M) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-SAME: index={M: xor(BLOCK_M*(Mod($ARGK, 2)), BLOCK_M) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-SAME: index={N: BLOCK_N/2 + xor(BLOCK_N*(Mod($ARGK, 2)), BLOCK_N) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-SAME: index={M: xor(BLOCK_M*(Mod($ARGK, 2)), BLOCK_M) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
-    # CHECK-NEXT: reduction end
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-NEXT: read(memory=allocate,
-    # CHECK-NEXT: read(memory=allocate_1,
-    # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK: allocate(shape=(2*N, K), distributed_shape=(2*BLOCK_N, BLOCK_K + 4)
+        # CHECK-NEXT: allocate(shape=(2*M, K), distributed_shape=(2*BLOCK_M, BLOCK_K + 4)
+        # CHECK-NEXT: write(register_=read_21,
+        # CHECK-NEXT: write(register_=read_22,
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK: reduction begin
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK + 1, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-NEXT: write(register_=read_21,
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-NEXT: write(register_=read_22,
+        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-NEXT: reduction end
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-NEXT: read(memory=allocate,
+        # CHECK-NEXT: read(memory=allocate_1,
+        # CHECK-NEXT: read(memory=allocate_1,
 
 
 if __name__ == "__main__":

--- a/lit_tests/kernel/wave/multi_buffering.py
+++ b/lit_tests/kernel/wave/multi_buffering.py
@@ -165,25 +165,25 @@ def test_gemm_multibuffering():
         # CHECK-NEXT: read(memory=allocate,
         # CHECK: reduction begin
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK + 1, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK + 1, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: write(register_=read_21,
-        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
         # CHECK-NEXT: write(register_=read_22,
-        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-SAME: index={2*N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={2*N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: reduction end
         # CHECK-NEXT: read(memory=allocate_1,
         # CHECK-NEXT: read(memory=allocate,

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -107,7 +107,9 @@ def test_gemm_pipelined():
         hoist_loop_invariant_ops(trace, constraints)
         minimize_global_loads(trace, constraints)
         apply_shared_memory_indexing_corrections(trace, constraints)
-        schedule_graph(trace, constraints, True, SchedulingType.MODULO)
+        schedule_graph(
+            trace, constraints, True, SchedulingType.MODULO, multi_buffer_count=2
+        )
 
     print_subgraph(trace, "pipelined_iterate", False)
     # CHECK: %acc_m_0_n_0_k_0
@@ -158,59 +160,111 @@ def test_gemm_pipelined():
     # CHECK-SAME: ({Operation.MMA: 2, Operation.READ_SHARED: 2}, 0)
     # CHECK-NEXT: [mma_M:0_N:0_K:1, mma_M:0_N:1_K:1, mma_M:1_N:0_K:1, mma_M:1_N:1_K:1, read_4_shared_M:0_N:0_K:1, read_2_shared_M:0_N:0_K:1, read_2_shared_M:1_N:0_K:0, read_2_shared_M:1_N:0_K:1]
 
-    print_subgraph(trace, "region_1", False)
-    # CHECK: %a
-    # CHECK-NEXT: %b
-    # CHECK-NEXT: %c
-    # CHECK-NEXT: %register_M:0_N:0_K:0
-    # CHECK-NEXT: %register_M:0_N:1_K:0
-    # CHECK-NEXT: %register_M:1_N:0_K:0
-    # CHECK-NEXT: %register_M:1_N:1_K:0
-    # CHECK-NEXT: %allocate_1
-    # CHECK-NEXT: %allocate
-    # CHECK-NEXT: %read_21
-    # CHECK-NEXT: %read_22
-    # CHECK-NEXT: %write_10
-    # CHECK-NEXT: %write_11
-    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
-    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
-    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
-    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
-    # CHECK-NEXT: %iterate_1
-    # CHECK-NEXT: %get_result_M:0_N:0_K:0
-    # CHECK-NEXT: %get_result_M:0_N:1_K:0
-    # CHECK-NEXT: %get_result_M:1_N:0_K:0
-    # CHECK-NEXT: %get_result_M:1_N:1_K:0
-    # CHECK-NEXT: %get_result_9
-    # CHECK-NEXT: %get_result_10
-    # CHECK-NEXT: %get_result_11
-    # CHECK-NEXT: %get_result_12
-    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
-    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
-    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
-    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
+        print_subgraph(trace, "region_1", False)
+        # CHECK: %a
+        # CHECK-NEXT: %b
+        # CHECK-NEXT: %c
+        # CHECK-NEXT: %register_M:0_N:0_K:0
+        # CHECK-NEXT: %register_M:0_N:1_K:0
+        # CHECK-NEXT: %register_M:1_N:0_K:0
+        # CHECK-NEXT: %register_M:1_N:1_K:0
+        # CHECK-NEXT: %allocate_1
+        # CHECK-NEXT: %allocate
+        # CHECK-NEXT: %read_21
+        # CHECK-NEXT: %read_22
+        # CHECK-NEXT: %write_10
+        # CHECK-NEXT: %write_11
+        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
+        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
+        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
+        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
+        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
+        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
+        # CHECK-NEXT: %read_21
+        # CHECK-NEXT: %read_22
+        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
+        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
 
-    # CHECK-NEXT: %mma_M:0_N:0_K:0
-    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %get_result_M:0_N:0_K:0, None)
-    # CHECK-NEXT: %mma_M:1_N:0_K:0
-    # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:0_K:0, %get_result_M:1_N:0_K:0, None)
-    # CHECK-NEXT: %mma_M:0_N:0_K:1
-    # CHECK-SAME: (%get_result_10, %get_result_9, %mma_M:0_N:0_K:0, None)
-    # CHECK-NEXT: %mma_M:1_N:0_K:1
-    # CHECK-SAME: (%get_result_12, %get_result_9, %mma_M:1_N:0_K:0, None)
-    # CHECK-NEXT: %mma_M:0_N:1_K:0
-    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %get_result_M:0_N:1_K:0, None)
-    # CHECK-NEXT: %mma_M:1_N:1_K:0
-    # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:1_K:0, %get_result_M:1_N:1_K:0, None)
-    # CHECK-NEXT: %mma_M:0_N:1_K:1
-    # CHECK-SAME: (%get_result_10, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
-    # CHECK-NEXT: %mma_M:1_N:1_K:1
-    # CHECK-SAME: (%get_result_12, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
-    # CHECK-NEXT: %write_M:0_N:0_K:0
-    # CHECK-NEXT: %write_M:0_N:1_K:0
-    # CHECK-NEXT: %write_M:1_N:0_K:0
-    # CHECK-NEXT: %write_M:1_N:1_K:0
-    # CHECK-NEXT: return None
+        # CHECK-NEXT: %mma_M:0_N:0_K:0
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:0_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:0_K:0
+        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:1_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:0_N:0_K:1
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:0_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:0_K:1
+        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:1_N:0_K:0, None)
+
+        # CHECK-NEXT: %write_10
+        # CHECK-NEXT: %write_11
+
+        # CHECK-NEXT: %mma_M:0_N:1_K:0
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:0_N:1_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:1_K:0
+        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:1_N:1_K:0, None)
+
+        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
+        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
+
+        # CHECK-NEXT: %mma_M:0_N:1_K:1
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:1_K:1
+        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
+
+        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
+        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
+
+        # CHECK-NEXT: %iterate_1
+        # CHECK-SAME: (K, [%mma_M:0_N:0_K:1, %mma_M:0_N:1_K:1, %mma_M:1_N:0_K:1, %mma_M:1_N:1_K:1, %read_4_shared_M:0_N:0_K:1, %read_2_shared_M:0_N:0_K:1, %read_2_shared_M:1_N:0_K:0, %read_2_shared_M:1_N:0_K:1], pipelined_iterate, [%a, %b], 1, None, None)
+
+        # CHECK-NEXT: %get_result_M:0_N:0_K:0
+        # CHECK-SAME: (%iterate_1, 0)
+        # CHECK-NEXT: %get_result_M:0_N:1_K:0
+        # CHECK-SAME: (%iterate_1, 1)
+        # CHECK-NEXT: %get_result_M:1_N:0_K:0
+        # CHECK-SAME: (%iterate_1, 2)
+        # CHECK-NEXT: %get_result_M:1_N:1_K:0
+        # CHECK-SAME: (%iterate_1, 3)
+        # CHECK-NEXT: %get_result_9
+        # CHECK-SAME: (%iterate_1, 4)
+        # CHECK-NEXT: %get_result_10
+        # CHECK-SAME: (%iterate_1, 5)
+        # CHECK-NEXT: %get_result_11
+        # CHECK-SAME: (%iterate_1, 6)
+        # CHECK-NEXT: %get_result_12
+        # CHECK-SAME: (%iterate_1, 7)
+
+        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
+        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
+        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
+        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
+
+        # CHECK-NEXT: %mma_M:0_N:0_K:0
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %get_result_M:0_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:0_K:0
+        # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:0_K:0, %get_result_M:1_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:0_N:0_K:1
+        # CHECK-SAME: (%get_result_10, %get_result_9, %mma_M:0_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:0_K:1
+        # CHECK-SAME: (%get_result_12, %get_result_9, %mma_M:1_N:0_K:0, None)
+        # CHECK-NEXT: %mma_M:0_N:1_K:0
+        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %get_result_M:0_N:1_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:1_K:0
+        # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:1_K:0, %get_result_M:1_N:1_K:0, None)
+        # CHECK-NEXT: %mma_M:0_N:1_K:1
+        # CHECK-SAME: (%get_result_10, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
+        # CHECK-NEXT: %mma_M:1_N:1_K:1
+        # CHECK-SAME: (%get_result_12, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
+
+        # CHECK-NEXT: %write_M:0_N:0_K:0
+        # CHECK-SAME: (%mma_M:0_N:0_K:1, %c, 4, None, (), None)
+        # CHECK-NEXT: %write_M:0_N:1_K:0
+        # CHECK-SAME: (%mma_M:0_N:1_K:1, %c, 4, None, (), None)
+        # CHECK-NEXT: %write_M:1_N:0_K:0
+        # CHECK-SAME: (%mma_M:1_N:0_K:1, %c, 4, None, (), None)
+        # CHECK-NEXT: %write_M:1_N:1_K:0
+        # CHECK-SAME: (%mma_M:1_N:1_K:1, %c, 4, None, (), None)
+
+        # CHECK-NEXT: return None
 
 
 if __name__ == "__main__":

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -160,111 +160,111 @@ def test_gemm_pipelined():
     # CHECK-SAME: ({Operation.MMA: 2, Operation.READ_SHARED: 2}, 0)
     # CHECK-NEXT: [mma_M:0_N:0_K:1, mma_M:0_N:1_K:1, mma_M:1_N:0_K:1, mma_M:1_N:1_K:1, read_4_shared_M:0_N:0_K:1, read_2_shared_M:0_N:0_K:1, read_2_shared_M:1_N:0_K:0, read_2_shared_M:1_N:0_K:1]
 
-        print_subgraph(trace, "region_1", False)
-        # CHECK: %a
-        # CHECK-NEXT: %b
-        # CHECK-NEXT: %c
-        # CHECK-NEXT: %register_M:0_N:0_K:0
-        # CHECK-NEXT: %register_M:0_N:1_K:0
-        # CHECK-NEXT: %register_M:1_N:0_K:0
-        # CHECK-NEXT: %register_M:1_N:1_K:0
-        # CHECK-NEXT: %allocate_1
-        # CHECK-NEXT: %allocate
-        # CHECK-NEXT: %read_21
-        # CHECK-NEXT: %read_22
-        # CHECK-NEXT: %write_10
-        # CHECK-NEXT: %write_11
-        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
-        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
-        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
-        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
-        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
-        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
-        # CHECK-NEXT: %read_21
-        # CHECK-NEXT: %read_22
-        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
-        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
+    print_subgraph(trace, "region_1", False)
+    # CHECK: %a
+    # CHECK-NEXT: %b
+    # CHECK-NEXT: %c
+    # CHECK-NEXT: %register_M:0_N:0_K:0
+    # CHECK-NEXT: %register_M:0_N:1_K:0
+    # CHECK-NEXT: %register_M:1_N:0_K:0
+    # CHECK-NEXT: %register_M:1_N:1_K:0
+    # CHECK-NEXT: %allocate_1
+    # CHECK-NEXT: %allocate
+    # CHECK-NEXT: %read_21
+    # CHECK-NEXT: %read_22
+    # CHECK-NEXT: %write_10
+    # CHECK-NEXT: %write_11
+    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
+    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
+    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
+    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
+    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
+    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
+    # CHECK-NEXT: %read_21
+    # CHECK-NEXT: %read_22
+    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
+    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
 
-        # CHECK-NEXT: %mma_M:0_N:0_K:0
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:0_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:0_K:0
-        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:1_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:0_N:0_K:1
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:0_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:0_K:1
-        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:1_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:0_K:0
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:0_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:0_K:0
+    # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %register_M:1_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:0_K:1
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:0_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:0_K:1
+    # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:0_K:1, %mma_M:1_N:0_K:0, None)
 
-        # CHECK-NEXT: %write_10
-        # CHECK-NEXT: %write_11
+    # CHECK-NEXT: %write_10
+    # CHECK-NEXT: %write_11
 
-        # CHECK-NEXT: %mma_M:0_N:1_K:0
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:0_N:1_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:1_K:0
-        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:1_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:1_K:0
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:0_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:1_K:0
+    # CHECK-SAME: (%read_2_shared_M:1_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %register_M:1_N:1_K:0, None)
 
-        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
-        # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
+    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:0
+    # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
 
-        # CHECK-NEXT: %mma_M:0_N:1_K:1
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:1_K:1
-        # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:1_K:1
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:1_K:1
+    # CHECK-SAME: (%read_2_shared_M:1_N:0_K:1, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
 
-        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
-        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
+    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
+    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
 
-        # CHECK-NEXT: %iterate_1
-        # CHECK-SAME: (K, [%mma_M:0_N:0_K:1, %mma_M:0_N:1_K:1, %mma_M:1_N:0_K:1, %mma_M:1_N:1_K:1, %read_4_shared_M:0_N:0_K:1, %read_2_shared_M:0_N:0_K:1, %read_2_shared_M:1_N:0_K:0, %read_2_shared_M:1_N:0_K:1], pipelined_iterate, [%a, %b], 1, None, None)
+    # CHECK-NEXT: %iterate_1
+    # CHECK-SAME: (K, [%mma_M:0_N:0_K:1, %mma_M:0_N:1_K:1, %mma_M:1_N:0_K:1, %mma_M:1_N:1_K:1, %read_4_shared_M:0_N:0_K:1, %read_2_shared_M:0_N:0_K:1, %read_2_shared_M:1_N:0_K:0, %read_2_shared_M:1_N:0_K:1], pipelined_iterate, [%a, %b], 1, None, None)
 
-        # CHECK-NEXT: %get_result_M:0_N:0_K:0
-        # CHECK-SAME: (%iterate_1, 0)
-        # CHECK-NEXT: %get_result_M:0_N:1_K:0
-        # CHECK-SAME: (%iterate_1, 1)
-        # CHECK-NEXT: %get_result_M:1_N:0_K:0
-        # CHECK-SAME: (%iterate_1, 2)
-        # CHECK-NEXT: %get_result_M:1_N:1_K:0
-        # CHECK-SAME: (%iterate_1, 3)
-        # CHECK-NEXT: %get_result_9
-        # CHECK-SAME: (%iterate_1, 4)
-        # CHECK-NEXT: %get_result_10
-        # CHECK-SAME: (%iterate_1, 5)
-        # CHECK-NEXT: %get_result_11
-        # CHECK-SAME: (%iterate_1, 6)
-        # CHECK-NEXT: %get_result_12
-        # CHECK-SAME: (%iterate_1, 7)
+    # CHECK-NEXT: %get_result_M:0_N:0_K:0
+    # CHECK-SAME: (%iterate_1, 0)
+    # CHECK-NEXT: %get_result_M:0_N:1_K:0
+    # CHECK-SAME: (%iterate_1, 1)
+    # CHECK-NEXT: %get_result_M:1_N:0_K:0
+    # CHECK-SAME: (%iterate_1, 2)
+    # CHECK-NEXT: %get_result_M:1_N:1_K:0
+    # CHECK-SAME: (%iterate_1, 3)
+    # CHECK-NEXT: %get_result_9
+    # CHECK-SAME: (%iterate_1, 4)
+    # CHECK-NEXT: %get_result_10
+    # CHECK-SAME: (%iterate_1, 5)
+    # CHECK-NEXT: %get_result_11
+    # CHECK-SAME: (%iterate_1, 6)
+    # CHECK-NEXT: %get_result_12
+    # CHECK-SAME: (%iterate_1, 7)
 
-        # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
-        # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
-        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
-        # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
+    # CHECK-NEXT: %read_4_shared_M:0_N:0_K:0
+    # CHECK-NEXT: %read_2_shared_M:0_N:0_K:0
+    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:0
+    # CHECK-NEXT: %read_4_shared_M:0_N:1_K:1
 
-        # CHECK-NEXT: %mma_M:0_N:0_K:0
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %get_result_M:0_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:0_K:0
-        # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:0_K:0, %get_result_M:1_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:0_N:0_K:1
-        # CHECK-SAME: (%get_result_10, %get_result_9, %mma_M:0_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:0_K:1
-        # CHECK-SAME: (%get_result_12, %get_result_9, %mma_M:1_N:0_K:0, None)
-        # CHECK-NEXT: %mma_M:0_N:1_K:0
-        # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %get_result_M:0_N:1_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:1_K:0
-        # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:1_K:0, %get_result_M:1_N:1_K:0, None)
-        # CHECK-NEXT: %mma_M:0_N:1_K:1
-        # CHECK-SAME: (%get_result_10, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
-        # CHECK-NEXT: %mma_M:1_N:1_K:1
-        # CHECK-SAME: (%get_result_12, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:0_K:0
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:0_K:0, %get_result_M:0_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:0_K:0
+    # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:0_K:0, %get_result_M:1_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:0_K:1
+    # CHECK-SAME: (%get_result_10, %get_result_9, %mma_M:0_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:0_K:1
+    # CHECK-SAME: (%get_result_12, %get_result_9, %mma_M:1_N:0_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:1_K:0
+    # CHECK-SAME: (%read_2_shared_M:0_N:0_K:0, %read_4_shared_M:0_N:1_K:0, %get_result_M:0_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:1_K:0
+    # CHECK-SAME: (%get_result_11, %read_4_shared_M:0_N:1_K:0, %get_result_M:1_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:0_N:1_K:1
+    # CHECK-SAME: (%get_result_10, %read_4_shared_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None)
+    # CHECK-NEXT: %mma_M:1_N:1_K:1
+    # CHECK-SAME: (%get_result_12, %read_4_shared_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
 
-        # CHECK-NEXT: %write_M:0_N:0_K:0
-        # CHECK-SAME: (%mma_M:0_N:0_K:1, %c, 4, None, (), None)
-        # CHECK-NEXT: %write_M:0_N:1_K:0
-        # CHECK-SAME: (%mma_M:0_N:1_K:1, %c, 4, None, (), None)
-        # CHECK-NEXT: %write_M:1_N:0_K:0
-        # CHECK-SAME: (%mma_M:1_N:0_K:1, %c, 4, None, (), None)
-        # CHECK-NEXT: %write_M:1_N:1_K:0
-        # CHECK-SAME: (%mma_M:1_N:1_K:1, %c, 4, None, (), None)
+    # CHECK-NEXT: %write_M:0_N:0_K:0
+    # CHECK-SAME: (%mma_M:0_N:0_K:1
+    # CHECK-NEXT: %write_M:0_N:1_K:0
+    # CHECK-SAME: (%mma_M:0_N:1_K:1
+    # CHECK-NEXT: %write_M:1_N:0_K:0
+    # CHECK-SAME: (%mma_M:1_N:0_K:1
+    # CHECK-NEXT: %write_M:1_N:1_K:0
+    # CHECK-SAME: (%mma_M:1_N:1_K:1
 
-        # CHECK-NEXT: return None
+    # CHECK-NEXT: return None
 
 
 if __name__ == "__main__":

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -152,9 +152,11 @@ def testPureGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
-        multi_buffer_count=2,
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -188,8 +190,8 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
-        _xfail(SchedulingType.FOUR_STAGE),
-        _xfail(SchedulingType.MODULO),
+        SchedulingType.FOUR_STAGE,
+        SchedulingType.MODULO,
     ],
 )
 @pytest.mark.parametrize(
@@ -231,8 +233,11 @@ def testGemmGatherToLDS(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_global_to_shared=True,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -486,8 +491,11 @@ def testNonTransposeGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -917,8 +925,11 @@ def testVMFMAGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1043,8 +1054,11 @@ def testCDNA2IntGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1150,8 +1164,11 @@ def testCDNA3IntGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1252,8 +1269,11 @@ def testF8Gemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1600,8 +1620,11 @@ def testBatchedGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        use_multi_buffering=enable_scheduling
-        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=(
+            2
+            if enable_scheduling in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO]
+            else None
+        ),
     )
     options = set_default_run_config(options)
     batched_gemm = wave_compile(options, batched_gemm)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -118,7 +118,6 @@ def testGemmBench(tmp_path):
         SchedulingType.PREFETCH,
         SchedulingType.GEMM_FOUR_STAGE,
         SchedulingType.MODULO,
-        SchedulingType.MODULO_MULTI_BUFFERED,
     ],
 )
 @param_bool("dynamic_dims", "dyn")
@@ -153,6 +152,9 @@ def testPureGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        multi_buffer_count=2,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -188,7 +190,6 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
         SchedulingType.PREFETCH,
         _xfail(SchedulingType.GEMM_FOUR_STAGE),
         _xfail(SchedulingType.MODULO),
-        _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
     ],
 )
 @pytest.mark.parametrize(
@@ -230,6 +231,8 @@ def testGemmGatherToLDS(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_global_to_shared=True,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -386,7 +389,6 @@ def testGemmSmallTiles(
         _xfail(SchedulingType.PREFETCH),
         SchedulingType.GEMM_FOUR_STAGE,
         SchedulingType.MODULO,
-        _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
     ],
 )
 @param_bool("dynamic_dims", "dyn")
@@ -484,6 +486,8 @@ def testNonTransposeGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -913,6 +917,8 @@ def testVMFMAGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -935,7 +941,7 @@ def testVMFMAGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.MODULO_MULTI_BUFFERED],
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
@@ -1037,6 +1043,8 @@ def testCDNA2IntGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1063,7 +1071,6 @@ def testCDNA2IntGemm(
     [
         SchedulingType.NONE,
         SchedulingType.MODULO,
-        SchedulingType.MODULO_MULTI_BUFFERED,
         SchedulingType.GEMM_FOUR_STAGE,
     ],
 )
@@ -1143,6 +1150,8 @@ def testCDNA3IntGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1243,6 +1252,8 @@ def testF8Gemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1516,7 +1527,6 @@ def testPackedNonTransposeGemm(
     [
         SchedulingType.NONE,
         SchedulingType.MODULO,
-        SchedulingType.MODULO_MULTI_BUFFERED,
         SchedulingType.GEMM_FOUR_STAGE,
     ],
 )
@@ -1590,6 +1600,8 @@ def testBatchedGemm(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
+        use_multi_buffering=enable_scheduling
+        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     batched_gemm = wave_compile(options, batched_gemm)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -116,6 +116,7 @@ def testGemmBench(tmp_path):
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
+        SchedulingType.GEMM_FOUR_STAGE,
         SchedulingType.MODULO,
         SchedulingType.MODULO_MULTI_BUFFERED,
     ],
@@ -185,6 +186,7 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
+        _xfail(SchedulingType.GEMM_FOUR_STAGE),
         _xfail(SchedulingType.MODULO),
         _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
     ],
@@ -382,6 +384,7 @@ def testGemmSmallTiles(
     [
         SchedulingType.NONE,
         _xfail(SchedulingType.PREFETCH),
+        SchedulingType.GEMM_FOUR_STAGE,
         SchedulingType.MODULO,
         _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
     ],
@@ -808,7 +811,7 @@ def testGemmDot(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO],
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
@@ -1057,7 +1060,12 @@ def testCDNA2IntGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.MODULO_MULTI_BUFFERED],
+    [
+        SchedulingType.NONE,
+        SchedulingType.MODULO,
+        SchedulingType.MODULO_MULTI_BUFFERED,
+        SchedulingType.GEMM_FOUR_STAGE,
+    ],
 )
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -1157,7 +1165,8 @@ def testCDNA3IntGemm(
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
-    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+    "enable_scheduling",
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
 )
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -1504,7 +1513,12 @@ def testPackedNonTransposeGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_batched_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.MODULO_MULTI_BUFFERED],
+    [
+        SchedulingType.NONE,
+        SchedulingType.MODULO,
+        SchedulingType.MODULO_MULTI_BUFFERED,
+        SchedulingType.GEMM_FOUR_STAGE,
+    ],
 )
 def testBatchedGemm(
     shape: tuple[int],

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -116,7 +116,7 @@ def testGemmBench(tmp_path):
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
-        SchedulingType.GEMM_FOUR_STAGE,
+        SchedulingType.FOUR_STAGE,
         SchedulingType.MODULO,
     ],
 )
@@ -153,7 +153,7 @@ def testPureGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
         multi_buffer_count=2,
     )
     options = set_default_run_config(options)
@@ -188,7 +188,7 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
-        _xfail(SchedulingType.GEMM_FOUR_STAGE),
+        _xfail(SchedulingType.FOUR_STAGE),
         _xfail(SchedulingType.MODULO),
     ],
 )
@@ -232,7 +232,7 @@ def testGemmGatherToLDS(
         benchmark_results_file=perf_filename_tk,
         use_global_to_shared=True,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
+        in [SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -387,7 +387,7 @@ def testGemmSmallTiles(
     [
         SchedulingType.NONE,
         _xfail(SchedulingType.PREFETCH),
-        SchedulingType.GEMM_FOUR_STAGE,
+        SchedulingType.FOUR_STAGE,
         SchedulingType.MODULO,
     ],
 )
@@ -487,7 +487,7 @@ def testNonTransposeGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -815,7 +815,7 @@ def testGemmDot(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
@@ -918,7 +918,7 @@ def testVMFMAGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
+        in [SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -941,7 +941,7 @@ def testVMFMAGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
@@ -1044,7 +1044,7 @@ def testCDNA2IntGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1071,7 +1071,7 @@ def testCDNA2IntGemm(
     [
         SchedulingType.NONE,
         SchedulingType.MODULO,
-        SchedulingType.GEMM_FOUR_STAGE,
+        SchedulingType.FOUR_STAGE,
     ],
 )
 @pytest.mark.parametrize(
@@ -1151,7 +1151,7 @@ def testCDNA3IntGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1175,7 +1175,7 @@ def testCDNA3IntGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
-    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.GEMM_FOUR_STAGE],
+    [SchedulingType.NONE, SchedulingType.MODULO, SchedulingType.FOUR_STAGE],
 )
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -1253,7 +1253,7 @@ def testF8Gemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)
@@ -1527,7 +1527,7 @@ def testPackedNonTransposeGemm(
     [
         SchedulingType.NONE,
         SchedulingType.MODULO,
-        SchedulingType.GEMM_FOUR_STAGE,
+        SchedulingType.FOUR_STAGE,
     ],
 )
 def testBatchedGemm(
@@ -1601,7 +1601,7 @@ def testBatchedGemm(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_multi_buffering=enable_scheduling
-        in [SchedulingType.GEMM_FOUR_STAGE, SchedulingType.MODULO],
+        in [SchedulingType.FOUR_STAGE, SchedulingType.MODULO],
     )
     options = set_default_run_config(options)
     batched_gemm = wave_compile(options, batched_gemm)

--- a/wave_lang/kernel/wave/cache.py
+++ b/wave_lang/kernel/wave/cache.py
@@ -192,6 +192,7 @@ class WaveCacheManager(object):
             options.dynamic_symbols,
             options.schedule,
             options.use_scheduling_barriers,
+            options.multi_buffer_count,
             options.backend,
             options.target,
             options.gpu_native_math_precision,

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -25,6 +25,8 @@ class WaveCompileOptions:
     # === Scheduling options ===
     schedule: bool = SchedulingType.NONE
     use_scheduling_barriers: bool = False
+    use_multi_buffering: bool = False
+    multi_buffer_count: int = 2  # if no buffer count specified do double buffer
 
     # === Runtime options ===
     kernel_launch_info: KernelLaunchInfo = field(default_factory=KernelLaunchInfo)

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -25,9 +25,8 @@ class WaveCompileOptions:
     # === Scheduling options ===
     schedule: bool = SchedulingType.NONE
     use_scheduling_barriers: bool = False
-    multi_buffer_count: Optional[int] = (
-        None  # None if no buffer count specified else 2 and up
-    )
+    # None if no buffer count specified else 2 and up
+    multi_buffer_count: Optional[int] = None
 
     # === Runtime options ===
     kernel_launch_info: KernelLaunchInfo = field(default_factory=KernelLaunchInfo)

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -25,8 +25,9 @@ class WaveCompileOptions:
     # === Scheduling options ===
     schedule: bool = SchedulingType.NONE
     use_scheduling_barriers: bool = False
-    use_multi_buffering: bool = False
-    multi_buffer_count: int = 2  # if no buffer count specified do double buffer
+    multi_buffer_count: Optional[int] = (
+        None  # None if no buffer count specified else 2 and up
+    )
 
     # === Runtime options ===
     kernel_launch_info: KernelLaunchInfo = field(default_factory=KernelLaunchInfo)

--- a/wave_lang/kernel/wave/scheduling/four_stage_pipelined_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/four_stage_pipelined_scheduling.py
@@ -20,9 +20,7 @@ class FourStageStage(Enum):
     COMPUTE = auto()
     SCHEDULING_NOOP = -1
 
-    # Helper function to get next stage from the current.
-    # If at stage 3 returns itself to prevent crash
-    # since it is final stage.
+    # Helper function to check next stage follows from current.
     @staticmethod
     def is_valid_transition(
         from_stage: "FourStageStage", to_stage: "FourStageStage"

--- a/wave_lang/kernel/wave/scheduling/gemm_four_stage_pipelined_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/gemm_four_stage_pipelined_scheduling.py
@@ -1,0 +1,148 @@
+import torch.fx as fx
+from ...ops.wave_ops import get_custom
+from .graph_utils import Edge, sort_graph_by_edge_weight
+from .resources import Operation, get_custom_operation_type
+from enum import Enum
+import math
+
+
+class GemmFourStageStage(Enum):
+    GLOBAL_LOAD = 0
+    LOCAL_STORE = 1
+    LOCAL_LOAD = 2
+    COMPUTE = 3
+    SCHEDULING_NOOP = -1
+
+    # Helper function to get next stage from the current.
+    # If at stage 3 returns itself to prevent crash
+    # since it is final stage.
+    def next(self):
+
+        if self.value == 3:
+            return GemmFourStageStage(3)
+        v = self.value + 1
+        return GemmFourStageStage(v)
+
+
+operation_stage_table = {
+    Operation.READ_SHARED: GemmFourStageStage.LOCAL_LOAD,
+    Operation.WRITE_SHARED: GemmFourStageStage.LOCAL_STORE,
+    Operation.READ_GLOBAL: GemmFourStageStage.GLOBAL_LOAD,
+    Operation.MMA: GemmFourStageStage.COMPUTE,
+    Operation.NOOP: GemmFourStageStage.SCHEDULING_NOOP,
+    Operation.VALU: GemmFourStageStage.COMPUTE,
+    Operation.SHUFFLE: GemmFourStageStage.COMPUTE,
+    Operation.WRITE_GLOBAL: GemmFourStageStage.COMPUTE,
+}
+
+
+def get_scheduling_stage(op: fx.Node) -> GemmFourStageStage:
+    op_ty = get_custom_operation_type(get_custom(op))
+    if op_ty not in operation_stage_table:
+        raise NotImplementedError(f"Cannot find {op_ty} in operation_stage_table")
+    return operation_stage_table[op_ty]
+
+
+class GemmFourStageScheduler:
+    """
+    GEMM Four Stage Pipelined Scheduler
+
+    Convert vanilla schedule of:
+        for i = 0 to N:
+            a = READ_GLOBAL i
+            WRITE_SHARED a
+            barrier
+            b = READ_SHARED
+            COMPUTE b
+
+    let SM be shared memory, then SM[0] SM[1] are the multibuffers
+    into mega pipelined schedule:
+        a_0 = READ_GLOBAL 0
+
+        WRITE_SHARED a_0 SM[0]
+        a_1 = READ_GLOBAL 1
+
+        b_0 = READ_SHARED SM[0]
+        WRITE_SHARED a_1 SM[1]
+        a_2 = READ_GLOBAL 2
+
+
+        for i = 0 to N -3:
+            COMPUTE b_i
+            b_{i+1} = READ_SHARED SM[i+1 %2]
+            WRITE_SHARED a_{i+2} SM[i%2]
+            a_{i+3} = READ_GLOBAL k+3
+
+
+        COMPUTE b_{n-2}
+        b_{n-1} = READ_SHARED SM[n-1 %2]
+        WRITE_SHARED a_{n} SM[n % 2]
+
+        COMPUTE b_{n-1}
+        b_{n} = READ_SHARED SM[n %2]
+
+        COMPUTE b_n
+
+    """
+
+    def __init__(
+        self,
+        graph: fx.Graph,
+        edges: list[Edge],
+        resources: list[int],
+    ) -> None:
+        # assert False
+        self.graph = graph
+        self.edges = edges
+        self.resources = resources
+        self.seed = 2024
+
+    def mega_pipelined_scheduling(self, graph: fx.Graph, edges: list[Edge]):
+        """
+        Classify node to different stages. Based on it's stage,
+        program schedules clock for each node. This function also checks
+        that sorted node "contiguously" move between stages.
+        """
+        sorted_nodes = sort_graph_by_edge_weight(graph.nodes, edges)
+        schedule = {}
+        current_stage = GemmFourStageStage.GLOBAL_LOAD
+
+        for node in sorted_nodes:
+            node_stage = get_scheduling_stage(node)
+            next_stage = current_stage.next()
+            if node_stage in [current_stage, GemmFourStageStage.SCHEDULING_NOOP]:
+                schedule[node] = current_stage.value
+            elif node_stage == next_stage:
+                schedule[node] = next_stage.value
+                current_stage = next_stage
+            else:
+                # Node do not move contigously through stages.
+                return {}, False
+        return schedule, True
+
+    def schedule_graph(self) -> tuple[dict[fx.Node, int], bool]:
+        """
+        1. Identify which nodes are part of the global_read/local_write/local_read/compute phase
+        2. Set nodes to clock (0,1,2,3) based on phase.
+        3. Set initiation interval to 1.
+        """
+        self.schedule, success = self.mega_pipelined_scheduling(self.graph, self.edges)
+        self._initiation_interval = 1
+        return self.schedule, success
+
+    @property
+    def initiation_interval(self) -> int:
+        """
+        Returns the initiation interval of the schedule.
+        """
+        return self._initiation_interval
+
+    @property
+    def num_stages(self) -> int:
+        """
+        Returns the number of stages in the kernel of the pipelined loop.
+        """
+        max_cycle = max(
+            [t + 1 for t in self.schedule.values()]
+        )  # plus 1 because 0 indexing
+        return math.ceil(max_cycle / self.initiation_interval)

--- a/wave_lang/kernel/wave/scheduling/modulo_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/modulo_scheduling.py
@@ -4,13 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import math
 from typing import Callable
 
 import numpy as np
 import torch.fx as fx
 
 from wave_lang.support.logging import get_logger
+from .scheduler_utils import BaseScheduler
 
 from .graph_utils import (
     Edge,
@@ -25,7 +25,7 @@ from .graph_utils import (
 logger = get_logger("wave.modulo_scheduling")
 
 
-class ModuloScheduler:
+class ModuloScheduler(BaseScheduler):
     """
     Vanilla Modulo Scheduler.
     References:
@@ -38,10 +38,8 @@ class ModuloScheduler:
         edges: list[Edge],
         resources: list[int],
     ) -> None:
-        self.graph = graph
-        self.edges = edges
-        self.resources = resources
-        self.seed = 2024
+        super().__init__(graph, edges, resources)
+
         self.cached_edges_to = {}
         self.cached_edges_from = {}
 
@@ -268,23 +266,8 @@ class ModuloScheduler:
         return filtered
 
     @property
-    def initiation_interval(self) -> int:
-        """
-        Returns the initiation interval of the schedule.
-        """
-        return self._initiation_interval
-
-    @property
     def resource_reservations(self) -> np.array:
         """
         Returns the resource reservations of the schedule.
         """
         return self.RT
-
-    @property
-    def num_stages(self) -> int:
-        """
-        Returns the number of stages in the kernel of the pipelined loop.
-        """
-        max_cycle = max(t for t in self.schedule.values())
-        return math.ceil(max_cycle / self.initiation_interval)

--- a/wave_lang/kernel/wave/scheduling/multi_buffering.py
+++ b/wave_lang/kernel/wave/scheduling/multi_buffering.py
@@ -60,6 +60,9 @@ def heuristically_multi_buffer_shared_memory(
         # mapping have to match the shape of memory location the
 
         # operation reads from / writes to, which we change below.
+        new_node.index = get_dict_with_updated_key(
+            new_node.index, dim, dim * multi_buffer_count
+        )
         if isinstance(new_node.mapping, IndexMapping):
             input_mapping = new_node.mapping.input_mapping
             output_mapping = new_node.mapping.output_mapping

--- a/wave_lang/kernel/wave/scheduling/multi_buffering.py
+++ b/wave_lang/kernel/wave/scheduling/multi_buffering.py
@@ -6,11 +6,9 @@
 
 from __future__ import annotations
 
-import wave_lang.kernel.lang as tkl
 
 from ..._support.indexing import (
     IndexSymbol,
-    xor,
 )
 from ..._support.tracing import CapturedTrace
 from ...compiler.base import CodegenError
@@ -24,7 +22,90 @@ from ...ops.wave_ops import (
     get_custom,
 )
 from ..utils.mapping_utils import get_dict_with_updated_key
-from .schedule_enums import SchedulingType
+
+
+def heuristically_multi_buffer_shared_memory(
+    new_node: CustomOp,
+    induction_variable: IndexSymbol,
+    reduction: Iterate,
+    multi_buffer_count: int = -1,
+):
+    """
+    This function adjusts the offset to a shared memory buffer to multibuffer.
+    This enables the removal of LDS barriers and enables greater parallelism
+    during software pipelining and schedule reordering techniques
+
+    The induction variable used in this function is the induction variable before
+    it's remapped during schedule reordering. (See update_node_index in loop_reconstuction.py)
+
+    This enables index to be set to buffer_size * (original_induction_variable % multi_buffer_count)
+    Regardless of current node stage, because it will be remapped correctly later depending on if
+    prologue, epilogue, or kernel stage
+    """
+    assert multi_buffer_count != -1
+    original_buffer = get_custom(new_node.memory)
+    reduction_axis = reduction.axis
+    reduction_dim_indices = [
+        i for i, dim in enumerate(original_buffer.shape) if dim == reduction_axis
+    ]
+    for i, dim in enumerate(original_buffer.shape):
+        if i in reduction_dim_indices or dim not in new_node.index:
+            continue
+        block_size = original_buffer.distributed_shape[i]
+        which_buffer = induction_variable % multi_buffer_count
+        offset = block_size * which_buffer
+        new_node.index[dim].start += offset
+
+        # Update the mapping for the operation as the keys for the
+        # mapping have to match the shape of memory location the
+
+        # operation reads from / writes to, which we change below.
+        if isinstance(new_node.mapping, IndexMapping):
+            input_mapping = new_node.mapping.input_mapping
+            output_mapping = new_node.mapping.output_mapping
+            if dim in input_mapping:
+                new_node.mapping.input_mapping = get_dict_with_updated_key(
+                    input_mapping, dim, dim * multi_buffer_count
+                )
+            if dim in output_mapping:
+                new_node.mapping.output_mapping = get_dict_with_updated_key(
+                    output_mapping, dim, dim * multi_buffer_count
+                )
+
+
+def multi_buffer(trace: CapturedTrace, multi_buffer_count=-1):
+    """Perform multi buffering for all supported shared memory locations"""
+
+    # Find all reductions
+    reductions = trace.walk(lambda node: isinstance(get_custom(node), Iterate))
+
+    # Get reduction dimension from first reduction
+    if not reductions or len(reductions) != 1:
+        raise CodegenError(
+            f"Unexpected number of reductions found in graph: {len(reductions)} vs 1"
+        )
+
+    reduction_axis = get_custom(reductions[0]).axis
+
+    # Find reads and writes operating on shared memory
+    reads_and_writes = list()
+    for node in trace.get_subgraph(get_custom(reductions[0]).subgraph_name).nodes:
+        custom = get_custom(node)
+        if (
+            isinstance(custom, Read | Write)
+            and custom.memory_type.address_space == SHARED_ADDRESS_SPACE
+        ):
+            reads_and_writes.append(custom)
+
+    # Partition reads and writes by memory location
+    memory_to_shared_memory_op = _partition_by_memory(reads_and_writes)
+    # Perform multi buffering for all collected memory locations
+    for memory_location in set(memory_to_shared_memory_op):
+        _increase_dimensions_for_multibuffering(
+            original_buffer=memory_location,
+            reduction_axis=reduction_axis,
+            buffer_count=multi_buffer_count,
+        )
 
 
 def _increase_dimensions_for_multibuffering(
@@ -51,139 +132,6 @@ def _increase_dimensions_for_multibuffering(
 
     original_buffer.update_arg(0, tuple(new_shape))
     original_buffer.update_arg(1, tuple(new_distributed_shape))
-
-
-def multi_buffer(trace: CapturedTrace, scheduling_type: SchedulingType):
-    """Perform multi buffering for all supported shared memory locations"""
-
-    # Find all reductions
-    reductions = trace.walk(lambda node: isinstance(get_custom(node), Iterate))
-
-    # Get reduction dimension from first reduction
-    if not reductions or len(reductions) != 1:
-        raise CodegenError(
-            f"Unexpected number of reductions found in graph: {len(reductions)} vs 1"
-        )
-
-    reduction_axis = get_custom(reductions[0]).axis
-
-    # Find reads and writes operating on shared memory
-    reads = []
-    writes = []
-    for node in trace.get_subgraph(get_custom(reductions[0]).subgraph_name).nodes:
-        custom = get_custom(node)
-        if (
-            isinstance(custom, Read | Write)
-            and custom.memory_type.address_space == SHARED_ADDRESS_SPACE
-        ):
-            if isinstance(custom, Read):
-                reads.append(custom)
-            elif isinstance(custom, Write):
-                writes.append(custom)
-
-    # Partition reads and writes by memory location
-    memory_to_reads = _partition_by_memory(reads)
-    memory_to_writes = _partition_by_memory(writes)
-
-    # Perform multi buffering for all collected memory locations
-    for memory_location in set(memory_to_reads.keys()) | set(memory_to_writes.keys()):
-        if scheduling_type == SchedulingType.GEMM_FOUR_STAGE:
-            _increase_dimensions_for_multibuffering(
-                original_buffer=memory_location,
-                reduction_axis=reduction_axis,
-                buffer_count=2,
-            )
-            # rest of multibuffering logic pre-handled in loop_reconstruction.py
-
-        elif scheduling_type == SchedulingType.MODULO_MULTI_BUFFERED:
-            read_nodes = memory_to_reads.get(memory_location, [])
-            write_nodes = memory_to_writes.get(memory_location, [])
-            _multi_buffer_memory_location(
-                trace,
-                memory_location,
-                read_nodes,
-                write_nodes,
-                reduction_axis,
-                2,
-                scheduling_type,
-            )
-            _increase_dimensions_for_multibuffering(
-                original_buffer=memory_location,
-                reduction_axis=reduction_axis,
-                buffer_count=2,
-            )
-
-
-def _multi_buffer_memory_location(
-    trace: CapturedTrace,
-    original_buffer: CustomOp,
-    read_nodes: list[Read],
-    write_nodes: list[Write],
-    reduction_axis: IndexSymbol,
-    buffer_count: int,
-    scheduling_type: SchedulingType,
-):
-    """
-    Implements multi buffering for all reads and write of a shared memory buffer.
-    """
-    # For now we only support double buffering
-    if buffer_count != 2:
-        raise CodegenError(
-            "Current multi buffering implementation supports only buffer_count=2"
-        )
-
-    # Add the buffer offset to the index of each read/write operation
-    stage_mapping: dict[int, list[CustomOp]] = {}
-    for custom_op in read_nodes + write_nodes:
-        cycle = custom_op.fx_node.scheduling_parameters["cycle"]
-
-        # Group nodes by their cycle
-        if cycle not in stage_mapping:
-            stage_mapping[cycle] = []
-        stage_mapping[cycle].append(custom_op)
-
-    reduction_dim_indices = [
-        i for i, dim in enumerate(original_buffer.shape) if dim == reduction_axis
-    ]
-    induction_var = tkl.IndexSymbol(
-        f"$ARG{reduction_axis.name}",
-        integer=True,
-        nonnegative=True,
-    )
-    buffer_selector = induction_var % buffer_count  # 0 to buffer_count-1
-    for stage, ops_in_stage in stage_mapping.items():
-        offset = 0
-        for op in ops_in_stage:
-            # Determine buffer offset based on stage
-            use_alternate_buffer = stage >= 2 and stage <= 4
-
-            # Update each non-reduction dimension with appropriate offset
-            for i, dim in enumerate(original_buffer.shape):
-                if i not in reduction_dim_indices and dim in op.index:
-                    block_size = original_buffer.distributed_shape[i]
-
-                    # Calculate offset based on buffer selection
-                    if use_alternate_buffer:
-                        # XOR with block_size for ping-pong effect
-                        offset = xor(buffer_selector * block_size, block_size)
-                    else:
-                        offset = buffer_selector * block_size
-                    op.index[dim].start = op.index[dim].start + offset
-
-                    # Update the mapping for the operation as the keys for the
-                    # mapping have to match the shape of memory location the
-                    # operation reads from / writes to, which we change below.
-                    if isinstance(op.mapping, IndexMapping):
-                        input_mapping = op.mapping.input_mapping
-                        output_mapping = op.mapping.output_mapping
-                        if dim in input_mapping:
-                            op.mapping.input_mapping = get_dict_with_updated_key(
-                                input_mapping, dim, dim * buffer_count
-                            )
-                        if dim in output_mapping:
-                            op.mapping.output_mapping = get_dict_with_updated_key(
-                                output_mapping, dim, dim * buffer_count
-                            )
 
 
 def _partition_by_memory(nodes: list[CustomOp]) -> dict[CustomOp, list[CustomOp]]:

--- a/wave_lang/kernel/wave/scheduling/schedule.py
+++ b/wave_lang/kernel/wave/scheduling/schedule.py
@@ -62,6 +62,7 @@ def schedule_reduction(
     scheduling_type: SchedulingType = SchedulingType.NONE,
     override_schedule_file: str = None,
     dump_schedule_file: str = None,
+    multi_buffer_count: int = -1,
 ):
     """
     Clones the reduction graph and does the following:
@@ -215,16 +216,14 @@ def schedule_reduction(
         max_induction_variable,
         visualize,
         use_scheduling_barriers,
-        scheduling_type,
+        multi_buffer_count,
     )
 
     # Update new reduction count.
     new_reduction.count = max_induction_variable - (num_stages - 1)
-    if (
-        scheduling_type == SchedulingType.MODULO_MULTI_BUFFERED
-        or scheduling_type == SchedulingType.GEMM_FOUR_STAGE
-    ):
-        multi_buffer(trace, scheduling_type)
+
+    if multi_buffer_count != -1:
+        multi_buffer(trace, multi_buffer_count)
 
 
 def schedule_graph(
@@ -234,6 +233,7 @@ def schedule_graph(
     scheduling_type: SchedulingType = SchedulingType.NONE,
     override_schedule: str = None,
     dump_schedule: str = None,
+    multi_buffer_count: int = -1,
 ):
     """
     Given a graph, pipelines the reductions in the graph.
@@ -261,4 +261,5 @@ def schedule_graph(
             scheduling_type,
             override_schedule,
             dump_schedule,
+            multi_buffer_count,
         )

--- a/wave_lang/kernel/wave/scheduling/schedule.py
+++ b/wave_lang/kernel/wave/scheduling/schedule.py
@@ -41,6 +41,7 @@ from .resources import (
     get_resource_names,
 )
 from .schedule_enums import SchedulingType
+from typing import Optional
 
 logger = get_logger("wave.scheduling.schedule")
 
@@ -62,7 +63,7 @@ def schedule_reduction(
     scheduling_type: SchedulingType = SchedulingType.NONE,
     override_schedule_file: str = None,
     dump_schedule_file: str = None,
-    multi_buffer_count: int = -1,
+    multi_buffer_count: Optional[int] = None,
 ):
     """
     Clones the reduction graph and does the following:
@@ -222,7 +223,7 @@ def schedule_reduction(
     # Update new reduction count.
     new_reduction.count = max_induction_variable - (num_stages - 1)
 
-    if multi_buffer_count != -1:
+    if multi_buffer_count is not None:
         multi_buffer(trace, multi_buffer_count)
 
 
@@ -233,7 +234,7 @@ def schedule_graph(
     scheduling_type: SchedulingType = SchedulingType.NONE,
     override_schedule: str = None,
     dump_schedule: str = None,
-    multi_buffer_count: int = -1,
+    multi_buffer_count: Optional[int] = None,
 ):
     """
     Given a graph, pipelines the reductions in the graph.

--- a/wave_lang/kernel/wave/scheduling/schedule.py
+++ b/wave_lang/kernel/wave/scheduling/schedule.py
@@ -34,7 +34,7 @@ from .loop_reconstruction import construct_pipelined_loop
 from .modulo_scheduling import ModuloScheduler
 from .multi_buffering import multi_buffer
 from .prefetch_scheduling import PrefetchScheduler
-from .gemm_four_stage_pipelined_scheduling import GemmFourStageScheduler
+from .four_stage_pipelined_scheduling import FourStageScheduler
 from .resources import (
     annotate_resource_usage,
     get_available_resources,
@@ -108,8 +108,8 @@ def schedule_reduction(
             scheduler = ModuloScheduler(graph, edges, get_available_resources())
         elif scheduling_type == SchedulingType.PREFETCH:
             scheduler = PrefetchScheduler(graph, edges, get_available_resources())
-        elif scheduling_type == SchedulingType.GEMM_FOUR_STAGE:
-            scheduler = GemmFourStageScheduler(graph, edges, get_available_resources())
+        elif scheduling_type == SchedulingType.FOUR_STAGE:
+            scheduler = FourStageScheduler(graph, edges, get_available_resources())
         else:
             raise ValueError("Unknown scheduling type")
 

--- a/wave_lang/kernel/wave/scheduling/schedule_enums.py
+++ b/wave_lang/kernel/wave/scheduling/schedule_enums.py
@@ -21,4 +21,5 @@ class SchedulingType(Enum):
     NONE = 0x00
     MODULO = 0x10
     PREFETCH = 0x20
+    GEMM_FOUR_STAGE = 0x21
     MODULO_MULTI_BUFFERED = 0x11

--- a/wave_lang/kernel/wave/scheduling/schedule_enums.py
+++ b/wave_lang/kernel/wave/scheduling/schedule_enums.py
@@ -21,4 +21,4 @@ class SchedulingType(Enum):
     NONE = 0x00
     MODULO = 0x10
     PREFETCH = 0x20
-    GEMM_FOUR_STAGE = 0x21
+    FOUR_STAGE = 0x21

--- a/wave_lang/kernel/wave/scheduling/schedule_enums.py
+++ b/wave_lang/kernel/wave/scheduling/schedule_enums.py
@@ -22,4 +22,3 @@ class SchedulingType(Enum):
     MODULO = 0x10
     PREFETCH = 0x20
     GEMM_FOUR_STAGE = 0x21
-    MODULO_MULTI_BUFFERED = 0x11

--- a/wave_lang/kernel/wave/scheduling/scheduler_utils.py
+++ b/wave_lang/kernel/wave/scheduling/scheduler_utils.py
@@ -7,6 +7,7 @@ import math
 from typing import TypeVar
 from enum import Enum
 from .resources import Operation
+from typing import List
 
 ScheduleStage = TypeVar("ScheduleStage", bound=Enum)
 
@@ -19,6 +20,18 @@ def get_scheduling_stage(
     if op_ty not in operation_stage_table:
         raise NotImplementedError(f"Cannot find {op_ty} in operation_stage_table")
     return operation_stage_table[op_ty]
+
+
+def is_single_mma_source(all_mma_nodes: List[fx.Node]):
+    pre_expansion_ids = set(
+        [get_custom(node).pre_expansion_id for node in all_mma_nodes]
+    )
+    return len(pre_expansion_ids) == 1
+
+
+def is_mma_node(possible_mma_node: fx.Node):
+    op_ty = get_custom_operation_type(get_custom(possible_mma_node))
+    return op_ty == Operation.MMA
 
 
 class BaseScheduler:

--- a/wave_lang/kernel/wave/scheduling/scheduler_utils.py
+++ b/wave_lang/kernel/wave/scheduling/scheduler_utils.py
@@ -1,0 +1,47 @@
+from .resources import get_custom_operation_type
+import torch.fx as fx
+from enum import Enum
+from .graph_utils import Edge
+from ...ops.wave_ops import get_custom
+import math
+
+ScheduleStage = Enum  # alias
+
+
+def get_scheduling_stage(
+    op: fx.Node, operation_stage_table: dict[ScheduleStage:int]
+) -> ScheduleStage:
+    op_ty = get_custom_operation_type(get_custom(op))
+    assert op_ty is not None, f"get_custom_operation_type returned None for {op}"
+    if op_ty not in operation_stage_table:
+        raise NotImplementedError(f"Cannot find {op_ty} in operation_stage_table")
+    return operation_stage_table[op_ty]
+
+
+class BaseScheduler:
+    def __init__(
+        self,
+        graph: fx.Graph,
+        edges: list[Edge],
+        resources: list[int],
+    ) -> None:
+        # assert False
+        self.graph = graph
+        self.edges = edges
+        self.resources = resources
+        self.seed = 2024
+
+    @property
+    def initiation_interval(self) -> int:
+        """
+        Returns the initiation interval of the schedule.
+        """
+        return self._initiation_interval
+
+    @property
+    def num_stages(self) -> int:
+        """
+        Returns the number of stages in the kernel of the pipelined loop.
+        """
+        max_cycle = max([t + 1 for t in self.schedule.values()])
+        return math.ceil(max_cycle / self.initiation_interval)

--- a/wave_lang/kernel/wave/scheduling/scheduler_utils.py
+++ b/wave_lang/kernel/wave/scheduling/scheduler_utils.py
@@ -45,5 +45,5 @@ class BaseScheduler:
         """
         Returns the number of stages in the kernel of the pipelined loop.
         """
-        max_cycle = max([t + 1 for t in self.schedule.values()])
+        max_cycle = max(t + 1 for t in self.schedule.values())
         return math.ceil(max_cycle / self.initiation_interval)

--- a/wave_lang/kernel/wave/scheduling/scheduler_utils.py
+++ b/wave_lang/kernel/wave/scheduling/scheduler_utils.py
@@ -4,12 +4,15 @@ from enum import Enum
 from .graph_utils import Edge
 from ...ops.wave_ops import get_custom
 import math
+from typing import TypeVar
+from enum import Enum
+from .resources import Operation
 
-ScheduleStage = Enum  # alias
+ScheduleStage = TypeVar("ScheduleStage", bound=Enum)
 
 
 def get_scheduling_stage(
-    op: fx.Node, operation_stage_table: dict[ScheduleStage:int]
+    op: fx.Node, operation_stage_table: dict[Operation, ScheduleStage]
 ) -> ScheduleStage:
     op_ty = get_custom_operation_type(get_custom(op))
     assert op_ty is not None, f"get_custom_operation_type returned None for {op}"
@@ -25,7 +28,6 @@ class BaseScheduler:
         edges: list[Edge],
         resources: list[int],
     ) -> None:
-        # assert False
         self.graph = graph
         self.edges = edges
         self.resources = resources

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -687,9 +687,9 @@ class LaunchableWave(Launchable):
         # Schedule the reduction ops.
         scheduling_type = options.schedule
         use_scheduling_barriers = options.use_scheduling_barriers
-        multi_buffer_count = (
-            options.multi_buffer_count if options.use_multi_buffering else -1
-        )
+        multi_buffer_count = options.multi_buffer_count
+        if multi_buffer_count is not None:
+            multi_buffer_count = max(1, options.multi_buffer_count)
         graph_passes.append(
             partial(
                 schedule_graph,

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -687,6 +687,9 @@ class LaunchableWave(Launchable):
         # Schedule the reduction ops.
         scheduling_type = options.schedule
         use_scheduling_barriers = options.use_scheduling_barriers
+        multi_buffer_count = (
+            options.multi_buffer_count if options.use_multi_buffering else -1
+        )
         graph_passes.append(
             partial(
                 schedule_graph,
@@ -696,6 +699,7 @@ class LaunchableWave(Launchable):
                 scheduling_type,
                 options.override_schedule,
                 options.dump_schedule,
+                multi_buffer_count,
             )
         )
 


### PR DESCRIPTION
Tested this new pipelined schedule on various tests in wave_gemm_test.py. Also modified wave_gemm_test.py correspondingly. 

Here is a representation of the type of schedule generated from a (GR, LW, LR, MMA) GEMM kernel:
```

a_0 = READ_GLOBAL 0

WRITE_SHARED a_0 SM[0]
a_1 = READ_GLOBAL 1
lds_barrier

b_0 = READ_SHARED SM[0]
WRITE_SHARED a_1 SM[1]
a_2 = READ_GLOBAL 2
lds_barrier

for i = 0 to N -3:
    COMPUTE b_i
    b_{i+1} = READ_SHARED SM[i+1 %2]
    // Work in progress is removing the immediate subsequent lds_barrier
    (lds_barrier)
    WRITE_SHARED a_{i+2} SM[i%2]
    a_{i+3} = READ_GLOBAL k+3
    lds_barrier

COMPUTE b_{n-2}
b_{n-1} = READ_SHARED SM[n-1 %2]
WRITE_SHARED a_{n} SM[n % 2]

COMPUTE b_{n-1}
b_{n} = READ_SHARED SM[n %2]

COMPUTE b_n
```

Thank you in advance for reviewing