### PR TITLE
add mappings to debug_log

### DIFF
--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -132,6 +132,8 @@ def write(
 def debug_log(
     register_: "Register",
     label: Optional[str],
+    mapping: Optional[IndexMapping] = None,
+    mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
 ): ...
 
 
@@ -2046,6 +2048,8 @@ class DebugLog(CustomOp):
 
     register_: fx.Proxy
     label: Optional[str] = None
+    mapping: Optional[IndexMapping] = None
+    mapping_dynamic_vals: tuple[fx.Node, ...] = ()
 
     @property
     def memory(self) -> Optional[fx.Proxy]:

--- a/wave_lang/kernel/wave/debug_log_hoist.py
+++ b/wave_lang/kernel/wave/debug_log_hoist.py
@@ -70,6 +70,8 @@ def debug_log_write_replace(trace: CapturedTrace, debug_arg_info: list[DebugArgI
             new_write = Write(
                 doc.register_,
                 doc.memory,
+                mapping=doc.mapping,
+                mapping_dynamic_vals=doc.mapping_dynamic_vals,
             ).add_to_graph(graph)
             get_custom(new_write).infer_type()
         doc.erase()


### PR DESCRIPTION
In the original debug_log PR we decided to hold off on adding mappings and wait to see if they are necessary.  But practical debugging situations have now demanded that we add mappings.