### PR TITLE
[Wave] Remove torch from default requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,6 @@ setuptools
 typing_extensions
 wheel
 
-# It is expected that you have installed a PyTorch version/variant specific
-# to your needs, so we only include a minimum version spec.
-torch>=2.5,<2.8
-torchaudio
-torchvision
-
 # Used for managing pre-commit flows.
 pre-commit
 


### PR DESCRIPTION
Since, we have requirements.txt that is specifically for pytorch such as pytorch-rocm-requirements.txt and pytorch-cpu-requirements.txt, we remove it from the default one to maximize efficiency, also to not accidentally overwrite pytorch versions we'd like to keep.