### PR TITLE
rename debug_log_write to debug_log

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2207,7 +2207,7 @@ def test_scatter_add(shape, elems_per_thread, request):
 
 @require_e2e
 @param_bool("dynamic_dims", "dyn")
-def test_debug_log_write(dynamic_dims: bool):
+def test_debug_log(dynamic_dims: bool):
     M = tkl.sym.M
     N = tkl.sym.N
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
@@ -2238,10 +2238,10 @@ def test_debug_log_write(dynamic_dims: bool):
     ):
         lhs = tkw.read(a)
         rhs = tkw.read(b)
-        tkw.debug_log_write(lhs)
-        tkw.debug_log_write(rhs, log_name="rhslog")
+        tkw.debug_log(lhs)
+        tkw.debug_log(rhs, label="rhslog")
         res = lhs + rhs
-        tkw.debug_log_write(res)
+        tkw.debug_log(res)
         tkw.write(res, c)
 
     a = device_randn(shape, dtype=torch.float16)

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -128,9 +128,9 @@ def write(
 ): ...
 
 
-def debug_log_write(
+def debug_log(
     register_: "Register",
-    log_name: Optional[str],
+    label: Optional[str],
 ): ...
 
 
@@ -2017,9 +2017,9 @@ class Write(CustomOp):
         )
 
 
-@define_op("debug_log_write")
+@define_op("debug_log")
 @dataclass
-class DebugLogWrite(CustomOp):
+class DebugLog(CustomOp):
     """
     An op for debugging.
     Represents a write to an implicit global memory location.
@@ -2033,7 +2033,7 @@ class DebugLogWrite(CustomOp):
     """
 
     register_: fx.Proxy
-    log_name: Optional[str] = None
+    label: Optional[str] = None
 
     @property
     def memory(self) -> Optional[fx.Proxy]:

--- a/wave_lang/kernel/wave/debug_log_hoist.py
+++ b/wave_lang/kernel/wave/debug_log_hoist.py
@@ -9,7 +9,7 @@ from ..ops.wave_ops import (
     get_custom,
     Write,
     Placeholder,
-    DebugLogWrite,
+    DebugLog,
 )
 from .._support.dtype import DataType
 from .._support.indexing import IndexSymbol
@@ -24,7 +24,7 @@ class DebugArgInfo(TypedDict):
 
 
 def is_debug_log_transformer(node):
-    return isinstance(get_custom(node), DebugLogWrite)
+    return isinstance(get_custom(node), DebugLog)
 
 
 def debug_log_hoist(trace: CapturedTrace):
@@ -41,7 +41,7 @@ def debug_log_hoist(trace: CapturedTrace):
         debug_log_ops = trace.walk(is_debug_log_transformer)
         for index, debug_op in enumerate(debug_log_ops):
             custom = get_custom(debug_op)
-            placeholder_name = custom.log_name or f"debug_log_output_{index}"
+            placeholder_name = custom.label or f"debug_log_output_{index}"
             type_expr = None
             placeholder = Placeholder(placeholder_name, type_expr).add_to_graph(root)
             custom.fx_node.memory = placeholder


### PR DESCRIPTION
and its argument from log_name to label.

I originally wrote debug_log_write thinking it would be a primitive operation that I would write other operations on top of, but now I think we will just use this one op instead of making variants of it.  The old names are maybe more descriptive, but for its use as a debugging op, I think it will be worthwhile to make the names shorter and easier to write.

Since we just added this feature and haven't had a major release yet, and this is a debugging tool that is explicitly marked as not being stable and that should be removed from production kernels, I think it is fair to change the API like this.
