### PR TITLE
[compiler] Apply padding in `materialized_shapes`

### DIFF
--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -13,6 +13,7 @@ from wave_lang.kernel.wave.analysis.index_sequence_analysis import (
     set_post_expansion_indices,
 )
 from wave_lang.kernel.wave.barriers import add_shared_memory_barriers
+from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
 from wave_lang.kernel.wave.expansion.expansion import add_get_results, expand_graph
 from wave_lang.kernel.wave.hoisting import hoist_loop_invariant_ops
 from wave_lang.kernel.wave.minimize_global_loads import minimize_global_loads
@@ -269,6 +270,73 @@ def test_gemm():
     # CHECK-NEXT: read(memory=allocate, elements_per_thread=4, mapping_dynamic_vals=(), _write_dependency=[write_18, write_19], index={M: Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1})
     # CHECK-NEXT: read(memory=allocate, elements_per_thread=4, mapping_dynamic_vals=(), _write_dependency=[write_18, write_19], index={M: Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 32 : 4 : 1})
     # CHECK-NEXT: read(memory=allocate, elements_per_thread=4, mapping_dynamic_vals=(), _write_dependency=[write_18, write_19], index={M: Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 48 : 4 : 1})
+
+
+@run_test
+def test_materialized_shape_padding():
+
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    dtype = tkl.f16
+    shape = (16, 16, 17)
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, mma_type=tkw.MMAType.F32_16x16x16_F16
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, dtype],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, dtype],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        def mma_instruction(
+            acc: tkl.Register[M, N, tkl.f32],
+        ) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(mma_instruction(c_reg), c)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 16,
+        BLOCK_N: 16,
+        M: 16,
+        N: 16,
+        K: 17,
+    }
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+    )
+    gemm = wave_compile(options, gemm)
+    print(gemm.asm)
+
+    # CHECK-LABEL:    test_materialized_shape_padding
+    # CHECK-DAG:        #{{.*}} =  affine_map<()[s0] -> ((s0 floordiv 4) mod 16)>
+    # CHECK-DAG:        #{{.*}} =  affine_map<()[s0] -> (s0 * 8 - (s0 floordiv 4) * 32)>
+    # CHECK:            func.func @gemm
+    # CHECK:                %{{.*}} = arith.constant dense<17> : vector<8xindex>
+    # CHECK:                %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7]> : vector<8xindex>
+    # CHECK:                %{{.*}} = vector.load %0[%1, %2] : memref<16x17xf16, strided<[17, 1], offset: ?>>, vector<8xf16>
 
 
 if __name__ == "__main__":

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -41,7 +41,7 @@ _xfail = lambda *a: pytest.param(*a, marks=pytest.mark.xfail)
 # (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, SEQ_LENS)
 # TODO: xfailure case - wrong numerics with minimize_global_loads but produces
 # correct results without it.
-shapes = [_xfail((1, 1, 13, 13, (64, 64))), (4, 1, 64, 64, (128, 256))]
+shapes = [(1, 1, 13, 13, (64, 64)), (4, 1, 64, 64, (128, 256))]
 
 
 # From: https://github.com/sgl-project/sglang/blob/main/test/srt/test_triton_attention_kernels.py

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -125,8 +125,10 @@ def get_gather_to_shared_config(
         f"store_elems_per_thread={store_elems_per_thread}, "
         f"max_elements_per_store={max_elements_per_store}"
     )
-
-    materialized_shape = materialize_shape(constraint_tile_size, symbolic_shape)
+    vector_shapes = read.vector_shapes
+    materialized_shape = materialize_shape(
+        constraint_tile_size, symbolic_shape, vector_shapes
+    )
     logger.info(f"materialized_shape={materialized_shape}")
 
     total_number_of_elements = prod(materialized_shape)

--- a/wave_lang/kernel/wave/global_to_shared_gathers.py
+++ b/wave_lang/kernel/wave/global_to_shared_gathers.py
@@ -245,7 +245,9 @@ def add_optimized_nodes(
                     + i * max_elements_per_load
                 )
                 materialized_shape = materialize_shape(
-                    constraint_tile_size, custom.memory_type.symbolic_shape
+                    constraint_tile_size,
+                    custom.memory_type.symbolic_shape,
+                    custom.vector_shapes,
                 )
                 read.index = construct_min_global_access_pattern(
                     access_pattern,

--- a/wave_lang/kernel/wave/in_thread_transpose.py
+++ b/wave_lang/kernel/wave/in_thread_transpose.py
@@ -155,8 +155,9 @@ def get_transpose_config(
             f"scaled dimensions are not supported, dst_symbolic_shape={dst_symbolic_shape}, read.index={read.index}"
         )
         return None
-
-    materialized_shape = materialize_shape(constraint_tile_size, dst_symbolic_shape)
+    materialized_shape = materialize_shape(
+        constraint_tile_size, dst_symbolic_shape, read.vector_shapes
+    )
     if any(s > 1 for s in materialized_shape[:-2]) or any(
         s <= 1 for s in materialized_shape[-2:]
     ):
@@ -218,7 +219,7 @@ def create_transpose_reads(
     Create new reads for transpose.
     """
     load_shape = get_tiled_shape(
-        materialize_shape(constraint_tile_size, src_symbolic_shape),
+        materialize_shape(constraint_tile_size, src_symbolic_shape, read.vector_shapes),
         load_elems_per_thread,
         expected_number_of_loads,
     )


### PR DESCRIPTION
This patch fixes numerical error when the problem shape is unaligned and not constrained. During `minimize_global_loads` `materialized_shape` is used to calculate the new optimized access pattern and the issue is solved by applying padding to the unaligned dimension. We haven't encountered this issue before because the unaligned shape has always been part of the constraints.

Follow-up to https://github.com/iree-org/wave/pull/155 