### PR TITLE
Rename print-ir-after-all compiler option

### DIFF
--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -83,6 +83,7 @@ class WaveCompileOptions:
     dump_schedule: Optional[str] = None
 
     # === Print options ===
+    mlir_print_ir_after_all: bool = False
     print_ir_after: list[str] = field(default_factory=list)
     print_ir_before: list[str] = field(default_factory=list)
     profile_pass: list[str] = field(default_factory=list)
@@ -91,5 +92,4 @@ class WaveCompileOptions:
     print_signature: bool = False
     print_mlir: bool = False
     print_mlir_file: Optional[str] = None
-    print_ir_after_all: bool = False
     print_pass_times: bool = False

--- a/wave_lang/kernel/wave/utils/compile_utils.py
+++ b/wave_lang/kernel/wave/utils/compile_utils.py
@@ -46,7 +46,7 @@ def compile_to_vmfb(
     if options.backend == "rocm":
         flags.append(f"--iree-hip-target={options.target}")
 
-    if options.print_ir_after_all:
+    if options.mlir_print_ir_after_all:
         flags.append("--mlir-print-ir-after-all")
 
     if options.iree_preprocessing_pass_pipeline:


### PR DESCRIPTION
The name of the compiler option `print-ir-after-all` suggests that it will print the IR after every wave pass. However, this option is passed through to mlir and prints the IR after all mlir passes. 
This PR renames this option to `mlir_print_ir_after_all`, which makes this explicit and now shares the name with the option on mlir.