### PR TITLE
`print` by default in `debug_log` op

### DIFF
--- a/docs/wave/debugging.rst
+++ b/docs/wave/debugging.rst
@@ -35,7 +35,7 @@ We can sprinkle in some debug_logs to get a picture of what is going on inside.
     a_reg = tkw.read(a)
     tkw.debug_log(a_reg, label="a_reg", printer=print)
 
-Note that the printer function will receive 2 arguments: the label, and the tensor data.
+Note that the printer function (which defaults to `print`) will receive 2 arguments: the label, and the tensor data.
 This will print out a global view of the contents of ``a_reg``, where “global view” means that it will print an entire MxK matrix based on the ``a_reg`` value from each wave.
 The ``debug_log`` op works by writing to global memory, where the global memory is automatically added to the kernel signature and launch arguments.
 Since ``a_reg`` is just read from the ``a`` memory, with an identity mapping, the result of the debug_log is equal to the ``a`` matrix.

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -2119,7 +2119,7 @@ class DebugLog(CustomOp):
     Note that the logs collected in the `debug_logs` field, or handled by `printer` or `handler` represent a global view of the log after all writes, not limited to any one wave or loop iteration.
 
     The optional `printer` argument should be a function that accepts a string (the log's `label`) and the value of the log itself (a Torch tensor).
-    A handy value for this is `print`, though note that it will probably print an abbreviated view of the global tensor.
+    The default value for this is `print`, though note that it will probably print an abbreviated view of the global tensor.
 
     The optional `handler` argument should be a function that accepts the whole `debug_logs` object (IE all logs, not just one).
     The handler function gives a way to specify something like a viewer for all logs, but specify it inline among print functions rather than separately.
@@ -2141,7 +2141,7 @@ class DebugLog(CustomOp):
     ] = None
     mapping: Optional[IndexMapping] = None
     mapping_dynamic_vals: tuple[fx.Node, ...] = ()
-    printer: Optional[Callable[[str, Any], Any]] = None
+    printer: Optional[Callable[[str, Any], Any]] = print
     handler: Optional[Callable[[dict[str, Any]], Any]] = None
 
     @property


### PR DESCRIPTION
Reduces the number of required arguments, makes `debug_log` a little easier to use and faster to write.