### PR TITLE
[Wave] Fix prefetch scheduling for `GatherToLDS`

### DIFF
--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -136,7 +136,13 @@ def torchScaledGemmMXFP8(x, w, x_scales, w_scales):
     ],
 )
 @param_bool("use_global_to_shared")
-@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
+@pytest.mark.parametrize(
+    "enable_scheduling",
+    [
+        SchedulingType.NONE,
+        SchedulingType.PREFETCH,
+    ],
+)
 def testScaledGemmMXFP4(
     shape: tuple[int],
     mfma_variant: ScaledMMAType,

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -228,7 +228,6 @@ def testGemmGatherToLDS(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_global_to_shared=True,
-        # dump_schedule="schedule.txt",
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -184,7 +184,7 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     "enable_scheduling",
     [
         SchedulingType.NONE,
-        _xfail(SchedulingType.PREFETCH),
+        SchedulingType.PREFETCH,
         SchedulingType.MODULO,
         SchedulingType.MODULO_MULTI_BUFFERED,
     ],
@@ -228,6 +228,7 @@ def testGemmGatherToLDS(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         use_global_to_shared=True,
+        # dump_schedule="schedule.txt",
     )
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -185,8 +185,8 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     [
         SchedulingType.NONE,
         _xfail(SchedulingType.PREFETCH),
-        _xfail(SchedulingType.MODULO),
-        _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
+        SchedulingType.MODULO,
+        SchedulingType.MODULO_MULTI_BUFFERED,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -185,8 +185,8 @@ _global_to_lds_shapes = [(17, 23, 32), (15, 13, 4)]
     [
         SchedulingType.NONE,
         SchedulingType.PREFETCH,
-        SchedulingType.MODULO,
-        SchedulingType.MODULO_MULTI_BUFFERED,
+        _xfail(SchedulingType.MODULO),
+        _xfail(SchedulingType.MODULO_MULTI_BUFFERED),
     ],
 )
 @pytest.mark.parametrize(

--- a/wave_lang/kernel/_support/indexing.py
+++ b/wave_lang/kernel/_support/indexing.py
@@ -464,3 +464,6 @@ class IndexSequence:
 
     def __repr__(self) -> str:
         return f"{self.start} : {self.size} : {self.stride}"
+
+    def __hash__(self):
+        return hash((self.start, self.size, self.stride))

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -2518,8 +2518,8 @@ class GatherToLDS(CustomOp):
 
     src: Memory
     dst: Memory
-    src_idx: dict[IndexSymbol, IndexSequence]
-    dst_idx: dict[IndexSymbol, IndexSequence]
+    src_index: dict[IndexSymbol, IndexSequence]
+    dst_index: dict[IndexSymbol, IndexSequence]
     dtype: DataType
     elements_per_thread: Optional[IndexExpr | int]
     src_mapping: Optional[IndexMapping]

--- a/wave_lang/kernel/wave/scheduling/graph_utils.py
+++ b/wave_lang/kernel/wave/scheduling/graph_utils.py
@@ -478,7 +478,7 @@ def sort_graph_by_edge_weight(nodes: list[fx.Node], edges: list[Edge]):
         ]
 
         # Save for later if producer not registered yet.
-        if any([edge._from not in schedule_weight for edge in filter_producer_edge]):
+        if any(edge._from not in schedule_weight for edge in filter_producer_edge):
             # If we went over entire workqueue and still cannot find producer,
             # means it is missing producer from the edges.
             non_solved_counter += 1

--- a/wave_lang/kernel/wave/scheduling/loop_reconstruction_utils.py
+++ b/wave_lang/kernel/wave/scheduling/loop_reconstruction_utils.py
@@ -8,6 +8,7 @@ from wave_lang.support.logging import get_logger
 
 from ...lang.global_symbols import SHARED_ADDRESS_SPACE
 from ...ops.wave_ops import (
+    GatherToLDS,
     GetResult,
     IterArg,
     Iterate,
@@ -262,6 +263,10 @@ def liveness_analysis(graph: fx.Graph, reduction: Iterate) -> dict[fx.Node, int]
             and custom.memory_type.address_space == SHARED_ADDRESS_SPACE
         ):
             continue
+
+        if isinstance(custom, GatherToLDS):
+            continue
+
         if l > 0:
             num_rotating_registers[node] = l
 

--- a/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
@@ -4,12 +4,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import math
-from enum import Enum
+from enum import Enum, auto
 
 import torch.fx as fx
 
 from ...ops.wave_ops import get_custom
+from ..utils.general_utils import ceildiv
 from .graph_utils import Edge, sort_graph_by_edge_weight
 from .resources import Operation, get_custom_operation_type
 
@@ -19,33 +19,35 @@ logger = logging.getLogger(__name__)
 
 
 class PrefetchStage(Enum):
-    GLOBAL_LOAD = 0
-    LOCAL_STORE = 1
-    LOCAL_LOAD = 2
-    COMPUTE = 3
+    GLOBAL_LOAD = auto()
+    LOCAL_STORE = auto()
+    LOCAL_LOAD = auto()
+    COMPUTE = auto()
 
-    GLOBAL_TO_SHARED = 4
+    @staticmethod
+    def is_valid_transition(
+        from_stage: "PrefetchStage", to_stage: "PrefetchStage"
+    ) -> bool:
+        if from_stage == to_stage:
+            return True
 
-    def next(self):
-        # Helper function to get next stage from the current.
-        # If at stage 3 returns itself to prevent crash
-        # since it is final stage.
-        if self.value == 3:
-            return PrefetchStage(3)
-
-        # GLOBAL_TO_SHARED combines both GLOBAL_LOAD and LOCAL_STORE.
-        if self.value == 4:
-            return PrefetchStage(2)
-
-        v = self.value + 1
-        return PrefetchStage(v)
+        return (from_stage, to_stage) in _prefetch_stage_transition_table
 
 
-operation_stage_table = {
+_prefetch_stage_transition_table = {
+    (PrefetchStage.GLOBAL_LOAD, PrefetchStage.LOCAL_STORE),
+    (PrefetchStage.LOCAL_STORE, PrefetchStage.LOCAL_LOAD),
+    # GLOBAL_TO_SHARED combines both GLOBAL_LOAD and LOCAL_STORE
+    (PrefetchStage.GLOBAL_LOAD, PrefetchStage.LOCAL_LOAD),
+    (PrefetchStage.LOCAL_LOAD, PrefetchStage.COMPUTE),
+    (PrefetchStage.COMPUTE, PrefetchStage.GLOBAL_LOAD),
+}
+
+_operation_stage_table = {
     Operation.READ_SHARED: PrefetchStage.LOCAL_LOAD,
     Operation.WRITE_SHARED: PrefetchStage.LOCAL_STORE,
     Operation.READ_GLOBAL: PrefetchStage.GLOBAL_LOAD,
-    Operation.GLOBAL_TO_SHARED: PrefetchStage.GLOBAL_TO_SHARED,
+    Operation.GLOBAL_TO_SHARED: PrefetchStage.GLOBAL_LOAD,
     Operation.MMA: PrefetchStage.COMPUTE,
     Operation.NOOP: PrefetchStage.COMPUTE,
     Operation.VALU: PrefetchStage.COMPUTE,
@@ -56,9 +58,10 @@ operation_stage_table = {
 def get_scheduling_stage(op: fx.Node) -> Operation:
     op_ty = get_custom_operation_type(get_custom(op))
     assert op_ty is not None, f"get_custom_operation_type returned None for {op}"
-    if op_ty not in operation_stage_table:
-        raise NotImplementedError(f"Cannot find {op_ty} in operation_stage_table")
-    return operation_stage_table[op_ty]
+    if op_ty not in _operation_stage_table:
+        raise NotImplementedError(f"Cannot find {op_ty} in _operation_stage_table")
+
+    return _operation_stage_table[op_ty]
 
 
 class PrefetchScheduler:
@@ -108,24 +111,22 @@ class PrefetchScheduler:
         """
         sorted_nodes = sort_graph_by_edge_weight(graph.nodes, edges)
         schedule = {}
-        # current_stage = PrefetchStage.GLOBAL_LOAD
         current_stage = get_scheduling_stage(sorted_nodes[0])
         current_stage_idx = 0
         for node in sorted_nodes:
             node_stage = get_scheduling_stage(node)
-            next_stage = current_stage.next()
-            logger.info(
-                f"Node {node} is in stage {node_stage}, next stage {next_stage}"
-            )
+            logger.info(f"Node {node} is in stage {node_stage}")
             if node_stage == current_stage:
                 schedule[node] = current_stage_idx
-            elif node_stage == next_stage:
+            elif PrefetchStage.is_valid_transition(current_stage, node_stage):
                 current_stage_idx += 1
                 schedule[node] = current_stage_idx
-                current_stage = next_stage
+                current_stage = node_stage
             else:
                 # Node do not move contigously through stages.
-                logger.warning(f"Node {node} does not move contigously through stages.")
+                logger.warning(
+                    f"No valid transition from {current_stage} to {node_stage} for node {node}"
+                )
                 return {}, False
         return schedule, True
 
@@ -161,5 +162,5 @@ class PrefetchScheduler:
         """
         Returns the number of stages in the kernel of the pipelined loop.
         """
-        max_cycle = max(t for t in self.schedule.values())
-        return math.ceil(max_cycle / self.initiation_interval)
+        max_cycle = max(t + 1 for t in self.schedule.values())
+        return ceildiv(max_cycle, self.initiation_interval)

--- a/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
@@ -143,11 +143,12 @@ class PrefetchScheduler:
 
         logger.info(f"Schedule: {self.schedule}")
         assert self.schedule, "Schedule is empty"
-        self._initiation_interval = 1
-        # self._initiation_interval = 2
-        # if self.num_stages != self._initiation_interval:
-        #     logger.warning(f"Initiation interval {self._initiation_interval} does not match number of stages {self.num_stages}")
-        #     return {}, False
+        self._initiation_interval = 2
+        if self.num_stages != self._initiation_interval:
+            logger.warning(
+                f"Initiation interval {self._initiation_interval} does not match number of stages {self.num_stages}"
+            )
+            return {}, False
         return self.schedule, success
 
     @property


### PR DESCRIPTION
* For prefetch scheduling purposes, treat `GatherToLDS` as `GLOBAL_LOAD`. Add a state machine, allowing jumping `GLOBAL_LOAD` -> `LOCAL_LOAD` for `GatherToLDS` as there will no local stores. 
* Handle `GatherToLDS` in `liveness_analysis`
* Properly update `GatherToLDS`s `src_index` and `dst_index` in scheduling.