### PR TITLE
Fix filecheck tests on non-gpu machines

### DIFF
--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -326,6 +326,7 @@ def test_materialized_shape_padding():
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
+        compile_to_mlir=True,
     )
     gemm = wave_compile(options, gemm)
     print(gemm.asm)

--- a/lit_tests/kernel/wave/scaled_gemm.py
+++ b/lit_tests/kernel/wave/scaled_gemm.py
@@ -698,6 +698,7 @@ def test_mxfp4_scaled_mma_unaligned_16x16x128():
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
+        compile_to_mlir=True,
         schedule=enable_scheduling,
         use_buffer_load_ops=True,
         use_buffer_store_ops=True,


### PR DESCRIPTION
Two of our filecheck tests are failing when building wave with `pip install -r pytorch-cpu-requirements.txt` because they invoke IREE with `--iree-hip-target=gfx942`, which is not available in this configuration:

```
# | Diagnostics:
# | iree-compile: Unknown command line argument '--iree-hip-target=gfx942'.  Try: '/Users/martin/dev/amd/wave/.venv/lib/python3.12/site-packages/iree/compiler/tools/../_mlir_libs/iree-compile --help'
# | iree-compile: Did you mean '--iree-vulkan-target=gfx942'?
# | 
# | 
# | Invoked with:
# |  iree-compile /Users/martin/dev/amd/wave/.venv/lib/python3.12/site-packages/iree/compiler/tools/../_mlir_libs/iree-compile - --iree-input-type=auto --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=rocm --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false --iree-hal-target-backends=rocm --iree-vm-bytecode-module-strip-source-map=true --iree-opt-strip-assertions=true --iree-vm-target-truncate-unsupported-floats --iree-hip-target=gfx942
```

This PR adds enables the option `compile_to_mlir` for the respective tests which is sufficient for the filecheck tests.