### PR TITLE
draft of MXFP4 ping pong with GatherToLDS on MI350

### DIFF
--- a/tests/kernel/wave/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave/wave_gemm_mxfp_test.py
@@ -439,7 +439,7 @@ def testScaledGemmMXFP8(
     ],
 )
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.PREFETCH])
-def testScaledGemmPrefetechMXFP4(
+def testScaledGemmPrefetchMXFP4(
     shape: tuple[int],
     mfma_variant: ScaledMMAType,
     enable_scheduling: SchedulingType,
@@ -504,6 +504,12 @@ def testScaledGemmPrefetechMXFP4(
         subs=hyperparams,
         canonicalize=True,
         schedule=enable_scheduling,
+        use_global_to_shared=True,
+        multi_buffer_count=2,
+        use_stride_cache_swizzle=True,
+        # print_mlir=True,
+        # print_mlir_file="testMXFP4.mlir",
+        iree_launch_async=False,
     )
     options = set_default_run_config(options)
     prefetch_gemm = wave_compile(options, prefetch_gemm)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -258,6 +258,113 @@ def testGemmGatherToLDS(
 
 
 @require_e2e
+@pytest.mark.parametrize("shape", [(4096, 4096, 4096)])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+    ],
+)
+def testPingPongwithGatherToLDS(
+    shape: tuple[int],
+    mfma_variant: MMAType,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
+):
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [tkw.HardwareConstraint(threads_per_wave=64, mma_type=mfma_variant)]
+
+    # Wave-level micro-kernel.
+    # Since warps are not directly addressable, there is no
+    # explicit notion of a warp id (like a workgroup or thread id).
+    # This kernel uses the input sizes M, N, K throughout, as the tiling
+    # and data movement strategy is determined during the compilation process.
+    # These can be influenced by introducing constraints.
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the iterate
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            # a_reg: tkw.Register[M, K, tkl.f16]
+            a_reg = tkw.read(a)
+            # b_reg: tkw.Register[N, K, tkl.f16]
+            b_reg = tkw.read(b)
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 128,
+        BLOCK_N: 256,
+        BLOCK_K: 64,
+        M: shape[0],
+        N: shape[1],
+        K: shape[2],
+    }
+    hyperparams.update(get_default_scheduling_params())
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=SchedulingType.PREFETCH,
+        use_scheduling_barriers=False,
+        dynamic_symbols=[],
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=perf_filename_tk,
+        use_global_to_shared=True,
+    )
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm)
+
+    a = device_randn(shape[0], shape[2], dtype=torch.float16)
+    b = device_randn(shape[1], shape[2], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    asm = gemm(a, b, c)
+
+    # filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
+    # with open(filename, "w") as f:
+    #     f.write(asm)
+
+    if run_bench:
+        options.benchmark_results_file = perf_filename_iree
+
+    iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    assert_close(c, iree_ref, check_device=False)
+
+
+@require_e2e
 @pytest.mark.parametrize("shape", [(32, 32, 32)] + get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",


### PR DESCRIPTION
This is a draft PR of the scheduling I created to execute Ping Pong when GatherToLDS is turned on with MXFP4 Gemm.

I created a new test on wave_gemm_test.py to test PingPong with GatherToLDS on fp16, and although it works and is reflected in the MLIR, I'm not sure it's performant enough.

I modified the testScaledGemmPrefetchMXFP4 on the wave_gemm_mfxp_test.py so that it automatically runs Ping Pong + Prefetch - a new test may have to be created to test just Ping Pong.

In schedule_reordering.py, I have the two schedules - one for FP16 with GatherToLDS and one for MXFP4 with GatherToLDS