### PR TITLE
Fix constant value in silu_and_mul kernel

### DIFF
--- a/tests/kernel/wave/moe_test.py
+++ b/tests/kernel/wave/moe_test.py
@@ -75,7 +75,8 @@ def silu_and_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
 
     out = torch.zeros(gate.shape, dtype=gate.dtype, device=gate.device)
     wave_kernel(gate, up, out)
-    ref = silu_and_mul_ref(gate, up)
+    ref = silu_and_mul_torch_ref(gate, up)
+
     if check_individual_kernels:
         torch.testing.assert_close(out, ref, rtol=rtol, atol=atol, check_device=False)
     return out

--- a/wave_lang/kernel/wave/templates/moe.py
+++ b/wave_lang/kernel/wave/templates/moe.py
@@ -126,7 +126,7 @@ def get_silu_and_mul_kernel(
     ):
         x1_reg = tkw.read(x1)
         cst_m1 = tkl.Register[M, N, datatype](-1.0)
-        cst_1 = tkl.Register[M, N, datatype](-1.0)
+        cst_1 = tkl.Register[M, N, datatype](1.0)
         exp_out = tkw.exp2(x1_reg * cst_m1)
         sigmoid = cst_1 / (cst_1 + exp_out)
         silu = sigmoid * x1_reg


### PR DESCRIPTION
The constant value 1 surprisingly doesn't have much impact on numerical correctness (that's why this error has been unnoticed).

Replacing 1 with some other constant values (e.g. 2, -2) still keeps the tests green.