### PR TITLE
Temporary fix for math library loading while using cache

### DIFF
--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -64,6 +64,9 @@ def invoke_with_wave_runtime(
     ) + tuple(dynamic_symbols)
     # Update the grid size as this may vary depending
     # on the dynamic symbols.
+    import math
+
+    options.kernel_launch_info.grid.__globals__.setdefault("math", math)
     grid = compute_grid(dynamic_dims, options.kernel_launch_info.grid)
 
     stream = torch.cuda.current_stream().cuda_stream


### PR DESCRIPTION
This error causes unit test failures on subsequent runs if cache_on is not set to 0. The issue stems from missing library context (e.g., math) when deserializing cached lambda functions.

With this workaround in place, we can proceed with submitting the PR for SGLang review.