### PR TITLE
NFC move some reordering logic for debug logs

### DIFF
--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -125,8 +125,7 @@ class WaveKernel:
         debug_args = []
         debug_logs = kwargs.get("debug_logs", {})
         if self.debug_outputs:
-            # Process backwards so that the debug_logs output is ordered.
-            for info_dict in self.debug_outputs[::-1]:
+            for info_dict in self.debug_outputs:
                 shape = [
                     self.options.subs.get(symdim, None)
                     or get_dynamic_dimension_actual(symdim)

--- a/wave_lang/kernel/wave/debug_log_hoist.py
+++ b/wave_lang/kernel/wave/debug_log_hoist.py
@@ -93,4 +93,5 @@ def debug_log_write_replace(trace: CapturedTrace, debug_arg_info: list[DebugArgI
         custom = get_custom(debug_placeholder_op)
         debug_placeholder_op.meta["dtype"] = custom.type.dtype
         debug_placeholder_op.meta["symbolic_shape"] = custom.type.symbolic_shape
-        debug_arg_info.append(debug_placeholder_op.meta)
+        # Insert in front since the placeholders are in reverse order compared to the log ops in source code.
+        debug_arg_info.insert(0, debug_placeholder_op.meta)


### PR DESCRIPTION
This will be helpful when there is more processing.  I originally did this in https://github.com/iree-org/wave/pull/95 but I have since decided to approach the main aspect of it in a different way, I'm pulling out this small NFC that will still be helpful for other ways to write printing / visualizingg features.