### PR TITLE
[Wave] add scaled_dim/scaled_gemm support for gather_to_lds

### DIFF
--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -22,7 +22,7 @@ from wave_lang.kernel.wave.constraints import (
     ScaledMMAType,
 )
 
-from .common.utils import require_e2e, require_cdna4
+from .common.utils import param_bool, require_e2e, require_cdna4
 
 # Note this is specified by the HW and cannot be changed.
 SCALE_GROUP_SIZE = 32
@@ -135,11 +135,13 @@ def torchScaledGemmMXFP8(x, w, x_scales, w_scales):
         ScaledMMAType.F32_16x16x128_F8F6F4,
     ],
 )
+@param_bool("use_global_to_shared")
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 def testScaledGemmMXFP4(
     shape: tuple[int],
     mfma_variant: ScaledMMAType,
     enable_scheduling: SchedulingType,
+    use_global_to_shared: bool,
 ):
     # Input sizes
     M = tkl.sym.M
@@ -201,6 +203,7 @@ def testScaledGemmMXFP4(
         subs=hyperparams,
         canonicalize=True,
         schedule=enable_scheduling,
+        use_global_to_shared=use_global_to_shared,
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -39,6 +39,7 @@ from .utils.general_utils import (
     ceildiv,
     delinearize_index,
     get_hardware_constraint,
+    infer_dim,
     remove_thread_indexing,
     find_index_bounds,
 )
@@ -214,8 +215,9 @@ def emit_global_to_lds(
         nd_index = delinearize_index(thread_id_adjusted, materialized_shape_adjusted)
         logger.info(f"nd_index={nd_index}")
         write_index = {}
-        for dim, idx in zip(symbolic_shape, nd_index):
-            last = dim == symbolic_shape[-1]
+        for bound_expr, idx in zip(symbolic_shape, nd_index):
+            last = bound_expr == symbolic_shape[-1]
+            dim = infer_dim(bound_expr)
 
             idx = idx * elements_per_thread if last else idx
             size = elements_per_thread if last else 1


### PR DESCRIPTION
In scaled gemm, the symbolic_shape != dim. Typically symbolic_shape = dim // K. Hence we teach the compiler to handle such cases.