### PR TITLE
Support and build for Windows

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build_packages:
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: write
     env:
@@ -45,6 +45,24 @@ jobs:
             package: wave-lang
             python-version: cp313
             platform: manylinux_x86_64
+
+          # Windows packages.
+          - runs-on: windows-2025
+            package: wave-lang
+            python-version: cp310
+            platform: win_amd64
+          - runs-on: windows-2025
+            package: wave-lang
+            python-version: cp311
+            platform: win_amd64
+          - runs-on: windows-2025
+            package: wave-lang
+            python-version: cp312
+            platform: win_amd64
+          - runs-on: windows-2025
+            package: wave-lang
+            python-version: cp313
+            platform: win_amd64
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,17 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DCMAKE_BUILD_TYPE={'Debug' if self.debug else 'Release'}",
         ]
+
+        # Clang is required on Windows, since Wave runtime uses variable-length
+        # arrays (VLAs) which not supported by MSVC
+        if os.name == "nt":
+            cmake_args += [
+                "-G",
+                "Ninja",
+                "-DCMAKE_C_COMPILER=clang",
+                "-DCMAKE_CXX_COMPILER=clang++",
+            ]
+
         subprocess.check_call(["cmake", ext.sourcedir, *cmake_args], cwd=build_dir)
 
         # Build CMake project

--- a/wave_lang/kernel/wave/runtime/CMakeLists.txt
+++ b/wave_lang/kernel/wave/runtime/CMakeLists.txt
@@ -6,8 +6,8 @@
 cmake_minimum_required(VERSION 3.19...3.27)
 project(wave_runtime)
 
-# Skip building on macOS and Windows
-if(APPLE OR WIN32)
+# Skip building on macOS
+if(APPLE)
   message(STATUS "Skipping wave_runtime build on ${CMAKE_SYSTEM_NAME}")
   return()
 endif()


### PR DESCRIPTION
Enables adding the `wave-lang` package to [shark-ai](https://github.com/nod-ai/shark-ai), which uses Windows in CI.

Accomplished by supporting Windows in the Wave C++ runtime, which is the only non-portable code (everything else is Python). This also enables Windows builds.

Note that Windows testing has not been added, especially since Wave currently only supports CDNA; machines on that architecture only support Linux. In the future RDNA support will be added.