### PR TITLE
Add debug_print_global op

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2238,7 +2238,7 @@ def test_debug_log_write():
         lhs = tkw.read(a)
         rhs = tkw.read(b)
         tkw.debug_log_write(lhs)
-        tkw.debug_log_write(rhs, log_name="rhslog")
+        tkw.debug_log_write(rhs, label="rhslog")
         res = lhs + rhs
         tkw.debug_log_write(res)
         tkw.write(res, c)

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -130,9 +130,13 @@ def write(
 
 def debug_log_write(
     register_: "Register",
-    elements_per_thread: Optional[IndexExpr | int] = None,
-    mapping: Optional[IndexMapping] = None,
-    mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
+    label: Optional[str],
+): ...
+
+
+def debug_print_global(
+    register_: "Register",
+    label: Optional[str],
 ): ...
 
 
@@ -2035,7 +2039,7 @@ class DebugLogWrite(CustomOp):
     """
 
     register_: fx.Proxy
-    log_name: Optional[str] = None
+    label: Optional[str] = None
 
     @property
     def memory(self) -> Optional[fx.Proxy]:
@@ -2058,6 +2062,20 @@ class DebugLogWrite(CustomOp):
 
         self.type = type_expr
         self.fx_node.type = type_expr
+
+
+@define_op("debug_print_global")
+@dataclass
+class DebugPrintGlobal(DebugLogWrite):
+    """
+    An op for debugging.
+
+    Like debug_log_write, it adds an implicit global memory location for debug logging.
+    While you can access the debug log like with debug_log_write, it is also automatically printed after the kernel is run.
+    Note that it prints the entire global tensor once, probably in an abbreviated form.
+
+    The API and semantics of this operation are not yet stable, but since it is just a debugging tool, you want to take any debug logging out of your kernel before shipping it anyway.
+    """
 
 
 @define_op("apply_expr")

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -121,8 +121,7 @@ class WaveKernel:
         debug_args = []
         debug_logs = kwargs.get("debug_logs", {})
         if self.debug_outputs:
-            # Process backwards so that the debug_logs output is ordered.
-            for info_dict in self.debug_outputs[::-1]:
+            for info_dict in self.debug_outputs:
                 shape = [
                     self.options.subs[sdim] for sdim in info_dict["symbolic_shape"]
                 ]
@@ -166,6 +165,12 @@ class WaveKernel:
                 print_bench_result(
                     benchmark_results, self.options.benchmark_results_file
                 )
+
+        # Print global logs if any
+        if self.debug_outputs:
+            for info in self.debug_outputs:
+                if info.get("debug_print_style", None) == "global":
+                    print(f"{info['symbol_name']}:\n{debug_logs[info['symbol_name']]}")
 
         return self.asm
 


### PR DESCRIPTION
This is like debug_log_write, except it automatically prints, so you can have a one-line print in your kernel which prints the whole tensor.

Also add some minor changes to debug_log_write handling.