### PR TITLE
Fix issues with multi-buffering

### DIFF
--- a/lit_tests/kernel/wave/multi_buffering.py
+++ b/lit_tests/kernel/wave/multi_buffering.py
@@ -165,25 +165,25 @@ def test_gemm_multibuffering():
         # CHECK-NEXT: read(memory=allocate,
         # CHECK: reduction begin
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK + 1, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK + 1, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: {2*N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: {N: BLOCK_N*(Mod(ARGK + 1, 2)) + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: write(register_=read_21,
-        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
         # CHECK-NEXT: write(register_=read_22,
-        # CHECK-SAME: index={2*N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
+        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod(32*$T1 + floor($T0/4), 64) : 1 : 1, K: 8*(Mod($T0, 4)) : 8 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) + 16 : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: read(memory=allocate_1,
-        # CHECK-SAME: index={2*N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={N: BLOCK_N*(Mod(ARGK, 2)) + BLOCK_N/2 + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: read(memory=allocate,
-        # CHECK-SAME: index={2*M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
+        # CHECK-SAME: index={M: BLOCK_M*(Mod(ARGK, 2)) + Mod($T0, 16) : 1 : 1, K: 4*floor((Mod($T0, 64))/16) + 16 : 4 : 1}
         # CHECK-NEXT: reduction end
         # CHECK-NEXT: read(memory=allocate_1,
         # CHECK-NEXT: read(memory=allocate,

--- a/wave_lang/kernel/wave/scheduling/multi_buffering.py
+++ b/wave_lang/kernel/wave/scheduling/multi_buffering.py
@@ -13,7 +13,6 @@ from ..._support.indexing import (
 from ..._support.tracing import CapturedTrace
 from ...compiler.base import CodegenError
 from ...lang.global_symbols import SHARED_ADDRESS_SPACE
-from ...lang.wave_types import IndexMapping
 from ...ops.wave_ops import (
     CustomOp,
     Iterate,
@@ -22,7 +21,6 @@ from ...ops.wave_ops import (
     get_custom,
 )
 import copy
-from ..utils.mapping_utils import get_dict_with_updated_key
 from typing import Optional
 
 
@@ -64,29 +62,10 @@ def heuristically_multi_buffer_shared_memory(
         offset = block_size * which_buffer
         new_node_idx[dim].start += offset
 
-        # Update the mapping for the operation as the keys for the
-        # mapping have to match the shape of memory location the
-
-        # operation reads from / writes to, which we change below.
-        new_node_idx = get_dict_with_updated_key(
-            new_node_idx, dim, dim * multi_buffer_count
-        )
         if not is_read_write:
             new_node.dst_index = new_node_idx
             return
         new_node.index = new_node_idx
-
-        if isinstance(new_node.mapping, IndexMapping):
-            input_mapping = new_node.mapping.input_mapping
-            output_mapping = new_node.mapping.output_mapping
-            if dim in input_mapping:
-                new_node.mapping.input_mapping = get_dict_with_updated_key(
-                    input_mapping, dim, dim * multi_buffer_count
-                )
-            if dim in output_mapping:
-                new_node.mapping.output_mapping = get_dict_with_updated_key(
-                    output_mapping, dim, dim * multi_buffer_count
-                )
 
         return
 


### PR DESCRIPTION
In the current multi-buffering code, when doing N buffers along the B dimension, the index was being modified from

{B: ..., K: ... }

to

{N*B: ..., K ... }

But this does not make sense as the index keys are the distribution symbols / indexing dims and not the actual shape of memory allocated.