### PR TITLE
Use latest Rust version in rtd yaml

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.12"
-    rust: "1.88"
+    rust: "latest"
   jobs:
     pre_build:
       - python -m pip install .


### PR DESCRIPTION
This PR moves the Rust version to latest
as 1.88 is not yet supported.