### PR TITLE
Extend prefill attention

### DIFF
--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -88,9 +88,9 @@ def context_attention_fwd(
         qkv_len = end - start
         Q = q[start:end].permute(1, 0, 2)
         K = k[start:end].permute(1, 0, 2)
-        K = K.expand(Q.shape[0], *K.shape[1:])
+        K = K.repeat_interleave(Q.shape[0] // K.shape[0], dim=0)
         V = v[start:end].permute(1, 0, 2)
-        V = V.expand(Q.shape[0], *V.shape[1:])
+        V = V.repeat_interleave(Q.shape[0] // V.shape[0], dim=0)
         dk_sqrt = math.sqrt(1.0 / Q.shape[-1])
         a = torch.bmm(Q * dk_sqrt, K.transpose(-1, -2))
         if score_mod == ScoreMod.SoftCap:

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -70,7 +70,7 @@ class WaveCompileOptions:
     denorm_fp_math_f32: str = None
     waves_per_eu: int = None
     wave_runtime: bool = False
-    iree_launch_async: bool = True
+    iree_launch_async: bool = False
     use_buffer_load_ops: bool = False
     use_buffer_store_ops: bool = False
     use_stride_cache_swizzle: bool = False

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -70,7 +70,7 @@ class WaveCompileOptions:
     denorm_fp_math_f32: str = None
     waves_per_eu: int = None
     wave_runtime: bool = False
-    iree_launch_async: bool = False
+    iree_launch_async: bool = True
     use_buffer_load_ops: bool = False
     use_buffer_store_ops: bool = False
     use_stride_cache_swizzle: bool = False

--- a/wave_lang/kernel/wave/templates/extend_attention.py
+++ b/wave_lang/kernel/wave/templates/extend_attention.py
@@ -204,8 +204,8 @@ def get_extend_attention_kernel(
     k_layout = tkl.MemoryLayout(shape=set_dynamic_dim(k_shape))
     v_layout = tkl.MemoryLayout(shape=set_dynamic_dim(v_shape))
     o_layout = tkl.MemoryLayout(shape=set_dynamic_dim(o_shape))
-    k_cache_layout = tkl.MemoryLayout(shape=k_cache_shape)
-    v_cache_layout = tkl.MemoryLayout(shape=v_cache_shape)
+    k_cache_layout = tkl.MemoryLayout(shape=set_dynamic_dim(k_cache_shape))
+    v_cache_layout = tkl.MemoryLayout(shape=set_dynamic_dim(v_cache_shape))
     num_seqs_layout = tkl.MemoryLayout(shape=[None])
     kv_indices_layout = tkl.MemoryLayout(shape=[None])
 
@@ -323,6 +323,10 @@ def get_extend_attention_kernel(
             return m_j, d_j, acc
 
         res_max, res_sum, res_mm = first_loop
+        
+        res_max = tkl.Register[H, N_Q, tkl.f32](0.0)
+        res_sum = tkl.Register[H, N_Q, tkl.f32](0.0)
+        res_mm = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
 
         if is_causal:
             seq_len_extend = tkw.apply_expr(

--- a/wave_lang/kernel/wave/templates/extend_attention.py
+++ b/wave_lang/kernel/wave/templates/extend_attention.py
@@ -323,10 +323,6 @@ def get_extend_attention_kernel(
             return m_j, d_j, acc
 
         res_max, res_sum, res_mm = first_loop
-        
-        res_max = tkl.Register[H, N_Q, tkl.f32](0.0)
-        res_sum = tkl.Register[H, N_Q, tkl.f32](0.0)
-        res_mm = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
 
         if is_causal:
             seq_len_extend = tkw.apply_expr(


### PR DESCRIPTION
Some minor (not affecting normal usage) things that were fixed in order to enable extend prefill attention for Sarathi Prefill + else on SharkTank:

- Support for dynamic dims on k_cache/v_cache were not enabled, causing interesting but unfortunate crashes
- Fixed test to support num_kv_heads being different from num_q_heads