### PR TITLE
[Wave] Add pass profiling and optimize `expand_graph` pass.

### DIFF
--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -84,6 +84,7 @@ class WaveCompileOptions:
     # === Print options ===
     print_ir_after: list[str] = field(default_factory=list)
     print_ir_before: list[str] = field(default_factory=list)
+    profile_pass: list[str] = field(default_factory=list)
     print_trace_begin: bool = False
     print_grid: bool = False
     print_signature: bool = False

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -8,7 +8,7 @@ import itertools
 import math
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Sequence, Callable
 
 from torch import fx
 
@@ -117,13 +117,14 @@ class ExpansionContext:
 def get_dim_combinations(
     node: CustomOp,
     constraints: Sequence[Constraint],
+    get_scaling: Callable[[CustomOp], dict[IndexSymbol, int]],
 ):
     """
     Returns all combinations of sizes for the selected dimensions.
     Other dimensions are clamped to 0. A dictionary is return where
     the keys are the dimensions and the values are the combination.
     """
-    dim_scaling = get_dim_scaling(constraints, node)
+    dim_scaling = get_scaling(node)
     adjusted_dimension_sizes = [
         list(range(dim_scaling[dim])) if dim in node.indexing_dims else [0]
         for dim in dim_scaling
@@ -612,6 +613,7 @@ def dfs(
     dim_query: dict[IndexSymbol, int],
     constraints: Sequence[Constraint],
     expansion_context: ExpansionContext,
+    get_scaling: Callable[[CustomOp], dict[IndexSymbol, int]],
 ):
     """
     Perform a depth-first search on the graph starting at the given node
@@ -625,7 +627,7 @@ def dfs(
         if (node, metadata) in visited:
             continue
         visited.add((node, metadata))
-        dim_scaling = get_dim_scaling(constraints, node)
+        dim_scaling = get_scaling(node)
         nodes_to_expand = expand_node(
             node, dim_scaling, nodes_to_expand, metadata, expansion_context
         )
@@ -775,14 +777,27 @@ def expand_graph(
         logger.warning(
             f"No leaf operations found in kernel. Using final operation {final_op}"
         )
+
+    # get_dim_scaling is expensive, so we cache the results.
+    scaling_cache = {}
+
+    def get_scaling(node: CustomOp):
+        if val := scaling_cache.get(node, None):
+            return val
+
+        scaling = get_dim_scaling(constraints, node)
+        scaling_cache[node] = scaling
+        return scaling
+
     expansion_context = ExpansionContext()
     for custom in leaf_ops:
-        for dim_combination in get_dim_combinations(custom, constraints):
+        for dim_combination in get_dim_combinations(custom, constraints, get_scaling):
             dfs(
                 custom,
                 dim_combination,
                 constraints,
                 expansion_context,
+                get_scaling,
             )
 
     # Fixup all reduction nodes.

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -113,6 +113,9 @@ class ExpansionContext:
     def __setitem__(self, key: ExpansionInfo, value: CustomOp):
         self.expansion_context[key] = value
 
+    def get(self, key: ExpansionInfo):
+        return self.expansion_context.get(key, None)
+
 
 def get_dim_combinations(
     node: CustomOp,
@@ -335,8 +338,7 @@ def update_users(
                 continue
             dim_query = metadata.source_dim_query
         key = ExpansionInfo(user, get_indexed_dims(dim_query, user))
-        if key in expansion_context:
-            new_user = expansion_context[key]
+        if new_user := expansion_context.get(key):
             if not new_user.node_args:
                 continue
             indices = user.get_node_arg_index(node)

--- a/wave_lang/kernel/wave/expansion/expansion_utils.py
+++ b/wave_lang/kernel/wave/expansion/expansion_utils.py
@@ -265,16 +265,16 @@ def remove_original_nodes(leaf_nodes: list[CustomOp]):
     """
     Remove the original nodes from the graph.
     """
-    queue = leaf_nodes
+    queue = [node.fx_node for node in leaf_nodes]
     while queue:
-        custom = queue.pop(0)
-        if custom.fx_node._erased:
+        node = queue.pop(0)
+        if node._erased:
             continue
-        inputs, _ = get_inputs(custom.fx_node, None)
+        inputs, _ = get_inputs(node, None)
         for input in inputs:
-            queue.append(get_custom(input))
-        if not custom.users:
-            custom.erase()
+            queue.append(input)
+        if not node.users:
+            get_custom(node).erase()
 
 
 def remove_unused_registers(trace: CapturedTrace):

--- a/wave_lang/kernel/wave/utils/print_utils.py
+++ b/wave_lang/kernel/wave/utils/print_utils.py
@@ -765,6 +765,7 @@ def try_apply_pass(
     trace: CapturedTrace,
     print_ir_before: Sequence[str] = [],
     print_ir_after: Sequence[str] = [],
+    profile_pass: Sequence[str] = [],
     pass_times: Optional[dict[str, float]] = None,
 ):
     pass_name = p.__name__
@@ -773,7 +774,14 @@ def try_apply_pass(
         print_trace(trace)
     try:
         start = timeit.default_timer()
-        p()
+        if "all" in profile_pass or pass_name in profile_pass:
+            import cProfile
+
+            with cProfile.Profile() as pr:
+                p()
+            pr.print_stats(sort="cumulative")
+        else:
+            p()
         end = timeit.default_timer()
         if pass_times is not None:
             print_name = pass_name

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -580,6 +580,7 @@ class LaunchableWave(Launchable):
 
         print_ir_after = options.print_ir_after
         print_ir_before = options.print_ir_before
+        profile_pass = options.profile_pass
         if options.print_trace_begin:
             print(f"\n***Tracing kernel {self._name}***")
 
@@ -667,7 +668,9 @@ class LaunchableWave(Launchable):
 
         pass_times = {}
         for p in graph_passes:
-            try_apply_pass(p, trace, print_ir_before, print_ir_after, pass_times)
+            try_apply_pass(
+                p, trace, print_ir_before, print_ir_after, profile_pass, pass_times
+            )
 
         if options.print_pass_times:
             pass_times_list = sorted(


### PR DESCRIPTION
* Add pass profiling using `cProfile`.
* Cache `get_dim_scaling` results as it's expensive.
* Reduce excessive `get_custom` in `remove_original_nodes`.

Cuts `expand_graph` time in half (3s -> 1.5s) in extend attention test.