### PR TITLE
fix signature of debug_log_write

### DIFF
--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -130,9 +130,7 @@ def write(
 
 def debug_log_write(
     register_: "Register",
-    elements_per_thread: Optional[IndexExpr | int] = None,
-    mapping: Optional[IndexMapping] = None,
-    mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
+    log_name: Optional[str],
 ): ...
 
 


### PR DESCRIPTION
In the original PR adding debug_log_write it originally had more arguments, and after removing them from the implementation I forgot to remove them from the type annotation.