### PR TITLE
NFC: Fix type annotations for return values in attention kernels

### DIFF
--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -87,11 +87,11 @@ def test_attention_32x32x8():
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -220,11 +220,11 @@ def test_dynamic_attention_32x32x8():
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)

--- a/lit_tests/kernel/wave/attention/attention_bias.py
+++ b/lit_tests/kernel/wave/attention/attention_bias.py
@@ -81,11 +81,11 @@ def test_attention_bias():
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             # b_reg: tkw.Register[B, N, K, tkl.f16]

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -86,11 +86,11 @@ def test_dynamic_attention_pipelined():
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -213,11 +213,11 @@ def test_attention_pipelined():
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -936,11 +936,11 @@ def attention(
         partial_max: tkl.Register[B, M, tkl.f32],
         partial_sum: tkl.Register[B, M, tkl.f32],
         acc: tkl.Register[B, N, M, tkl.f32],
-    ) -> (
+    ) -> tuple[
         tkl.Register[B, M, tkl.f32],
         tkl.Register[B, M, tkl.f32],
         tkl.Register[B, N, M, tkl.f32],
-    ):
+    ]:
         imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
         q_reg = tkw.read(q, elements_per_thread=4)
         k_reg = tkw.read(k, elements_per_thread=4)

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -588,11 +588,11 @@ def testAttentionBias(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q)
             # b_reg: tkw.Register[B, N, K, tkl.f16]
@@ -772,11 +772,11 @@ def testAttentionSoftCap(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q)
             # b_reg: tkw.Register[B, N, K, tkl.f16]
@@ -945,11 +945,11 @@ def testAttentionF8(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q)
             k_reg = tkw.read(k)

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -96,11 +96,11 @@ def generate_attention_kernel(constraints: list[Constraint], head_dim: int):
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
             acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, M, tkl.f32],
             tkl.Register[B, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             # b_reg: tkw.Register[B, N, K, tkl.f16]

--- a/tests/kernel/wave/type_inference_test.py
+++ b/tests/kernel/wave/type_inference_test.py
@@ -92,11 +92,11 @@ class TypeInferenceTest(unittest.TestCase):
                 partial_max: tkl.Register[B, M, tkl.f32],
                 partial_sum: tkl.Register[B, M, tkl.f32],
                 acc: tkl.Register[B, N, M, tkl.f32],
-            ) -> (
+            ) -> tuple[
                 tkl.Register[B, M, tkl.f32],
                 tkl.Register[B, M, tkl.f32],
                 tkl.Register[B, N, M, tkl.f32],
-            ):
+            ]:
                 imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
                 q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
                 # b_reg: tkw.Register[B, N, K, tkl.f16]

--- a/wave_lang/kernel/wave/templates/evoformer.py
+++ b/wave_lang/kernel/wave/templates/evoformer.py
@@ -124,11 +124,11 @@ def get_evoformer_kernel(
             partial_max: tkl.Register[B, BN, H, M, tkl.f32],
             partial_sum: tkl.Register[B, BN, H, M, tkl.f32],
             acc: tkl.Register[B, BN, H, N, M, tkl.f32],
-        ) -> (
+        ) -> tuple[
             tkl.Register[B, BN, H, M, tkl.f32],
             tkl.Register[B, BN, H, M, tkl.f32],
             tkl.Register[B, BN, H, N, M, tkl.f32],
-        ):
+        ]:
             imm_reg = tkl.Register[B, BN, H, K2, M, tkl.f32](0.0)
             q_reg = tkw.read(
                 q, mapping=q_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD


### PR DESCRIPTION
Tuple expresisons cannot be used in type annotations, a subscripted `tuple` class should be used instead.