### PR TITLE
[debugging] add printer and handler args to debug_log

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2238,6 +2238,17 @@ def test_debug_log(dynamic_dims: bool):
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N)]
 
+    printer_args = None
+    handler_arg = None
+
+    def printer(*args):
+        nonlocal printer_args
+        printer_args = args
+
+    def handler(arg):
+        nonlocal handler_arg
+        handler_arg = arg
+
     @tkw.wave(constraints)
     def test(
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
@@ -2246,12 +2257,12 @@ def test_debug_log(dynamic_dims: bool):
     ):
         lhs = tkw.read(a)
         rhs = tkw.read(b)
-        tkw.debug_log(lhs)
+        tkw.debug_log(lhs, printer=printer)
         tkw.debug_log(rhs, label="rhslog")
         lhs_mapped = tkw.read(a, mapping=read_mapping)
         tkw.debug_log(lhs_mapped, label="lhs_mapped", mapping=write_mapping)
         res = lhs + rhs
-        tkw.debug_log(res, label="res")
+        tkw.debug_log(res, label="res", handler=handler)
         tkw.write(res, c)
 
     a = device_randn(shape, dtype=torch.float16)
@@ -2278,10 +2289,14 @@ def test_debug_log(dynamic_dims: bool):
 
     debug_logs = {}
     test(a, b, c, debug_logs=debug_logs)
-    assert_close(a, debug_logs["debug_log_output_0"])
-    assert_close(b, debug_logs["rhslog"])
-    assert_close(c, debug_logs["res"])
-    # with the input mapping the rows of the first half are duplicated, with the output mapping the duplicate rows are written back only to the first half
+    assert_close(a, debug_logs["debug_log_output_0"]["value"])
+    assert printer_args[0] == "debug_log_output_0"
+    assert printer_args[1] is debug_logs["debug_log_output_0"]["value"]
+    assert_close(b, debug_logs["rhslog"]["value"])
+    assert_close(c, debug_logs["res"]["value"])
+    # with the input mapping the rows of the first half are duplicated, with the
+    # output mapping the duplicate rows are written back only to the first half.
     assert_close(
-        a[0 : shape[0] // 2, :], debug_logs["lhs_mapped"][0 : shape[0] // 2, :]
+        a[0 : shape[0] // 2, :], debug_logs["lhs_mapped"]["value"][0 : shape[0] // 2, :]
     )
+    assert handler_arg == debug_logs

--- a/wave_lang/kernel/_support/tracing.py
+++ b/wave_lang/kernel/_support/tracing.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import warnings
 from abc import ABC, abstractmethod
-from types import FunctionType
+from types import FunctionType, BuiltinFunctionType
 from typing import (
     Callable,
     Dict,
@@ -163,6 +163,8 @@ class KernelTracer(SubgraphTracer):
         if isinstance(a, GenericDot):
             return a
         if isinstance(a, FunctionType):
+            return a
+        if isinstance(a, BuiltinFunctionType):
             return a
         return super().create_arg(a)
 

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -134,6 +134,8 @@ def debug_log(
     label: Optional[str],
     mapping: Optional[IndexMapping] = None,
     mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
+    printer: Optional[Callable[[str, Any], Any]] = None,
+    handler: Optional[Callable[[dict[str, Any]], Any]] = None,
 ): ...
 
 
@@ -2073,9 +2075,19 @@ class DebugLog(CustomOp):
     Represents a write to an implicit global memory location.
     The kernel will implicitly have an extra memory input added that will be injected by the Python kernel launcher.
     The memory can be accessed by passing an an extra keyword to kernel invokation "debug_logs" with an empty dictionary.
-    The dictionary will be mutated to contain the logs.
+    The dictionary will be mutated, adding the `label`s as keys that map to nested dictionaries.
+    The nested dictionaries have a `value` field with the log tensor, and other keys (eg. `symbolic_shape`).
 
-    This is intended as a primitive for building more convenient debug logging tools.
+    IE the debug_logs dictionary will look like:
+    `{LABEL: {"value": LOG_TENSOR, (other metadata keys) ...}}``
+
+    Note that the logs collected in the `debug_logs` field, or handled by `printer` or `handler` represent a global view of the log after all writes, not limited to any one wave or loop iteration.
+
+    The optional `printer` argument should be a function that accepts a string (the log's `label`) and the value of the log itself (a Torch tensor).
+    A handy value for this is `print`, though note that it will probably print an abbreviated view of the global tensor.
+
+    The optional `handler` argument should be a function that accepts the whole `debug_logs` object (IE all logs, not just one).
+    The handler function gives a way to specify something like a viewer for all logs, but specify it inline among print functions rather than separately.
 
     The API and semantics of this operation are not yet stable, but since it is just a debugging tool, you want to take any debug logging out of your kernel before shipping it anyway.
     """
@@ -2084,6 +2096,8 @@ class DebugLog(CustomOp):
     label: Optional[str] = None
     mapping: Optional[IndexMapping] = None
     mapping_dynamic_vals: tuple[fx.Node, ...] = ()
+    printer: Optional[Callable[[str, Any], Any]] = None
+    handler: Optional[Callable[[dict[str, Any]], Any]] = None
 
     @property
     def memory(self) -> Optional[fx.Proxy]:

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -48,6 +48,7 @@ class WaveKernel:
         symbols_args_map: dict[IndexSymbol, tuple[int, int]],
         trace: Optional["CapturedTrace"] = None,
         debug_outputs: Optional[Sequence[DebugArgInfo]] = None,
+        debug_handlers: Optional[Sequence[Any]] = None,
     ):
         self.options = options
         self.executable = executable
@@ -67,6 +68,7 @@ class WaveKernel:
         self.bound_scalar_symbols = bound_scalar_symbols
         self.symbols_args_map = symbols_args_map
         self.debug_outputs = debug_outputs
+        self.debug_handlers = debug_handlers
 
         if not options.wave_runtime:
             # Disable async dispatch for benchmarking.
@@ -134,8 +136,12 @@ class WaveKernel:
                 memory = torch.zeros(
                     shape, dtype=wave_dtype_to_torch(info_dict["dtype"]), device="cuda"
                 )
+                log_info = {
+                    "value": memory,
+                    "symbolic_shape": info_dict["symbolic_shape"],
+                }
                 debug_args.append(memory)
-                debug_logs[info_dict["symbol_name"]] = memory
+                debug_logs[info_dict["symbol_name"]] = log_info
         kernel_outputs = kernel_outputs + debug_args
 
         dynamic_symbols = []
@@ -170,6 +176,15 @@ class WaveKernel:
                 print_bench_result(
                     benchmark_results, self.options.benchmark_results_file
                 )
+
+        if self.debug_outputs:
+            for info_dict, (label, debug_log) in zip(
+                self.debug_outputs, debug_logs.items()
+            ):
+                if info_dict.get("printer", None):
+                    info_dict["printer"](label, debug_log["value"])
+            for handler in self.debug_handlers or []:
+                handler(debug_logs)
 
         return self.asm
 
@@ -268,7 +283,8 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
                 binary_path,
                 bound_scalar_symbols,
                 symbols_args_map,
-                None,  # TODO - this means that the cache is broken for kernels with debug logging.  But I want to focus on getting the feature at all before figuring out how to add extra info to the cache.
+                None,
+                None,
             )
 
     # For the wave runtime, we need the hsaco binary. So we turn on
@@ -286,6 +302,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         entrypoint_name,
         options,
         debug_arg_info,
+        debug_handlers,
     ) = kernel._trace_and_get_kernel_signature(options)
     options.kernel_sig = kernel_sig
 
@@ -342,6 +359,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
             bound_scalar_symbols,
             symbols_args_map,
             debug_arg_info,
+            debug_handlers,
         )
 
     compiled_wave_vmfb = compile_to_vmfb(asm, options)
@@ -375,6 +393,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         symbols_args_map,
         trace,
         debug_arg_info,
+        debug_handlers,
     )
 
 

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -511,6 +511,7 @@ class LaunchableWave(Launchable):
         trace: CapturedTrace,
         options: WaveCompileOptions,
         debug_arg_info: list[DebugArgInfo],
+        debug_handlers: list[Any],
         print_ir_before: Sequence[str] = [],
         print_ir_after: Sequence[str] = [],
     ):
@@ -523,7 +524,7 @@ class LaunchableWave(Launchable):
             self.hardware_constraints[0].subs_vector_shapes(idxc.subs)
 
         return [
-            partial(debug_log_hoist, trace),
+            partial(debug_log_hoist, trace, debug_handlers),
             partial(initialize_iter_args, trace),
             partial(self.create_induction_vars, trace),
             partial(self.initialize_reductions, trace),
@@ -587,6 +588,7 @@ class LaunchableWave(Launchable):
             print(f"\n***Tracing kernel {self._name}***")
 
         debug_arg_info = []
+        debug_handlers = []
 
         trace = self._trace(location_capture_config=options.location_capture_config)
         if (
@@ -600,7 +602,12 @@ class LaunchableWave(Launchable):
 
         # Initial passes, pre-optimization.
         graph_passes = self.build_initial_pass_pipeline(
-            trace, options, debug_arg_info, print_ir_before, print_ir_after
+            trace,
+            options,
+            debug_arg_info,
+            debug_handlers,
+            print_ir_before,
+            print_ir_after,
         )
 
         graph_passes += [
@@ -722,6 +729,7 @@ class LaunchableWave(Launchable):
             *self.compile_to_mlir(trace, context, module_op, options=options),
             options,
             debug_arg_info,
+            debug_handlers,
         )
 
     def aot_execute(self, args, kwargs):


### PR DESCRIPTION
This provides an easy in-line way to print debug logs without modifying code outside of their use site. It also modifies the debug_logs dictionary to be able to hold extra metadata that will be useful for a viewer.