### PR TITLE
Fix broken read the docs builds

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.12"
+    rust: "1.88"
   jobs:
     pre_build:
       - python -m pip install .


### PR DESCRIPTION
The read the docs builds were failing ever since
we added rust to setup.py. This PR fixes that
by adding rust as a tool in the rtd yaml file.