### PR TITLE
Re-enable `manylinux` builds with `cibuildwheel`

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -30,44 +30,36 @@ jobs:
         include:
           # Linux packages
           - runs-on: ubuntu-24.04
-            platform: linux-x86_64
             package: wave-lang
-            python-version: "3.10"
+            python-version: cp310
+            platform: manylinux_x86_64
           - runs-on: ubuntu-24.04
-            platform: linux-x86_64
             package: wave-lang
-            python-version: "3.11"
+            python-version: cp311
+            platform: manylinux_x86_64
           - runs-on: ubuntu-24.04
-            platform: linux-x86_64
             package: wave-lang
-            python-version: "3.12"
+            python-version: cp312
+            platform: manylinux_x86_64
           - runs-on: ubuntu-24.04
-            platform: linux-x86_64
             package: wave-lang
-            python-version: "3.13"
+            python-version: cp313
+            platform: manylinux_x86_64
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
-        with:
-          version: "0.8.3"
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Build
-        run: uv build --wheel
+      - name: Build wheels
+        uses: pypa/cibuildwheel@9e4e50bd76b3190f55304387e333f6234823ea9b # v3.1.2
+        env:
+          CIBW_BUILD: ${{ matrix.python-version }}-${{ matrix.platform }}
 
       - name: Upload python wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           if-no-files-found: error
-          name: snapshot-${{ matrix.package }}-${{ matrix.platform }}-${{ matrix.python-version }}
-          path: dist
+          name: snapshot-${{ matrix.package }}-${{ matrix.python-version }}-${{ matrix.platform }}
+          path: ./wheelhouse/*.whl
 
   release_packages:
     needs: build_packages


### PR DESCRIPTION
It would also be straightforward to add `musllinux` builds.

See https://github.com/paulzzy/wave/actions/runs/16614171122 for an example build-and-release run.