### PR TITLE
Adding scatter_max operation

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2133,14 +2133,6 @@ def test_scatter_add(shape, elems_per_thread, request):
         tkw.WaveConstraint(N, BLOCK_N),
     ]
 
-    i = tkw.IndexMapping.iterator(0)
-    j = tkw.IndexMapping.iterator(1)
-    mapping = tkw.IndexMapping(
-        num_iterators=2,
-        inputs={M: i, N: j},
-        outputs={M: i, N: j},
-    )
-
     @tkw.wave(constraints)
     def test(
         a: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
@@ -2155,15 +2147,10 @@ def test_scatter_add(shape, elems_per_thread, request):
             index_reg,
             dim=0,
             memory=lds,
-            mapping=mapping,
             elements_per_thread=STORE_ELEMS_PER_THREAD,
         )
-        lds_reg = tkw.read(
-            lds, elements_per_thread=LOAD_ELEMS_PER_THREAD, mapping=mapping
-        )
-        tkw.write(
-            lds_reg, b, elements_per_thread=STORE_ELEMS_PER_THREAD, mapping=mapping
-        )
+        lds_reg = tkw.read(lds, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        tkw.write(lds_reg, b, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     options = WaveCompileOptions(
         subs={
@@ -2264,3 +2251,96 @@ def test_debug_log_write():
     assert_close(a, debug_logs["debug_log_output_0"])
     assert_close(b, debug_logs["rhslog"])
     assert_close(c, debug_logs["debug_log_output_2"])
+
+
+@require_e2e
+@pytest.mark.parametrize(
+    "shape, elems_per_thread",
+    [
+        ((3840, 1), 1),
+        ((64, 64), 1),
+        ((64, 64), 2),
+        ((64, 64), 4),
+    ],
+)
+def test_scatter_max(shape, elems_per_thread, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    m_size, n_size = shape
+
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 64, N: elems_per_thread},
+        ),
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.WaveConstraint(M, BLOCK_M / 1),
+        tkw.WaveConstraint(N, BLOCK_N),
+    ]
+
+    @tkw.wave(constraints)
+    def read_kernel(
+        a: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        index: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        lds: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+        b: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        index_reg = tkw.read(index, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        tkw.scatter_max(
+            a_reg,
+            index_reg,
+            dim=0,
+            memory=lds,
+            elements_per_thread=LOAD_ELEMS_PER_THREAD,
+        )
+        lds_reg = tkw.read(lds, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        tkw.write(lds_reg, b, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    options = WaveCompileOptions(
+        subs={
+            M: m_size,
+            N: n_size,
+            BLOCK_M: m_size,
+            BLOCK_N: n_size,
+            LOAD_ELEMS_PER_THREAD: elems_per_thread,
+            STORE_ELEMS_PER_THREAD: elems_per_thread,
+            ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+    )
+    options = set_default_run_config(options)
+    read_fn = wave_compile(options, read_kernel)
+
+    input = (
+        device_arange(m_size * n_size, dtype=torch.float32)
+        .reshape(m_size, n_size)
+        .contiguous()
+    )
+    index = device_randint(0, m_size, (m_size, n_size), dtype=torch.int32).contiguous()
+    lds = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+    output = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+
+    read_fn(input, index, lds, output)
+
+    def scatter_max_baseline(input, index):
+        input = input.to(dtype=torch.float32).contiguous()
+        index = index.to(dtype=torch.int64).contiguous()
+        baseline_output = device_zeros(input.shape, dtype=torch.float32)
+        baseline_output.scatter_reduce_(
+            dim=0, index=index, src=input, reduce="amax", include_self=False
+        )
+        return baseline_output
+
+    torch_output = scatter_max_baseline(input, index)
+    assert_close(output, torch_output)

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -20,6 +20,7 @@ from ..._support.tracing import CapturedTrace
 from ...ops.wave_ops import (
     MMA,
     ScatterAdd,
+    ScatterMax,
     Allocate,
     Conditional,
     CustomOp,
@@ -754,6 +755,7 @@ def is_leaf_node(node):
         or (isinstance(custom, GetResult) and not custom.users)
         or isinstance(custom, SetSymbol)
         or isinstance(custom, ScatterAdd)
+        or isinstance(custom, ScatterMax)
     )
 
 


### PR DESCRIPTION
This PR adds a new Wave operation: scatter_max. Its implementation mirrors that of scatter_add. It performs an element-wise maximum reduction from a source register into shared memory (LDS) using dynamic indices along a specified dimension. It supports both integer and floating-point data types and is lowered to memref.atomic_rmw using either maxs or maximumf, depending on the element type. 

Input arguments:
- src: a register containing the values to scatter
- index: a register containing the indices along dim where values should be written
- dim: the dimension along which scattering is performed
- memory: the target tensor in LDS where results are accumulated
- mapping: the index mapping representing mapping between sets of indices
- elements_per_thread: number of elements each thread loads

The mapping argument defaults to an identity IndexMapping, removing the need to pass it explicitly in common cases . Custom static (non-identity) index mappings (e.g transpositions) must be passed explicitly.

Implementation notes:
This op does not use the dynamic_val_mapping field of IndexMapping, unlike the read/write operations. The op iternally performs dynamic indexing, combining the index,dim and (optional) mapping to compute the final memory access coordinates. Potential Future Work: rewrite the operation handler and API to align with wave's write() operation implementation where in case of a scatter operation, index mapping expressions passed through are fully dynamic.
Tests are included in wave_e2e_test.py to validate the correctness of scatter_max.

Limitations:
Currently, scatter_max only works with a single wave. Using 2 or 4 waves results in incorrect behavior, especially when thread index to the same location. The operation supports multiple elements per thread provided that the non-scatter dimension is large enough (> elements_per_thread)