### PR TITLE
Bump minimum torch version to 2.6

### DIFF
--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1366,7 +1366,7 @@ def test_dynamic_gemm_pipelined():
 
 
 @run_test
-def test_gemm_two_cluter_pingpong():
+def test_gemm_two_cluster_pingpong():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K)]

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,4 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.5,<2.8
+torch>=2.6,<2.8
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,4 @@
 --index-url https://download.pytorch.org/whl/rocm6.3
---extra-index-url https://download.pytorch.org/whl/rocm6.2
-torch>=2.5,<2.8
+torch>=2.6,<2.8
 torchaudio
 torchvision


### PR DESCRIPTION
`torch.fx.graph.output_node` was [added in PyTorch 2.6](https://github.com/pytorch/pytorch/releases/tag/v2.6.0#:~:text=Add-,output_node,-util%20function%20to) and is used by `wave_lang.kernel.wave.schedule_reordering.insert_prefetch_loop_barriers`. That function is used by the test 
`lit_tests/kernel/wave/gemm.py:test_gemm_two_cluster_pingpong` (which also had a typo that I fixed).

And since ROCm 6.2 only supports up to PyTorch 2.5.1, the minimum ROCm version is now 6.3.