### PR TITLE
Added sigmoid operator

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -903,6 +903,7 @@ def test_unary_lowerings():
         res = tkw.softsign(res, logit_cap=30.0, apply_scaling=True, head_dim=128)
         res = tkw.roundeven(res)
         res = tkw.sin(res)
+        res = tkw.sigmoid(res)
         res = tkw.sinh(res)
         res = tkw.cos(res)
         res = tkw.cbrt(res)
@@ -957,6 +958,15 @@ def test_unary_lowerings():
     # CHECK: %[[ADD:.+]] = arith.addf %[[ONE]], %[[ABS2]] : vector<4xf16>
     # CHECK: %[[RECIP_DENOM:.+]] = arith.divf %[[ONE]], %[[ADD]] : vector<4xf16>
     # CHECK: %[[SOFTSIGN:.+]] = arith.mulf %[[TANH_APPROX]], %[[RECIP_DENOM]] : vector<4xf16>
+
+    # Tests sigmoid 
+    # Assuming input %[[SIGMOID_INPUT:.+]] = ...
+    # CHECK: %[[NEG_ONE:.+]] = arith.constant dense<-1.000000e+00> : vector<4xf16>
+    # CHECK: %[[ONE:.+]] = arith.constant dense<1.000000e+00> : vector<4xf16>
+    # CHECK: %[[NEG_X:.+]] = arith.mulf %[[SIGMOID_INPUT]], %[[NEG_ONE]] : vector<4xf16>
+    # CHECK: %[[EXP_NEG_X:.+]] = math.exp %[[NEG_X]] : vector<4xf16>
+    # CHECK: %[[ONE_PLUS_EXP:.+]] = arith.addf %[[ONE]], %[[EXP_NEG_X]] : vector<4xf16>
+    # CHECK: %[[SIGMOID_RESULT:.+]] = arith.divf %[[ONE]], %[[ONE_PLUS_EXP]] : vector<4xf16>
 
     # Tests roundeven
     # CHECK: %[[ROUNDEVEN:.+]] = math.roundeven %[[SOFTSIGN]]

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -186,6 +186,9 @@ def cos(src: "Register") -> "Register": ...
 def roundeven(src: "Register") -> "Register": ...
 
 
+def sigmoid(src: "Register") -> "Register": ...
+
+
 def sin(src: "Register") -> "Register": ...
 
 
@@ -940,6 +943,7 @@ class ComparisonPyOp(BinaryOpBase, ABC):
 @define_interface_op("roundeven")
 @define_interface_op("sin")
 @define_interface_op("sinh")
+@define_interface_op("sigmoid")
 @define_interface_op("tanh")
 @define_interface_op("tanh_approx")
 @define_interface_op("cos")

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -106,6 +106,7 @@ from ...ops.wave_ops import (
     sin,
     sinh,
     softsign,
+    sigmoid,
     sqrt,
     tanh,
     tanh_approx,
@@ -1116,6 +1117,38 @@ def handle_softsign(emitter: WaveEmitter, node: fx.Node) -> None:
     result = arith_d.mulf(source, reciprocal_denom, fastmath=get_fast_math_flags(opts))
 
     emitter.bind_node_proxy(node, IRProxyValue(result))
+
+
+@handle_unary_op(sigmoid)
+def handle_sigmoid(source: Value, options: WaveCompileOptions) -> OpResult:
+    # check element type
+    element_type = get_type_or_element_type(source.type)
+
+    if _is_float_type(element_type):
+        # constant one
+        one = arith_d.ConstantOp(
+            source.type,
+            DenseElementsAttr.get_splat(source.type, get_constant_attr(1.0, element_type)),
+        )
+        # negative one
+        neg_one = arith_d.ConstantOp(
+                source.type,
+                DenseElementsAttr.get_splat(
+                    source.type, get_constant_attr(-1.0, element_type)
+                ),
+            )
+        # negative x
+        neg_x = arith_d.mulf(source, neg_one, fastmath=get_fast_math_flags(options))
+        # denominator = 1 + exp(-x)
+        denom = arith_d.addf(one, math_d.exp(neg_x), fastmath=get_fast_math_flags(options))
+        # reciprocal_denom = 1 / denom
+        reciprocal_denom = arith_d.divf(one, denom, fastmath=get_fast_math_flags(options))
+        # result = 1 * (1 / denom)
+        result = arith_d.mulf(one, reciprocal_denom, fastmath=get_fast_math_flags(options))
+    else:
+        raise ValidationError(f"Found unhandled operand type for sigmoid: {element_type}")    
+    
+    return result
 
 
 @handle_unary_op(tanh)


### PR DESCRIPTION
### Use Cases
**Neural Network Inference:** Sigmoid is a fundamental activation function used in many ML models. 
**Probability Outputs:** Converting logits to probabilities in binary classification tasks.
**Gating Functions:** Used in attention mechanisms and memory networks.