### PR TITLE
Add conditional barriers to attention schedule

### DIFF
--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -1067,6 +1067,7 @@ def testAttentionBSHD_Prefetch_MultiBuffer(
         dynamic_dims,
         is_causal=is_causal,
         is_custom_mask=is_custom_mask,
+        num_waves=8,
     )
     q_shape = (1, shape.num_query_heads, shape.query_seq_len, shape.head_size)
     k_shape = (1, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1194,11 +1194,10 @@ class IterArg(Placeholder):
 
     @property
     def distributed_shape(self):
-        return self.fx_node.distributed_shape
-
-    @distributed_shape.setter
-    def distributed_shape(self, value):
-        self.fx_node.distributed_shape = value
+        init_arg = self.parent_op().init_args[self.iter_idx]
+        allocate = get_custom(init_arg)
+        assert isinstance(allocate, Allocate)
+        return allocate.distributed_shape
 
     def infer_type(self, *args):
         parent_op = self.parent_op()
@@ -2280,11 +2279,10 @@ class GetResult(CustomOp):
 
     @property
     def distributed_shape(self):
-        return self.fx_node.distributed_shape
-
-    @distributed_shape.setter
-    def distributed_shape(self, value):
-        self.fx_node.distributed_shape = value
+        iterate = get_custom(self.value)
+        allocate = get_custom(iterate.init_args[self.res_idx])
+        assert isinstance(allocate, Allocate)
+        return allocate.distributed_shape
 
 
 @define_op("extract")

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -594,6 +594,8 @@ class CustomOp(ABC):
                 if attr_name == "index":
                     attr = copy.deepcopy(attr)
                 setattr(new_node, attr_name, attr)
+        for key, value in self.fx_node.meta.items():
+            new_node.meta[key] = value
 
     def copy(
         self,
@@ -1173,7 +1175,8 @@ class Placeholder(CustomOp):
 class IterArg(Placeholder):
     """
     Represents a specific placeholder node in the graph that is an iter arg of
-    a reduction node.
+    a reduction node. IterArgs can be of type Register or Memory with
+    a Shared memory address space.
     """
 
     def parent_op(self):
@@ -1188,6 +1191,14 @@ class IterArg(Placeholder):
     @iter_idx.setter
     def iter_idx(self, value):
         self.fx_node.iter_idx = value
+
+    @property
+    def distributed_shape(self):
+        return self.fx_node.distributed_shape
+
+    @distributed_shape.setter
+    def distributed_shape(self, value):
+        self.fx_node.distributed_shape = value
 
     def infer_type(self, *args):
         parent_op = self.parent_op()
@@ -2266,6 +2277,14 @@ class GetResult(CustomOp):
     @index.setter
     def index(self, value: dict[IndexSymbol, IndexSequence]):
         CustomOp.index.fset(self, value)
+
+    @property
+    def distributed_shape(self):
+        return self.fx_node.distributed_shape
+
+    @distributed_shape.setter
+    def distributed_shape(self, value):
+        self.fx_node.distributed_shape = value
 
 
 @define_op("extract")

--- a/wave_lang/kernel/wave/schedule_reordering.py
+++ b/wave_lang/kernel/wave/schedule_reordering.py
@@ -8,7 +8,7 @@ import math
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable
+from typing import Iterable, Dict, List
 
 import torch.fx as fx
 from torch.utils import _pytree as pytree
@@ -36,6 +36,7 @@ from ..ops.wave_ops import (
 )
 from .constraints import (
     Constraint,
+    HardwareConstraint,
     get_constrained_shape,
 )
 from .scheduling.schedule_enums import SchedulingType
@@ -73,6 +74,63 @@ class SchedReorderStrategy(Enum):
     NONE = 0x00
     TWO_PP_CLUSTER = 0x220
     MXFP4_PP_CLUSTER = 0x101
+
+
+class AttentionOperationType(Enum):
+    """Enumeration of attention operation types for prefetch stages."""
+
+    MMA_0 = "mma_0"
+    MMA_1 = "mma_1"
+    SOFTMAX_0 = "softmax_0"
+    SOFTMAX_1 = "softmax_1"
+    LOCAL_LOAD_0 = "local_load_0"
+    GLOBAL_LOAD_0 = "global_load_0"
+    LOCAL_STORE_0 = "local_store_0"
+    LOCAL_LOAD_1 = "local_load_1"
+    GLOBAL_LOAD_1 = "global_load_1"
+    LOCAL_STORE_1 = "local_store_1"
+
+    @classmethod
+    def get_all_types(cls) -> List["AttentionOperationType"]:
+        """Get all operation types as a list."""
+        return list(cls)
+
+    @classmethod
+    def from_string(cls, value: str) -> "AttentionOperationType":
+        """Create an enum value from a string, with error handling."""
+        try:
+            return cls(value)
+        except ValueError:
+            raise ValueError(f"Unknown attention operation type: {value}")
+
+    def __str__(self) -> str:
+        """Return the string value of the enum."""
+        return self.value
+
+    @classmethod
+    def get_mma_types(cls) -> List["AttentionOperationType"]:
+        """Get all MMA operation types."""
+        return [cls.MMA_0, cls.MMA_1]
+
+    @classmethod
+    def get_softmax_types(cls) -> List["AttentionOperationType"]:
+        """Get all softmax operation types."""
+        return [cls.SOFTMAX_0, cls.SOFTMAX_1]
+
+    @classmethod
+    def get_load_types(cls) -> List["AttentionOperationType"]:
+        """Get all load operation types."""
+        return [
+            cls.LOCAL_LOAD_0,
+            cls.LOCAL_LOAD_1,
+            cls.GLOBAL_LOAD_0,
+            cls.GLOBAL_LOAD_1,
+        ]
+
+    @classmethod
+    def get_store_types(cls) -> List["AttentionOperationType"]:
+        """Get all store operation types."""
+        return [cls.LOCAL_STORE_0, cls.LOCAL_STORE_1]
 
 
 def is_pingpong_strategy(strategy):
@@ -194,11 +252,16 @@ def get_mma_tile_size(mma_nodes, constraints):
 
 
 def schedule_nodes_to_graph(graph, node_map, nodes):
+    from wave_lang.kernel.ops.wave_ops import IterArg, GetResult
+
     for node in nodes:
         custom = get_custom(node)
         new_node = custom.copy(
             new_graph=graph, arg_transform=lambda x: node_map[x] if x in node_map else x
         )
+        if isinstance(custom, (IterArg, GetResult)):
+            if hasattr(custom, "distributed_shape"):
+                new_node.distributed_shape = custom.distributed_shape
         node_map[node] = new_node.fx_node
 
 
@@ -684,16 +747,17 @@ def schedule_reordering(
         2. Get MMAs inside reduction/iterate op that is tiled with reduction dim.
         3. Based on mma_node's expanded_dim and consumers we can classify global read, local read, mma, and local write.
     """
-
-    # Only handles if scheduling type is prefetch
+    if scheduling_type == SchedulingType.PREFETCH_ATTENTION:
+        return attention_schedule_reordering(trace, constraints)
     if scheduling_type != SchedulingType.PREFETCH:
         return
+
     hardware_constraint = get_hardware_constraint(constraints)
     iterate_nodes = trace.walk(lambda node: isinstance(get_custom(node), Iterate))
     if not iterate_nodes:
         return
     for iterate_node in iterate_nodes:
-        custom_iterate = get_custom(iterate_nodes[0])
+        custom_iterate = get_custom(iterate_node)
         graph = trace.get_subgraph(custom_iterate.subgraph_name)
         iteration_dim = custom_iterate.axis
         # Get MMA nodes inside a for op, who's reduction dim is being tiled in the for op.
@@ -786,3 +850,309 @@ def schedule_reordering(
         custom_iterate.update_arg("subgraph_name", reordered_subgraph_name)
         if is_pingpong_strategy(reorder_strategy):
             add_conditional_barriers_to_loop(custom_iterate, trace, hardware_constraint)
+
+
+def create_attention_clusters(
+    mma0_nodes: List[fx.Node],
+    local_load_k: List[fx.Node],
+    local_write_k: List[fx.Node],
+    global_load_k: List[fx.Node],
+    mma1_nodes: List[fx.Node],
+    local_load_v: List[fx.Node],
+    local_write_v: List[fx.Node],
+    global_load_v: List[fx.Node],
+    softmax0_nodes: List[fx.Node],
+    softmax1_nodes: List[fx.Node],
+) -> List:
+    """
+    Create clusters for attention schedule reordering.
+
+    Args:
+        mma0_nodes: First set of MMA operations (QK computation)
+        local_load_k: Local load operations for K
+        local_write_k: Local write operations for K
+        global_load_k: Global load operations for K
+        mma1_nodes: Second set of MMA operations (PV computation)
+        local_load_v: Local load operations for V
+        local_write_v: Local write operations for V
+        global_load_v: Global load operations for V
+        softmax0_nodes: First set of softmax operations
+        softmax1_nodes: Second set of softmax operations
+
+    Returns:
+        List of operation clusters for reordering
+    """
+    clusters = []
+    tmp_graph = fx.Graph()
+
+    # Cluster 0: QK computation and softmax1
+    clusters.extend(_create_qk_softmax_cluster(mma0_nodes, softmax1_nodes, tmp_graph))
+
+    # Cluster 1: K data movement (global load, local write, local load V)
+    clusters.extend(
+        _create_k_data_movement_cluster(
+            global_load_k, local_write_k, local_load_v, tmp_graph
+        )
+    )
+
+    # Cluster 2: PV computation and softmax0
+    clusters.extend(_create_pv_softmax_cluster(mma1_nodes, softmax0_nodes, tmp_graph))
+
+    # Cluster 3: V data movement (global load, local write, local load K)
+    clusters.extend(
+        _create_v_data_movement_cluster(
+            global_load_v, local_write_v, local_load_k, tmp_graph
+        )
+    )
+
+    return clusters
+
+
+def _create_qk_softmax_cluster(
+    mma0_nodes: List[fx.Node], softmax1_nodes: List[fx.Node], tmp_graph: fx.Graph
+) -> List:
+    """Create cluster for QK computation and softmax1."""
+    clusters = []
+
+    # Set wave priority for QK computation
+    clusters.append(
+        insert_op_before(SetWavePrio(1).add_to_graph(tmp_graph), mma0_nodes)
+    )
+    clusters.append(mma0_nodes)
+    clusters.append(insert_op_after(SetWavePrio(0).add_to_graph(tmp_graph), mma0_nodes))
+
+    # Add softmax1 operations
+    clusters.append(softmax1_nodes)
+    clusters.append(
+        insert_op_after(WorkgroupBarrier().add_to_graph(tmp_graph), softmax1_nodes)
+    )
+    clusters.append(
+        insert_op_after(SchedulingBarrier([]).add_to_graph(tmp_graph), clusters[-1].op)
+    )
+
+    return clusters
+
+
+def _create_k_data_movement_cluster(
+    global_load_k: List[fx.Node],
+    local_write_k: List[fx.Node],
+    local_load_v: List[fx.Node],
+    tmp_graph: fx.Graph,
+) -> List:
+    """Create cluster for K data movement operations."""
+    clusters = []
+
+    # Global load K, local write K
+    clusters.append(global_load_k)
+    clusters.append(local_write_k)
+
+    # Local load V and scheduling barrier
+    clusters.append(local_load_v)
+    clusters.append(
+        insert_op_after(WorkgroupBarrier().add_to_graph(tmp_graph), local_load_v)
+    )
+    clusters.append(
+        insert_op_after(SchedulingBarrier([]).add_to_graph(tmp_graph), clusters[-1].op)
+    )
+
+    return clusters
+
+
+def _create_pv_softmax_cluster(
+    mma1_nodes: List[fx.Node], softmax0_nodes: List[fx.Node], tmp_graph: fx.Graph
+) -> List:
+    """Create cluster for PV computation and softmax0."""
+    clusters = []
+
+    # Set wave priority for PV computation
+    clusters.append(
+        insert_op_before(SetWavePrio(1).add_to_graph(tmp_graph), mma1_nodes)
+    )
+    clusters.append(mma1_nodes)
+    clusters.append(insert_op_after(SetWavePrio(0).add_to_graph(tmp_graph), mma1_nodes))
+
+    # Add softmax0 operations
+    clusters.append(softmax0_nodes)
+    clusters.append(
+        insert_op_after(WorkgroupBarrier().add_to_graph(tmp_graph), softmax0_nodes)
+    )
+    clusters.append(
+        insert_op_after(SchedulingBarrier([]).add_to_graph(tmp_graph), clusters[-1].op)
+    )
+
+    return clusters
+
+
+def _create_v_data_movement_cluster(
+    global_load_v: List[fx.Node],
+    local_write_v: List[fx.Node],
+    local_load_k: List[fx.Node],
+    tmp_graph: fx.Graph,
+) -> List:
+    """Create cluster for V data movement operations."""
+    clusters = []
+
+    # Global load V, local write V
+    clusters.append(global_load_v)
+    clusters.append(local_write_v)
+
+    # Local load K and scheduling barrier
+    clusters.append(local_load_k)
+    clusters.append(
+        insert_op_after(WorkgroupBarrier().add_to_graph(tmp_graph), local_load_k)
+    )
+    clusters.append(
+        insert_op_after(SchedulingBarrier([]).add_to_graph(tmp_graph), clusters[-1].op)
+    )
+
+    return clusters
+
+
+def _classify_attention_operations(
+    graph: fx.Graph,
+) -> Dict[AttentionOperationType, List[fx.Node]]:
+    """
+    Classify operations in the attention graph by their prefetch stage.
+
+    Args:
+        graph: The graph containing attention operations
+
+    Returns:
+        Dictionary mapping operation types to lists of nodes
+    """
+    operation_groups = {
+        op_type: [] for op_type in AttentionOperationType.get_all_types()
+    }
+
+    for node in graph.nodes:
+        prefetch_stage = node.meta.get("prefetch_stage", None)
+        if prefetch_stage:
+            try:
+                op_type = AttentionOperationType.from_string(prefetch_stage)
+                operation_groups[op_type].append(node)
+            except ValueError:
+                # Skip unknown prefetch stages
+                continue
+
+    return operation_groups
+
+
+def _validate_attention_operations(
+    operation_groups: Dict[AttentionOperationType, List[fx.Node]],
+) -> bool:
+    """
+    Validate that required attention operations are present.
+
+    Args:
+        operation_groups: Dictionary of operation groups
+
+    Returns:
+        True if validation passes, False otherwise
+    """
+    # All operation types are required
+    for op_type in AttentionOperationType.get_all_types():
+        if not operation_groups[op_type]:
+            return False
+
+    return True
+
+
+def attention_schedule_reordering(
+    trace: CapturedTrace, constraints: List[Constraint]
+) -> None:
+    """
+    Perform attention schedule reordering for prefetch attention kernels.
+
+    This function identifies attention operations in iterate nodes and reorders
+    them to optimize memory access patterns and computation scheduling.
+
+    Args:
+        trace: Captured trace containing the computation graph
+        constraints: List of constraints for the computation
+    """
+    hardware_constraint = get_hardware_constraint(constraints)
+    flat_wave_count = math.prod(hardware_constraint.waves_per_block)
+    # Only support 8 waves for now.
+    if flat_wave_count != 8:
+        return
+    iterate_nodes = trace.walk(lambda node: isinstance(get_custom(node), Iterate))
+
+    if not iterate_nodes:
+        return
+
+    for iterate_node in iterate_nodes:
+        _process_attention_iterate_node(iterate_node, trace, hardware_constraint)
+
+
+def _process_attention_iterate_node(
+    iterate_node: fx.Node, trace: CapturedTrace, hardware_constraint: HardwareConstraint
+) -> None:
+    """
+    Process a single iterate node for attention schedule reordering.
+
+    Args:
+        iterate_node: The iterate node to process
+        trace: Captured trace containing the computation graph
+        hardware_constraint: Hardware constraints for the computation
+    """
+    custom_iterate = get_custom(iterate_node)
+    graph = trace.get_subgraph(custom_iterate.subgraph_name)
+
+    # Classify operations by their prefetch stage
+    operation_groups = _classify_attention_operations(graph)
+
+    # Validate that all required operations are present
+    if not _validate_attention_operations(operation_groups):
+        return
+
+    # Create operation clusters for reordering
+    clusters = create_attention_clusters(
+        mma0_nodes=operation_groups[AttentionOperationType.MMA_0],
+        local_load_k=operation_groups[AttentionOperationType.LOCAL_LOAD_0],
+        local_write_k=operation_groups[AttentionOperationType.LOCAL_STORE_0],
+        global_load_k=operation_groups[AttentionOperationType.GLOBAL_LOAD_0],
+        mma1_nodes=operation_groups[AttentionOperationType.MMA_1],
+        local_load_v=operation_groups[AttentionOperationType.LOCAL_LOAD_1],
+        local_write_v=operation_groups[AttentionOperationType.LOCAL_STORE_1],
+        global_load_v=operation_groups[AttentionOperationType.GLOBAL_LOAD_1],
+        softmax0_nodes=operation_groups[AttentionOperationType.SOFTMAX_0],
+        softmax1_nodes=operation_groups[AttentionOperationType.SOFTMAX_1],
+    )
+
+    # Perform graph reordering
+    reordered_graph = reorder_graph(graph, clusters)
+    if reordered_graph is None:
+        return
+
+    # Update the trace with the reordered graph
+    _update_trace_with_reordered_graph(trace, graph, reordered_graph, custom_iterate)
+
+    # Add conditional barriers for ping-pong strategies
+    add_conditional_barriers_to_loop(custom_iterate, trace, hardware_constraint)
+
+
+def _update_trace_with_reordered_graph(
+    trace: CapturedTrace,
+    original_graph: fx.Graph,
+    reordered_graph: fx.Graph,
+    custom_iterate: Iterate,
+) -> None:
+    """
+    Update the trace with the reordered graph.
+
+    Args:
+        trace: Captured trace containing the computation graph
+        original_graph: Original graph before reordering
+        reordered_graph: Reordered graph after optimization
+        custom_iterate: The iterate operation being updated
+    """
+    # Set parent operation for the reordered graph
+    reordered_graph.parent_op = original_graph.parent_op
+
+    # Create new subgraph name and add to trace
+    reordered_subgraph_name = f"reordered_{custom_iterate.subgraph_name}"
+    trace.add_subgraph(reordered_subgraph_name, reordered_graph)
+    trace.get_root_graph().subgraphs[reordered_subgraph_name] = reordered_graph
+
+    # Update the iterate operation to use the new subgraph
+    custom_iterate.update_arg("subgraph_name", reordered_subgraph_name)

--- a/wave_lang/kernel/wave/schedule_reordering.py
+++ b/wave_lang/kernel/wave/schedule_reordering.py
@@ -47,6 +47,7 @@ from .utils.general_utils import (
     topological_sort_with_dependencies,
 )
 from .utils.symbol_utils import subs_idxc
+from .utils.classes import AttentionOperationType
 
 ##############################################################
 # General graph helper functions
@@ -74,63 +75,6 @@ class SchedReorderStrategy(Enum):
     NONE = 0x00
     TWO_PP_CLUSTER = 0x220
     MXFP4_PP_CLUSTER = 0x101
-
-
-class AttentionOperationType(Enum):
-    """Enumeration of attention operation types for prefetch stages."""
-
-    MMA_0 = "mma_0"
-    MMA_1 = "mma_1"
-    SOFTMAX_0 = "softmax_0"
-    SOFTMAX_1 = "softmax_1"
-    LOCAL_LOAD_0 = "local_load_0"
-    GLOBAL_LOAD_0 = "global_load_0"
-    LOCAL_STORE_0 = "local_store_0"
-    LOCAL_LOAD_1 = "local_load_1"
-    GLOBAL_LOAD_1 = "global_load_1"
-    LOCAL_STORE_1 = "local_store_1"
-
-    @classmethod
-    def get_all_types(cls) -> List["AttentionOperationType"]:
-        """Get all operation types as a list."""
-        return list(cls)
-
-    @classmethod
-    def from_string(cls, value: str) -> "AttentionOperationType":
-        """Create an enum value from a string, with error handling."""
-        try:
-            return cls(value)
-        except ValueError:
-            raise ValueError(f"Unknown attention operation type: {value}")
-
-    def __str__(self) -> str:
-        """Return the string value of the enum."""
-        return self.value
-
-    @classmethod
-    def get_mma_types(cls) -> List["AttentionOperationType"]:
-        """Get all MMA operation types."""
-        return [cls.MMA_0, cls.MMA_1]
-
-    @classmethod
-    def get_softmax_types(cls) -> List["AttentionOperationType"]:
-        """Get all softmax operation types."""
-        return [cls.SOFTMAX_0, cls.SOFTMAX_1]
-
-    @classmethod
-    def get_load_types(cls) -> List["AttentionOperationType"]:
-        """Get all load operation types."""
-        return [
-            cls.LOCAL_LOAD_0,
-            cls.LOCAL_LOAD_1,
-            cls.GLOBAL_LOAD_0,
-            cls.GLOBAL_LOAD_1,
-        ]
-
-    @classmethod
-    def get_store_types(cls) -> List["AttentionOperationType"]:
-        """Get all store operation types."""
-        return [cls.LOCAL_STORE_0, cls.LOCAL_STORE_1]
 
 
 def is_pingpong_strategy(strategy):
@@ -1026,9 +970,8 @@ def _classify_attention_operations(
             try:
                 op_type = AttentionOperationType.from_string(prefetch_stage)
                 operation_groups[op_type].append(node)
-            except ValueError:
-                # Skip unknown prefetch stages
-                continue
+            except:
+                raise ValueError(f"Unknown prefetch stage: {prefetch_stage}")
 
     return operation_groups
 

--- a/wave_lang/kernel/wave/schedule_reordering.py
+++ b/wave_lang/kernel/wave/schedule_reordering.py
@@ -252,16 +252,12 @@ def get_mma_tile_size(mma_nodes, constraints):
 
 
 def schedule_nodes_to_graph(graph, node_map, nodes):
-    from wave_lang.kernel.ops.wave_ops import IterArg, GetResult
 
     for node in nodes:
         custom = get_custom(node)
         new_node = custom.copy(
             new_graph=graph, arg_transform=lambda x: node_map[x] if x in node_map else x
         )
-        if isinstance(custom, (IterArg, GetResult)):
-            if hasattr(custom, "distributed_shape"):
-                new_node.distributed_shape = custom.distributed_shape
         node_map[node] = new_node.fx_node
 
 

--- a/wave_lang/kernel/wave/scheduling/loop_reconstruction.py
+++ b/wave_lang/kernel/wave/scheduling/loop_reconstruction.py
@@ -124,6 +124,10 @@ def add_nodes_by_schedule(
                     else x
                 ),
             )
+            if custom_node.scheduling_parameters["prefetch_stage"]:
+                new_node.fx_node.meta["prefetch_stage"] = (
+                    custom_node.scheduling_parameters["prefetch_stage"]
+                )
             if hasattr(new_node, "_write_dependency"):
                 # We cannot properly handle write dependencies for mapped nodes
                 # yet, so just drop it for now.
@@ -279,6 +283,7 @@ def populate_kernel_outer_vars(
             iter_arg.type = custom.type
             iter_arg.index = custom.index
             iter_arg.iter_idx = counter
+            iter_arg.distributed_shape = custom.distributed_shape
             counter += 1
             new_iter_args.append(iter_arg)
 
@@ -307,6 +312,7 @@ def populate_epilogue_outer_vars(
                 pipelined_reduction.graph,
                 type=custom.type,
             )
+            result.distributed_shape = custom.distributed_shape
             counter += 1
             new_results.append(result)
 

--- a/wave_lang/kernel/wave/scheduling/loop_reconstruction.py
+++ b/wave_lang/kernel/wave/scheduling/loop_reconstruction.py
@@ -283,7 +283,6 @@ def populate_kernel_outer_vars(
             iter_arg.type = custom.type
             iter_arg.index = custom.index
             iter_arg.iter_idx = counter
-            iter_arg.distributed_shape = custom.distributed_shape
             counter += 1
             new_iter_args.append(iter_arg)
 
@@ -312,7 +311,6 @@ def populate_epilogue_outer_vars(
                 pipelined_reduction.graph,
                 type=custom.type,
             )
-            result.distributed_shape = custom.distributed_shape
             counter += 1
             new_results.append(result)
 

--- a/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
@@ -7,6 +7,8 @@
 from enum import Enum
 from typing import Sequence
 
+from ..schedule_reordering import AttentionOperationType
+
 import torch.fx as fx
 
 from .graph_utils import Edge, sort_graph_by_edge_weight
@@ -142,6 +144,10 @@ class PrefetchScheduler(BaseScheduler):
 
 
 class MMAGroup:
+    """Groups MMA operations and their dependencies for prefetch scheduling."""
+
+    VALID_SUFFIXES = {"0", "1"}
+
     def __init__(self, mma_ops: list[fx.Node]):
         self.global_reads = set()
         self.shared_reads = set()
@@ -158,6 +164,78 @@ class MMAGroup:
                     self.shared_reads.add(node)
             elif isinstance(custom, Write):
                 self.shared_writes.add(node)
+
+    def _get_operation_type(
+        self, suffix: str, operation_category: str
+    ) -> AttentionOperationType:
+        """Get the appropriate operation type enum for a given suffix and category."""
+        operation_mapping = {
+            "0": {
+                "global_reads": AttentionOperationType.GLOBAL_LOAD_0,
+                "shared_reads": AttentionOperationType.LOCAL_LOAD_0,
+                "shared_writes": AttentionOperationType.LOCAL_STORE_0,
+                "mma_ops": AttentionOperationType.MMA_0,
+            },
+            "1": {
+                "global_reads": AttentionOperationType.GLOBAL_LOAD_1,
+                "shared_reads": AttentionOperationType.LOCAL_LOAD_1,
+                "shared_writes": AttentionOperationType.LOCAL_STORE_1,
+                "mma_ops": AttentionOperationType.MMA_1,
+            },
+        }
+
+        if suffix not in self.VALID_SUFFIXES:
+            raise ValueError(
+                f"Invalid suffix: {suffix}. Must be one of {self.VALID_SUFFIXES}."
+            )
+
+        if operation_category not in operation_mapping[suffix]:
+            raise ValueError(f"Invalid operation category: {operation_category}")
+
+        return operation_mapping[suffix][operation_category]
+
+    def get_all_operation_types(self, suffix: str) -> dict[str, AttentionOperationType]:
+        """Get all operation types for a given suffix."""
+        operation_mapping = {
+            "0": {
+                "global_reads": AttentionOperationType.GLOBAL_LOAD_0,
+                "shared_reads": AttentionOperationType.LOCAL_LOAD_0,
+                "shared_writes": AttentionOperationType.LOCAL_STORE_0,
+                "mma_ops": AttentionOperationType.MMA_0,
+            },
+            "1": {
+                "global_reads": AttentionOperationType.GLOBAL_LOAD_1,
+                "shared_reads": AttentionOperationType.LOCAL_LOAD_1,
+                "shared_writes": AttentionOperationType.LOCAL_STORE_1,
+                "mma_ops": AttentionOperationType.MMA_1,
+            },
+        }
+
+        if suffix not in self.VALID_SUFFIXES:
+            raise ValueError(
+                f"Invalid suffix: {suffix}. Must be one of {self.VALID_SUFFIXES}."
+            )
+
+        return operation_mapping[suffix]
+
+    def annotate(self, suffix: str):
+        """Annotate nodes with prefetch stage using enum values."""
+        for node in self.global_reads:
+            node.meta["prefetch_stage"] = self._get_operation_type(
+                suffix, "global_reads"
+            ).value
+        for node in self.shared_reads:
+            node.meta["prefetch_stage"] = self._get_operation_type(
+                suffix, "shared_reads"
+            ).value
+        for node in self.shared_writes:
+            node.meta["prefetch_stage"] = self._get_operation_type(
+                suffix, "shared_writes"
+            ).value
+        for node in self.mma_ops:
+            node.meta["prefetch_stage"] = self._get_operation_type(
+                suffix, "mma_ops"
+            ).value
 
     def __repr__(self):
         return f"MMAGroup(\nglobal_reads={self.global_reads},\nshared_reads={self.shared_reads},\nshared_writes={self.shared_writes},\nmma_ops={self.mma_ops})"
@@ -208,6 +286,11 @@ class PrefetchAttentionScheduler(BaseScheduler):
         softmax0 = softmax_ops[:split_index]
         softmax1 = softmax_ops[split_index:]
 
+        for node in softmax0:
+            node.meta["prefetch_stage"] = AttentionOperationType.SOFTMAX_0.value
+        for node in softmax1:
+            node.meta["prefetch_stage"] = AttentionOperationType.SOFTMAX_1.value
+
         # Safety check: ensure we have operations to schedule
         if not mmas and not softmax_ops:
             logger.warning("No MMAs or softmax operations found in graph")
@@ -221,6 +304,8 @@ class PrefetchAttentionScheduler(BaseScheduler):
             mma1,
             exclude_shared_reads=mma0_group.shared_reads,
         )
+        mma0_group.annotate("0")
+        mma1_group.annotate("1")
 
         # Cycle 0, 1: Global loads and shared writes for GEMM0
         schedule = _set_cycle(mma0_group.global_reads, 0, schedule)

--- a/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/wave_lang/kernel/wave/scheduling/prefetch_scheduling.py
@@ -7,8 +7,6 @@
 from enum import Enum
 from typing import Sequence
 
-from ..schedule_reordering import AttentionOperationType
-
 import torch.fx as fx
 
 from .graph_utils import Edge, sort_graph_by_edge_weight
@@ -25,6 +23,7 @@ from ...ops.wave_ops import (
     Extract,
 )
 from ..utils.graph_utils import capture_backward_slice
+from ..utils.classes import AttentionOperationType
 
 import logging
 

--- a/wave_lang/kernel/wave/scheduling/schedule.py
+++ b/wave_lang/kernel/wave/scheduling/schedule.py
@@ -158,6 +158,7 @@ def schedule_reduction(
             "cycle": cycle % initiation_interval,
             "stage": cycle // initiation_interval,
             "initiation_interval": initiation_interval,
+            "prefetch_stage": node.meta.get("prefetch_stage", None),
         }
         # Erase edges between outputs and iter args.
         if isinstance(get_custom(node), IterArg):
@@ -171,6 +172,7 @@ def schedule_reduction(
             "cycle": cycle % initiation_interval,
             "stage": cycle // initiation_interval,
             "initiation_interval": initiation_interval,
+            "prefetch_stage": custom.fx_node.meta.get("prefetch_stage", None),
         }
 
     erase_graph(graph)

--- a/wave_lang/kernel/wave/templates/vanilla_attention.py
+++ b/wave_lang/kernel/wave/templates/vanilla_attention.py
@@ -198,6 +198,7 @@ def get_bshd_attention_kernel(
     dynamic_dims: bool,
     is_causal: bool = False,
     is_custom_mask: bool = False,
+    num_waves: int = 4,
 ):
     # Input sizes
     # BxS_QxHxD x BxS_KVxH_KVxD
@@ -222,7 +223,7 @@ def get_bshd_attention_kernel(
     constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
     constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 3)]
     constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
-    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / num_waves)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
 
     if mfma_variant[1] == MMAType.F32_16x16x16_F16:
@@ -408,7 +409,7 @@ def get_bshd_attention_kernel(
         ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
         BLOCK_B: 1,
         BLOCK_H: 1,
-        BLOCK_M: 128,
+        BLOCK_M: 128 * (num_waves // 4),
         BLOCK_N: 64,
         BLOCK_K2: 64,
         B: 1,

--- a/wave_lang/kernel/wave/utils/classes.py
+++ b/wave_lang/kernel/wave/utils/classes.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from dataclasses import dataclass
+from typing import List
 from enum import Enum
 
 
@@ -27,3 +28,35 @@ class ShuffleMode(Enum):
     DOWN = 1
     UP = 2
     IDX = 3
+
+
+class AttentionOperationType(Enum):
+    """Enumeration of attention operation types for prefetch stages."""
+
+    MMA_0 = "mma_0"
+    MMA_1 = "mma_1"
+    SOFTMAX_0 = "softmax_0"
+    SOFTMAX_1 = "softmax_1"
+    LOCAL_LOAD_0 = "local_load_0"
+    GLOBAL_LOAD_0 = "global_load_0"
+    LOCAL_STORE_0 = "local_store_0"
+    LOCAL_LOAD_1 = "local_load_1"
+    GLOBAL_LOAD_1 = "global_load_1"
+    LOCAL_STORE_1 = "local_store_1"
+
+    @classmethod
+    def get_all_types(cls) -> List["AttentionOperationType"]:
+        """Get all operation types as a list."""
+        return list(cls)
+
+    @classmethod
+    def from_string(cls, value: str) -> "AttentionOperationType":
+        """Create an enum value from a string, with error handling."""
+        try:
+            return cls(value)
+        except ValueError:
+            raise ValueError(f"Unknown attention operation type: {value}")
+
+    def __str__(self) -> str:
+        """Return the string value of the enum."""
+        return self.value


### PR DESCRIPTION
This PR adds the ability to add conditional barriers for attention when the PREFETCH_ATTENTION schedule is used and 8 waves are specified. Based on annotations during scheduling, operations are clustered into groups and then reordered to enable ping pong.