### PR TITLE
[Wave] Added bool to float casting

### DIFF
--- a/lit_tests/kernel/wave/casting.py
+++ b/lit_tests/kernel/wave/casting.py
@@ -83,4 +83,9 @@ def test_cast():
     # CHECK:  %[[D4:.*]] = arith.extsi %[[D3]] : vector<16xi16> to vector<16xi32>
     # CHECK:  %[[D5:.*]] = arith.sitofp %[[D4]] : vector<16xi32> to vector<16xf32>
     # CHECK:  %[[D6:.*]] = arith.truncf %[[D5]] : vector<16xf32> to vector<16xf16>
-    # CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<16xi1>, vector<16xf16>
+    # CHECK:  %[[MASK:.*]] = arith.constant dense<true> : vector<16xi1>
+    # CHECK:  %[[ONE:.*]] = arith.constant 1.000000e+00 : f16
+    # CHECK:  %[[ZERO:.*]] = arith.constant 0.000000e+00 : f16
+    # CHECK:  %[[VONE:.*]] = vector.broadcast %[[ONE]] : f16 to vector<16xf16>
+    # CHECK:  %[[VZERO:.*]] = vector.broadcast %[[ZERO]] : f16 to vector<16xf16>
+    # CHECK:  %[[D7:.*]] = arith.select %[[MASK]], %[[VONE]], %[[VZERO]] : vector<16xi1>, vector<16xf16>

--- a/lit_tests/kernel/wave/casting.py
+++ b/lit_tests/kernel/wave/casting.py
@@ -68,6 +68,8 @@ def test_cast():
         a_reg = tkw.cast(a_reg, tkl.i32)
         a_reg = tkw.cast(a_reg, tkl.f32)
         a_reg = tkw.cast(a_reg, tkl.f16)
+        a_reg = tkw.Register[M, N, tkw.i1](1)
+        a_reg = tkw.cast(a_reg, tkl.f16)
         tkw.write(a_reg, b, elements_per_thread=16)
 
     options = get_wave_compile_options(canonicalize=False)
@@ -81,3 +83,4 @@ def test_cast():
     # CHECK:  %[[D4:.*]] = arith.extsi %[[D3]] : vector<16xi16> to vector<16xi32>
     # CHECK:  %[[D5:.*]] = arith.sitofp %[[D4]] : vector<16xi32> to vector<16xf32>
     # CHECK:  %[[D6:.*]] = arith.truncf %[[D5]] : vector<16xf32> to vector<16xf16>
+    # CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<16xi1>, vector<16xf16>


### PR DESCRIPTION
When tkw.cast is used with a bool -> float the resulting cast will now be:

- true -> 1.0
- false -> 0.0

This matches the semantics for python, c++.

Previously when doing this it would have the behavior of:

- true -> -1.0
- false -> 0.0