### PR TITLE
[Wave] Enable > 4GB bufferOps using resetOffset

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -162,7 +162,7 @@ def test_read_mapped_buffer():
     # CHECK-LABEL:    func.func @read_mapped_buffer
     # CHECK: %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast
     # CHECK: %[[COND:.*]] = arith.select {{%[0-9a-zA-Z_]+}}, {{%[0-9a-zA-Z_]+}}, {{%[0-9a-zA-Z_]+}} : index
-    # CHECK: %[[RES:.*]] = vector.load %[[BUF]][%[[COND]]] : memref<?xf16, strided<[1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>, vector<1xf16>
+    # CHECK: %[[RES:.*]] = vector.load %[[BUF]][%[[COND]]] : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1xf16>
     # CHECK: %[[EXTRACT:.*]] = vector.extract %[[RES]][0] : f16 from vector<1xf16>
     # CHECK: %[[FROM:.*]] = vector.from_elements %[[EXTRACT]]
 
@@ -207,7 +207,7 @@ def test_read_dynamic_3d_buffer():
     # CHECK:            %[[ARG0:.*]] = stream.binding.subspan {{.*}} : !stream.binding -> memref<?x?x16xf16, strided<[?, 16, 1], offset: ?>>
     # CHECK:            %[[MEMREF_CAST:.*]] = memref.reinterpret_cast %[[ARG0]] {{.*}} : memref<?x?x16xf16, strided<[?, 16, 1], offset: ?>> to memref<?xf16, strided<[1], offset: ?>>
     # CHECK:            %[[SWIZZLE_CAST:.*]] = arith.index_cast %c16{{.*}} : index to i14
-    # CHECK:            %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast %[[MEMREF_CAST]] {{.*}} : memref<?xf16, strided<[1], offset: ?>> to memref<?xf16, strided<[1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK:            %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast %[[MEMREF_CAST]] validBytes{{.*}} cacheSwizzleStride{{.*}} resetOffset : memref<?xf16, strided<[1], offset: ?>> to memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>
 
 
 @run_test

--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -311,6 +311,9 @@ def testScaledBatchedGemmMXFP4(
         subs=hyperparams,
         canonicalize=True,
         schedule=enable_scheduling,
+        use_buffer_load_ops=True,
+        use_buffer_store_ops=True,
+        use_stride_cache_swizzle=True,
         dynamic_symbols=dynamic_symbols,
     )
     options = set_default_run_config(options)

--- a/wave_lang/kernel/wave/codegen/read_write.py
+++ b/wave_lang/kernel/wave/codegen/read_write.py
@@ -459,7 +459,7 @@ def _cast_buffer_and_encode_stride(
             ptr,
             cache_swizzle_stride=stride,
             bounds_check=True,
-            reset_offset=False,
+            reset_offset=True,
             valid_bytes=valid_bytes_constant,
         )
 
@@ -467,7 +467,7 @@ def _cast_buffer_and_encode_stride(
         ptr = amdgpu_d.fat_raw_buffer_cast(
             ptr,
             bounds_check=True,
-            reset_offset=False,
+            reset_offset=True,
             valid_bytes=valid_bytes_constant,
         )
 


### PR DESCRIPTION
With the IREE bump, we can now properly use resetOffset to enable > 4GB buffer ops. It works because Wave generates:

memref.reinterpret_cast w/ workgroup offset + buffer_cast w/ resetOffset

With resetOffset, amdgpu.raw_buffer_cast will make the base pointer as the memref's base_ptr + workgroup_offset from reinterpret_cast. This makes the offsets during the read much much smaller allowing us to do > 4GB buffer loads/writes.

We also enable the tests for batched GEMM mxpf4 that has > 4GB to use bufferOps.  