### PR TITLE
add constraints to the cache key

### DIFF
--- a/wave_lang/kernel/wave/cache.py
+++ b/wave_lang/kernel/wave/cache.py
@@ -117,7 +117,7 @@ def get_nested_functions(root_fn: Callable):
     return fn_list
 
 
-def anonymize_constraints(input_constraints: list[Constraint]):
+def anonymize_constraints(input_constraints: list[Constraint]) -> list[Constraint]:
     """
     Helper function to anonymize constraint S.T we can have the same generate
     hash before and after initializing constraints and induction variables.
@@ -137,6 +137,7 @@ def anonymize_constraints(input_constraints: list[Constraint]):
             constraint.wave_id = None
         else:
             continue
+    return processed_constraints
 
 
 class WaveCacheManager(object):

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -215,6 +215,20 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     cache_manager = None
     binary_path = None
 
+    # Create an indexing context and populate substitutions.
+    push(IndexingContext, IndexingContext())
+    idxc = IndexingContext.current()
+
+    # Make a copy of the substitutions to avoid mutating the original
+    # options.subs.
+    idxc.subs = copy(options.subs)
+
+    # Since constraints are used to lookup the compiled kernel in the cache,
+    # we initialize/update the constraints _before_ the cache lookup.
+    kernel.initialize_wave_constraints()
+    kernel.initialize_symbolic_constraints()
+    kernel.initialize_workgroup_constraints()
+
     def get_binary_path():
         if is_cache_enabled():
             return (
@@ -252,14 +266,6 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
                 symbols_args_map,
                 None,  # TODO - this means that the cache is broken for kernels with debug logging.  But I want to focus on getting the feature at all before figuring out how to add extra info to the cache.
             )
-
-    # Create an indexing context and populate substitutions.
-    push(IndexingContext, IndexingContext())
-    idxc = IndexingContext.current()
-
-    # Make a copy of the substitutions to avoid mutating the original
-    # options.subs.
-    idxc.subs = copy(options.subs)
 
     # For the wave runtime, we need the hsaco binary. So we turn on
     # dumping of binaries and store in wave runtime directory. If we

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -313,7 +313,7 @@ class LaunchableWave(Launchable):
                 if tiling_constraint.dim == custom.axis:
                     tiling_constraint.induction_var = self.induction_vars[custom]
 
-    def initialize_wave_constraints(self, trace: CapturedTrace) -> None:
+    def initialize_wave_constraints(self) -> None:
         """
         For each wave constraint, determines the appropriate wave id by looking
         for workgroup constraints along the same dimension and using information
@@ -376,7 +376,7 @@ class LaunchableWave(Launchable):
             if constraint.dim in aliased_dims:
                 constraint.wg_dim = workgroup_dims[constraint.workgroup_dim].wg_dim
 
-    def initialize_workgroup_constraints(self, trace: CapturedTrace) -> None:
+    def initialize_workgroup_constraints(self) -> None:
         """
         For kernels that distribute more than three dimensions among workgroups,
         we need to update the workgroup constraints for dimensions >= 2
@@ -397,7 +397,7 @@ class LaunchableWave(Launchable):
             ]
         self.update_aliased_workgroup_constraints(workgroup_dims)
 
-    def initialize_symbolic_constraints(self, trace: CapturedTrace) -> None:
+    def initialize_symbolic_constraints(self) -> None:
         """
         For each symbolic constraint, create new constraints for the
         related symbolic values with appropriate substitutions.
@@ -525,10 +525,7 @@ class LaunchableWave(Launchable):
             partial(debug_log_hoist, trace),
             partial(initialize_iter_args, trace),
             partial(self.create_induction_vars, trace),
-            partial(self.initialize_wave_constraints, trace),
             partial(self.initialize_reductions, trace),
-            partial(self.initialize_symbolic_constraints, trace),
-            partial(self.initialize_workgroup_constraints, trace),
             finalize_indices,
             substitute_vector_shapes,
             partial(add_get_results, trace),


### PR DESCRIPTION
The `anonymize_constraints()` function has a bug, in that it updates the
constraints as desired, but it doesn't return the updated constraints.
At the same time, in the caller, we use the return value of the function
to create the cache key.  Consequently, prior to this patch, we always
used `None` as the constraint portion of the cache key, so even after
updating the constraints, Wave still retrieved a stale compiled kernel
from the cache.

Additionally, prior to this change, the uncached compilation path
initialized/updated the constraints, thus causing a cache miss even
though the kernel and the programmer-specified constraints didn't
change.  Luckily, the updates to the constraints seem independent of the
trace, so this patch moves the constraint updates _before_ the cache
lookup.