### PR TITLE
[debugging] add extra_iteration_dimensions argument to debug_log

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2173,7 +2173,7 @@ def test_scatter_add(shape, elems_per_thread, request):
 
 @require_e2e
 @param_bool("dynamic_dims", "dyn")
-def test_debug_log(dynamic_dims: bool):
+def test_debug_log_core(dynamic_dims: bool):
     M = tkl.sym.M
     N = tkl.sym.N
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
@@ -2272,3 +2272,90 @@ def test_debug_log(dynamic_dims: bool):
         a[0 : shape[0] // 2, :], debug_logs["lhs_mapped"]["value"][0 : shape[0] // 2, :]
     )
     assert handler_arg == debug_logs
+
+
+@require_e2e
+def test_debug_log_iteration_dims():
+    iterations = 4
+
+    # Basic gemm since it has an iteration.
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    constraints = [
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.TilingConstraint(K, BLOCK_K),
+        tkw.WaveConstraint(M, BLOCK_M / 2),
+        tkw.WaveConstraint(N, BLOCK_N / 2),
+        tkw.HardwareConstraint(
+            threads_per_wave=64, mma_type=tkw.MMAType.F32_16x16x16_F16
+        ),
+    ]
+
+    debug_logs = None
+
+    def handler(logs):
+        nonlocal debug_logs
+        debug_logs = logs
+
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: Register[M, N, tkl.f32]) -> Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            debug_log(
+                acc,
+                "acc",
+                extra_iteration_dimensions=[(tkl.sym.iter, k, iterations)],
+                handler=handler,
+            )
+            return acc
+
+        tkw.write(repeat, c)
+
+    def test_gemm():
+        m, n, k = 128, 256, 128  # Small dimensions for testing
+
+        torch.manual_seed(0)
+        a = torch.randn(m, k, dtype=torch.float16, device="cuda")
+        b = torch.randn(n, k, dtype=torch.float16, device="cuda")
+        c = torch.zeros(m, n, dtype=torch.float32, device="cuda")
+
+        hyperparams = {
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            BLOCK_M: 64,
+            BLOCK_N: 64,
+            BLOCK_K: 32,
+            M: m,
+            N: n,
+            K: k,
+        }
+
+        options = WaveCompileOptions(
+            subs=hyperparams,
+        )
+        options = set_default_run_config(options)
+        compiled_gemm = wave_compile(options, gemm)
+
+        compiled_gemm(a, b, c)
+
+        assert len(debug_logs["acc"]["value"]) == iterations
+        assert debug_logs["acc"]["iteration_dimensions"] == [tkl.sym.iter]
+        # The last element of the acc log should be the final iteration, and
+        # thus equal to the final output.
+        assert torch.equal(debug_logs["acc"]["value"][-1], c)
+        # Meanwhile the first element should be quite different.
+        assert not torch.allclose(debug_logs["acc"]["value"][0], c)

--- a/wave_lang/debugging/html_viewer.py
+++ b/wave_lang/debugging/html_viewer.py
@@ -20,6 +20,9 @@ def html_viewer(debug_logs: Dict[str, Any]) -> None:
             serializable["symbolic_shape"] = [
                 str(symbol) for symbol in serializable["symbolic_shape"]
             ]
+            serializable["iteration_dimensions"] = [
+                str(symbol) for symbol in serializable["iteration_dimensions"]
+            ]
             return serializable
 
         jsonable = {label: jsonify_debug_log(log) for label, log in debug_logs.items()}

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -132,6 +132,9 @@ def write(
 def debug_log(
     register_: "Register",
     label: Optional[str],
+    extra_iter_dimensions: Optional[
+        list[tuple["IndexSymbol", "IndexSymbol", int]]
+    ] = None,
     mapping: Optional[IndexMapping] = None,
     mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
     printer: Optional[Callable[[str, Any], Any]] = None,
@@ -2071,11 +2074,21 @@ class DebugLog(CustomOp):
     The optional `handler` argument should be a function that accepts the whole `debug_logs` object (IE all logs, not just one).
     The handler function gives a way to specify something like a viewer for all logs, but specify it inline among print functions rather than separately.
 
+    The optional `extra_iter_dimensions` argument allows you to add extra dimensions to capture values from multiple iterations of a loop.
+    It takes a list of tuples, where each tuple contains `(dimension_name, iteration_axis, max_iterations)`.
+    The `dimension_name` must be a unique symbol, and will be the name of the dimension in the symbolic shape of the output.
+    The `iteration_axis` must be the axis of an `Iterate` operation, IE the dimension being reduced in the iteration.
+    The `max_iterations` argument is a positive integer that represents the maximum number of iterations to store.
+    Note that if you give too few, later iterations will currently overwrite the final iteration slot.
+
     The API and semantics of this operation are not yet stable, but since it is just a debugging tool, you want to take any debug logging out of your kernel before shipping it anyway.
     """
 
     register_: fx.Proxy
     label: Optional[str] = None
+    extra_iteration_dimensions: Optional[
+        list[tuple["IndexSymbol", "IndexSymbol", int]]
+    ] = None
     mapping: Optional[IndexMapping] = None
     mapping_dynamic_vals: tuple[fx.Node, ...] = ()
     printer: Optional[Callable[[str, Any], Any]] = None

--- a/wave_lang/kernel/wave/unrolling.py
+++ b/wave_lang/kernel/wave/unrolling.py
@@ -9,11 +9,10 @@ from torch import fx
 
 from wave_lang.kernel._support.tracing import CapturedTrace
 
-from ..lang import IndexSymbol
 from ..ops.wave_ops import Iterate, Output, Placeholder, get_custom
 from .constraints import Constraint
 from .utils.general_utils import get_tiling_constraint
-from .utils.symbol_utils import subs_idxc
+from .utils.symbol_utils import subs_idxc, get_induction_symbol
 
 
 def remap_iter_args(
@@ -90,11 +89,7 @@ def unroll(
     # 3. The final output from the last unrolled copy becomes the new output
     #    of the entire unrolled loop body
     reduction_axis = iterate.axis
-    induction_var = IndexSymbol(
-        f"$ARG{reduction_axis.name}",
-        integer=True,
-        nonnegative=True,
-    )
+    induction_var = get_induction_symbol(reduction_axis)
     original_body_nodes = list(graph.nodes)
     for unroll_idx in range(0, unroll_factor - 1):
         for node in original_body_nodes:

--- a/wave_lang/kernel/wave/utils/symbol_utils.py
+++ b/wave_lang/kernel/wave/utils/symbol_utils.py
@@ -31,3 +31,7 @@ def get_min_expr(
         return expr1
 
     return sympy.Min(expr1, expr2)
+
+
+def get_induction_symbol(axis: IndexSymbol):
+    return IndexSymbol("$ARG" + str(axis), integer=True, nonnegative=True)

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -17,7 +17,6 @@ import sympy
 import torch.fx as fx
 from sympy.utilities.lambdify import lambdastr
 
-import wave_lang.kernel.lang as tkl
 from wave_lang.support.ir_imports import Context, Module, Operation
 
 from .._support.indexing import IndexExpr, IndexingContext, index_symbol
@@ -95,7 +94,7 @@ from .utils.graph_utils import (
 from .utils.print_utils import print_trace, try_apply_pass
 
 # Utils
-from .utils.symbol_utils import safe_subs, subs_idxc
+from .utils.symbol_utils import safe_subs, subs_idxc, get_induction_symbol
 from .workgroup_reordering import reorder_workgroups
 
 logger = logging.getLogger(__name__)
@@ -357,9 +356,7 @@ class LaunchableWave(Launchable):
         reduction_nodes = trace.walk(is_reduction)
         for node in reduction_nodes:
             custom = get_custom(node)
-            self.induction_vars[custom] = tkl.IndexSymbol(
-                "$ARG" + str(custom.axis), integer=True, nonnegative=True
-            )
+            self.induction_vars[custom] = get_induction_symbol(custom.axis)
             for tiling_constraint in self.tiling_constraints:
                 if tiling_constraint.dim == custom.axis:
                     tiling_constraint.induction_var = self.induction_vars[custom]
@@ -584,7 +581,13 @@ class LaunchableWave(Launchable):
             partial(add_get_results, trace),
             partial(infer_types, trace),
             partial(construct_index_mapping, trace, self.constraints),
-            partial(debug_log_write_replace, trace, debug_arg_info),
+            partial(
+                debug_log_write_replace,
+                trace,
+                self.constraints,
+                options,
+                debug_arg_info,
+            ),
             partial(
                 promote_placeholders,
                 trace,


### PR DESCRIPTION
This allows users to capture intermediate states during an iteration. When using extra_iteration_dimensions, output debug_log tensors have an extra dimension for each iteration axis specified.

This should allow the debug_log feature to become actually useful in many more situations.