### PR TITLE
NFC improving names and docstrings for clarity

### DIFF
--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -2500,17 +2500,6 @@ class ReduceOp(CustomOp, ABC):
             )
 
     @property
-    def num_reduction_dims(self) -> int:
-        if self.dim is None:
-            raise NotImplementedError(
-                "Currently do not support ReduceOp with no dims specified."
-            )
-        if isinstance(self.dim, Sequence):
-            return len(self.dim)
-        else:
-            return 1
-
-    @property
     def reduction_dim(self) -> IndexSymbol:
         return self.dim
 

--- a/wave_lang/kernel/wave/decompose_reduce_ops.py
+++ b/wave_lang/kernel/wave/decompose_reduce_ops.py
@@ -172,7 +172,7 @@ def emit_scalarized_local_reduction(
     return local_reduction
 
 
-def emit_global_reduction(
+def emit_intrawave_reduction(
     binary_fn: Callable,
     src: fx.Node,
     graph: fx.Graph,
@@ -395,7 +395,7 @@ def decompose_reduce_ops(
                 subgroup_size,
                 induction_vars,
             )
-            global_reduction = emit_global_reduction(
+            global_reduction = emit_intrawave_reduction(
                 binary_fn,
                 local_reduction,
                 custom.graph,


### PR DESCRIPTION
While reading some code to understand especially the expand_graph pass better, I decided to make some clarifications.  I've improved the docstring on the pass function to be more clear about what “expansion” means.  The code used the word “reduction” a lot for Iterate nodes, which is not wrong, but it is confusing when also I've been looking at the ReduceOp.  Renaming to relate to the Iterate op improves clarity.  Also this removes some unused code.