### PR TITLE
[Wave] Gather to lds swizzling

### DIFF
--- a/lit_tests/kernel/wave/gather_to_shared.py
+++ b/lit_tests/kernel/wave/gather_to_shared.py
@@ -257,10 +257,21 @@ def test_gather_to_shared_scaled_dims():
     print(scaled_gemm.asm)
 
     # CHECK-LABEL:    test_gather_to_shared_scaled_dims
+    # CHECK:          #[[map1:.*]] = affine_map<()[s0] -> ((s0 floordiv 8) mod 8)>
+    # CHECK:          #[[map2:.*]] = affine_map<()[s0] -> (s0 mod 8)>
+    # CHECK:          #[[map6:.*]] = affine_map<()[s0] -> ((s0 mod 64) floordiv 16)>
+    # CHECK:          #[[map7:.*]] = affine_map<()[s0] -> ((s0 mod 64) floordiv 16 + 4)>
     # CHECK:          func.func @scaled_gemm
+    # CHECK:          %[[thread_id_x:.*]] = gpu.thread_id x
     # CHECK-COUNT-1:    memref.alloc()
     # Check some swizzling was done
-    # CHECK-COUNT-3:    arith.xori
+    # CHECK:          %[[col:.*]] = affine.apply #[[map1]]()[%[[thread_id_x]]]
+    # CHECK:          %[[row:.*]] = affine.apply #[[map2]]()[%[[thread_id_x]]]
+    # CHECK:          %{{.*}} = arith.xori %[[row]], %[[col]] : index
+    # CHECK:          %[[row_swizzled:.*]] = affine.apply #[[map6]]()[%[[thread_id_x]]]
+    # CHECK:          %[[row_swizzled_2:.*]] = affine.apply #[[map7]]()[%[[thread_id_x]]]
+    # CHECK:          %{{.*}} = arith.xori %[[row_swizzled]], %[[row]] : index
+    # CHECK:          %{{.*}} = arith.xori %[[row_swizzled_2]], %[[row]] : index
     # CHECK:            scf.for
     # CHECK:              amdgpu.lds_barrier
     # CHECK-COUNT-4:      amdgpu.gather_to_lds {{.*}}

--- a/lit_tests/kernel/wave/gather_to_shared.py
+++ b/lit_tests/kernel/wave/gather_to_shared.py
@@ -259,6 +259,8 @@ def test_gather_to_shared_scaled_dims():
     # CHECK-LABEL:    test_gather_to_shared_scaled_dims
     # CHECK:          func.func @scaled_gemm
     # CHECK-COUNT-1:    memref.alloc()
+    # Check some swizzling was done
+    # CHECK-COUNT-3:    arith.xori
     # CHECK:            scf.for
     # CHECK:              amdgpu.lds_barrier
     # CHECK-COUNT-4:      amdgpu.gather_to_lds {{.*}}

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1634,6 +1634,10 @@ class Read(CustomOp):
         return get_custom(self.memory).type
 
     @property
+    def dtype(self) -> DataType:
+        return self.memory_type.dtype
+
+    @property
     def write_dependency(self) -> fx.Node:
         return self._write_dependency
 

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -521,4 +521,4 @@ def gather_to_shared_swizzling(
             col = global_index[col_dim].start + col
             index[col_dim] = IndexSequence(col, col_seq.size, col_seq.stride)
             logger.info(f"gather.src_index={gather.src_index} -> {index}")
-            gather.src_index = index
+            gather.update_arg("src_index", index)

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -267,6 +267,8 @@ def emit_global_to_lds(
         if i == 0:
             commmon_id = id(new_write)
 
+        # Set `pre_expansion_id` for newly created `GatherToLDS` ops so we can find
+        # they are part of the same group later.
         new_write.pre_expansion_id = commmon_id
 
         new_writes[write.memory].append(new_write)
@@ -519,6 +521,8 @@ def gather_to_shared_swizzling(
             read.index = index
 
         for gather in gathers:
+            # Only apply swissling to the thread part of the index and keep the
+            # global part of the index unchanged.
             index = dict(gather.src_index)
             global_index = remove_thread_indexing(index)
             local_index = remove_global_indexing(index, constraints)

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -453,6 +453,15 @@ def gather_to_shared_swizzling(
     constraints: list[Constraint],
     options: WaveCompileOptions,
 ):
+    """
+    This pass is used to swizzle the gather to shared op global index and
+    corresponding LDS load index to reduce LDS bank conflicts.
+
+    The formula for swizzling is:
+    ```
+    new_col = xor(row % 8, col // elements_per_thread) * elements_per_thread
+    ```
+    """
     if "gfx95" not in options.target:
         logger.info("gather_to_shared_swizzling not supported on this architecture")
         return

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -521,7 +521,7 @@ def gather_to_shared_swizzling(
             read.index = index
 
         for gather in gathers:
-            # Only apply swissling to the thread part of the index and keep the
+            # Only apply swizzling to the thread part of the index and keep the
             # global part of the index unchanged.
             index = dict(gather.src_index)
             global_index = remove_thread_indexing(index)

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -67,7 +67,7 @@ from .decompose_reduce_ops import decompose_reduce_ops
 from .decompose_scan_ops import decompose_scan_ops
 from .decompose_vmma_ops import decompose_vmma_ops
 from .expansion.expansion import add_get_results, expand_graph
-from .gather_to_shared import gather_to_shared
+from .gather_to_shared import gather_to_shared, gather_to_shared_swizzling
 from .generate_bounds_exprs import generate_bounds_exprs
 from .global_to_shared_gathers import global_to_shared_gathers
 from .hoisting import hoist_loop_invariant_ops
@@ -664,6 +664,7 @@ class LaunchableWave(Launchable):
             graph_passes += [
                 partial(hoist_loop_invariant_ops, trace, self.constraints),
                 partial(gather_to_shared, trace, self.constraints, options),
+                partial(gather_to_shared_swizzling, trace, self.constraints, options),
                 partial(in_thread_transpose, trace, self.constraints),
                 partial(global_to_shared_gathers, trace, self.constraints),
                 partial(minimize_global_loads, trace, self.constraints),


### PR DESCRIPTION
Add `GatherToLDS` swizzling. Swizzling is applied to shared memory reads index and then the inverse swizzling is applied the the `GatherToLDS` global read index (as its write index is always contiguous), "Inverse swizzling" is in fact the same formula as applying `xor` second time produces the original result.