### PR TITLE
disable writing to cache when there are debug_log operations

### DIFF
--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -344,7 +344,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     ]
     options.kernel_usages = kernel_usages
 
-    if is_cache_enabled():
+    if is_cache_enabled() and not debug_arg_info:
         cache_manager.store_kernel(
             compiled_wave_vmfb,
             asm,


### PR DESCRIPTION
Because debug_log operations require extra arguments detailed by the trace, we either need to disable the cache or save the extra debug arg info.  But since I plan to allow arbitrary closures to eventually be connected to the debug arg info (for automatic analysis, or launching of a viewer program, etc), which can not necessarily be serialized, let's just disable caching when there are debug ops.