### PR TITLE
Add a dedicated pass to partition gathers/scatters

### DIFF
--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -220,26 +220,23 @@ def test_paged_flash_decoding_small_head_size():
     # CHECK:                func.func @phase_0
     # Check we are generating comparison against 13
     # CHECK:                   %[[C13:.*]] = arith.constant 13 : index
-    # CHECK:                   %[[COND1:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
-    # CHECK:                   %[[COND2:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
-    # CHECK:                   %[[COND3:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
-    # CHECK:                   %[[COND4:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
+    # CHECK:                   %[[COND:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
 
     # CHECK:                   scf.for
 
-    # CHECK:                     %[[COND_AND1:.*]] = arith.andi %[[COND1]], %{{.*}}
+    # CHECK:                     %[[COND_AND1:.*]] = arith.andi %[[COND]], %{{.*}}
     # CHECK:                     %[[ELEM1_SPLAT:.*]] = vector.broadcast %[[COND_AND1]] : i1 to vector<1xi1>
     # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM1_SPLAT]], %{{.*}}
 
-    # CHECK:                     %[[COND_AND2:.*]] = arith.andi %[[COND2]], %{{.*}}
+    # CHECK:                     %[[COND_AND2:.*]] = arith.andi %[[COND]], %{{.*}}
     # CHECK:                     %[[ELEM2_SPLAT:.*]] = vector.broadcast %[[COND_AND2]] : i1 to vector<1xi1>
     # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM2_SPLAT]], %{{.*}}
 
-    # CHECK:                     %[[COND_AND3:.*]] = arith.andi %[[COND3]], %{{.*}}
+    # CHECK:                     %[[COND_AND3:.*]] = arith.andi %[[COND]], %{{.*}}
     # CHECK:                     %[[ELEM3_SPLAT:.*]] = vector.broadcast %[[COND_AND3]] : i1 to vector<1xi1>
     # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM3_SPLAT]], %{{.*}}
 
-    # CHECK:                     %[[COND_AND4:.*]] = arith.andi %[[COND4]], %{{.*}}
+    # CHECK:                     %[[COND_AND4:.*]] = arith.andi %[[COND]], %{{.*}}
     # CHECK:                     %[[ELEM4_SPLAT:.*]] = vector.broadcast %[[COND_AND4]] : i1 to vector<1xi1>
     # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM4_SPLAT]], %{{.*}}
 

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -220,22 +220,28 @@ def test_paged_flash_decoding_small_head_size():
     # CHECK:                func.func @phase_0
     # Check we are generating comparison against 13
     # CHECK:                   %[[C13:.*]] = arith.constant 13 : index
-    # CHECK:                   %[[COND:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]] : index
-    # CHECK:                   %[[COND_SPLAT:.*]] = vector.broadcast %[[COND]] : i1 to vector<4xi1>
-    # CHECK:                   %[[COND_AND:.*]] = arith.andi %[[COND_SPLAT]], %{{.*}} : vector<4xi1>
+    # CHECK:                   %[[COND1:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
+    # CHECK:                   %[[COND2:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
+    # CHECK:                   %[[COND3:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
+    # CHECK:                   %[[COND4:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]]
 
-    # CHECK:                   %[[ELEM0:.*]] = vector.extract %[[COND_AND]][0] : i1 from vector<4xi1>
-    # CHECK:                   %[[ELEM0_SPLAT:.*]] = vector.broadcast %[[ELEM0:.*]] : i1 to vector<1xi1>
-    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM0_SPLAT]], %{{.*}}
-    # CHECK:                   %[[ELEM1:.*]] = vector.extract %[[COND_AND]][1] : i1 from vector<4xi1>
-    # CHECK:                   %[[ELEM1_SPLAT:.*]] = vector.broadcast %[[ELEM1:.*]] : i1 to vector<1xi1>
-    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM1_SPLAT]], %{{.*}}
-    # CHECK:                   %[[ELEM2:.*]] = vector.extract %[[COND_AND]][2] : i1 from vector<4xi1>
-    # CHECK:                   %[[ELEM2_SPLAT:.*]] = vector.broadcast %[[ELEM2:.*]] : i1 to vector<1xi1>
-    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM2_SPLAT]], %{{.*}}
-    # CHECK:                   %[[ELEM3:.*]] = vector.extract %[[COND_AND]][3] : i1 from vector<4xi1>
-    # CHECK:                   %[[ELEM3_SPLAT:.*]] = vector.broadcast %[[ELEM3:.*]] : i1 to vector<1xi1>
-    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM3_SPLAT]], %{{.*}}
+    # CHECK:                   scf.for
+
+    # CHECK:                     %[[COND_AND1:.*]] = arith.andi %[[COND1]], %{{.*}}
+    # CHECK:                     %[[ELEM1_SPLAT:.*]] = vector.broadcast %[[COND_AND1]] : i1 to vector<1xi1>
+    # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM1_SPLAT]], %{{.*}}
+
+    # CHECK:                     %[[COND_AND2:.*]] = arith.andi %[[COND2]], %{{.*}}
+    # CHECK:                     %[[ELEM2_SPLAT:.*]] = vector.broadcast %[[COND_AND2]] : i1 to vector<1xi1>
+    # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM2_SPLAT]], %{{.*}}
+
+    # CHECK:                     %[[COND_AND3:.*]] = arith.andi %[[COND3]], %{{.*}}
+    # CHECK:                     %[[ELEM3_SPLAT:.*]] = vector.broadcast %[[COND_AND3]] : i1 to vector<1xi1>
+    # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM3_SPLAT]], %{{.*}}
+
+    # CHECK:                     %[[COND_AND4:.*]] = arith.andi %[[COND4]], %{{.*}}
+    # CHECK:                     %[[ELEM4_SPLAT:.*]] = vector.broadcast %[[COND_AND4]] : i1 to vector<1xi1>
+    # CHECK:                     vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM4_SPLAT]], %{{.*}}
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -308,7 +308,7 @@ def test_flash_decoding():
     # CHECK-COUNT-2:           arith.mulf
     # CHECK-COUNT-1:           arith.addf
     # CHECK-COUNT-1:      arith.divf
-    # CHECK-COUNT-1:      vector.scatter
+    # CHECK-COUNT-2:      vector.maskedstore
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -453,7 +453,6 @@ def test_bshd_attention_pipelined_prefetch_pingpong():
     # CHECK-COUNT-2: vector.load
     # CHECK: amdgpu.lds_barrier
     # CHECK-COUNT-2: vector.store
-    # CHECK-COUNT-1: memref.reinterpret_cast
     # CHECK-COUNT-4: memref.load
     # CHECK-COUNT-1: vector.from_elements
     # CHECK-DAG: llvm.call_intrinsic "llvm.amdgcn.sched.barrier"

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -117,7 +117,7 @@ def test_read_mapped():
     # CHECK-LABEL:    test_read_mapped
     # CHECK-DAG:        #{{.*}} = affine_map<()[s0, s1, s2, s3, s4, s5, s6] -> (((s0 * s1) floordiv s2) * s3 + (s4 mod s5) * s6)>
     # CHECK:          func.func @read_mapped
-    # CHECK-COUNT-16:   vector.maskedload
+    # CHECK-COUNT-16:   vector.load
     # CHECK-COUNT-16:   vector.extract
     # CHECK:            vector.from_elements
 
@@ -161,9 +161,7 @@ def test_read_mapped_buffer():
 
     # CHECK-LABEL:    func.func @read_mapped_buffer
     # CHECK: %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast
-    # CHECK: %[[COND:.*]] = arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<1xi1>, vector<1xindex>
-    # CHECK: %[[COND_EXT:.*]] = vector.extract %[[COND]][0] : index from vector<1xindex>
-    # CHECK: %[[RES:.*]] = vector.load %[[BUF]][%[[COND_EXT]]] : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1xf16>
+    # CHECK: %[[RES:.*]] = vector.load %[[BUF]][%{{.*}}] : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1xf16>
     # CHECK: %[[EXTRACT:.*]] = vector.extract %[[RES]][0] : f16 from vector<1xf16>
     # CHECK: %[[FROM:.*]] = vector.from_elements %[[EXTRACT]]
 
@@ -819,8 +817,8 @@ def test_dynamic_copy():
     print(dynamic_copy.asm)
 
     # CHECK-LABEL:    test_dynamic_copy
-    # CHECK-DAG:        #[[map1:.*]] = affine_map<()[s0, s1] -> (s0 + s1 * 16 - (s0 floordiv 64) * 48)>
-    # CHECK-DAG:        #[[map2:.*]] = affine_map<()[s0] -> (s0 * 16)>
+    # CHECK-DAG:        #[[map1:.*]] = affine_map<()[s0] -> (s0 * 16)>
+    # CHECK-DAG:        #[[map2:.*]] = affine_map<()[s0, s1] -> (s0 + s1 * 16 - (s0 floordiv 64) * 48)>
     # CHECK:          func.func @dynamic_copy
     # CHECH-SAME:       (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
     # CHECK-DAG:        %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf16>
@@ -830,17 +828,17 @@ def test_dynamic_copy():
     # CHECK:            %[[WORKGROUP_ID_1:.*]] = gpu.block_id y
     # CHECK:            %[[THREAD_ID_X:.*]] = gpu.thread_id  x
     # CHECK:            %[[D0:.*]] = stream.binding.subspan %[[ARG0]][%[[C0]]] : !stream.binding -> memref<?x?xf16, strided<[?, 1], offset: ?>>{%[[ARG1]], %[[ARG2]]}
-    # CHECK:            %[[D1:.*]] = affine.apply #[[map1]]()[%[[THREAD_ID_X]], %[[WORKGROUP_ID_0]]]
-    # CHECK:            %[[D2:.*]] = affine.apply #[[map2]]()[%[[WORKGROUP_ID_1]]]
-    # CHECK:            %[[D3:.*]] = vector.broadcast %[[D2]] : index to vector<16xindex>
-    # CHECK:            %[[D4:.*]] = arith.addi %[[D3]], %[[CST_0]] overflow<nsw, nuw> : vector<16xindex>
-    # CHECK:            %[[D5:.*]] = vector.broadcast %[[ARG2]] : index to vector<16xindex>
-    # CHECK:            %[[D6:.*]] = arith.cmpi slt, %[[D4]], %[[D5]] : vector<16xindex>
-    # CHECK:            %[[D7:.*]] = arith.cmpi slt, %[[D1]], %[[ARG1]] : index
+    # CHECK:            %[[D1:.*]] = affine.apply #[[map1]]()[%[[WORKGROUP_ID_1]]]
+    # CHECK:            %[[D2:.*]] = vector.broadcast %[[D1]] : index to vector<16xindex>
+    # CHECK:            %[[D3:.*]] = arith.addi %[[D2]], %[[CST_0]] overflow<nsw, nuw> : vector<16xindex>
+    # CHECK:            %[[D4:.*]] = vector.broadcast %[[ARG2]] : index to vector<16xindex>
+    # CHECK:            %[[D5:.*]] = arith.cmpi slt, %[[D3]], %[[D4]] : vector<16xindex>
+    # CHECK:            %[[D6:.*]] = affine.apply #[[map2]]()[%[[THREAD_ID_X]], %[[WORKGROUP_ID_0]]]
+    # CHECK:            %[[D7:.*]] = arith.cmpi slt, %[[D6]], %[[ARG1]] : index
     # CHECK:            %[[D8:.*]] = vector.broadcast %[[D7]] : i1 to vector<16xi1>
-    # CHECK:            %[[D9:.*]] = arith.andi %[[D6]], %[[D8]] : vector<16xi1>
-    # CHECK:            %[[D10:.*]] = vector.maskedload %[[D0]][%[[D1]], %[[D2]]], %[[D9]], %[[CST]] : memref<?x?xf16, strided<[?, 1], offset: ?>>, vector<16xi1>, vector<16xf16> into vector<16xf16>
-    # CHECK:            vector.maskedstore %[[D0]][%[[D1]], %[[D2]]], %[[D9]], %[[D10]] : memref<?x?xf16, strided<[?, 1], offset: ?>>, vector<16xi1>, vector<16xf16>
+    # CHECK:            %[[D9:.*]] = arith.andi %[[D5]], %[[D8]] : vector<16xi1>
+    # CHECK:            %[[D10:.*]] = vector.maskedload %[[D0]][%[[D6]], %[[D1]]], %[[D9]], %[[CST]] : memref<?x?xf16, strided<[?, 1], offset: ?>>, vector<16xi1>, vector<16xf16> into vector<16xf16>
+    # CHECK:            vector.maskedstore %[[D0]][%[[D6]], %[[D1]]], %[[D9]], %[[D10]] : memref<?x?xf16, strided<[?, 1], offset: ?>>, vector<16xi1>, vector<16xf16>
     # CHECK:          func.func @isolated_benchmark$async(%[[ARG:.*]]: !hal.buffer_view, %[[FENCE:.*]]: !hal.fence, %{{.*}}: !hal.fence)
     # CHECK:            %[[D0:.*]] = hal.buffer_view.dim<%[[ARG]] : !hal.buffer_view>[0] : index
     # CHECK:            %[[D1:.*]] = hal.buffer_view.dim<%[[ARG]] : !hal.buffer_view>[1] : index

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -650,7 +650,6 @@ def test_read_write_dynamic_symbol():
         num_iterators=2,
         inputs={S: S, N: j},
         outputs={S: i, N: j},
-        dynamic_val_mappings={S: i, N: j},
     )
 
     @tkw.wave(constraints)
@@ -709,7 +708,6 @@ def test_read_write_dynamic_symbol_expr():
         num_iterators=2,
         inputs={S: S, N: j},
         outputs={S: i, N: j},
-        dynamic_val_mappings={S: i, N: j},
     )
 
     @tkw.wave(constraints)

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -421,7 +421,7 @@ def test_read_write_mapping():
     # We are transposing, so contiguous load becomes non-contiguous store
     # CHECK:            vector.load
     # CHECK-NOT:        vector.load
-    # CHECK-COUNT-16:   memref.store
+    # CHECK-COUNT-16:   vector.store
 
 
 @run_test

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -464,21 +464,6 @@ def test_read_write_dynamic_mapping():
 
     # CHECK-LABEL:    test_read_write_dynamic_mapping
     # CHECK-DAG:        #[[map0:.*]] = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 1)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 2)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 3)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 4)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 5)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 6)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 7)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 8)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 9)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 10)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 11)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 12)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 13)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 14)>
-    # CHECK-DAG:        #{{.*}} = affine_map<()[s0] -> (s0 - (s0 floordiv 64) * 48 + 15)>
 
     # CHECK:          func.func @read_write_dynamic_mapping
     # CHECK-SAME:       (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding)

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -212,52 +212,52 @@ def test_gemm():
     # CHECK-NEXT: get_result(value=iterate, res_idx=1
     # CHECK-NEXT: get_result(value=iterate, res_idx=2
     # CHECK-NEXT: get_result(value=iterate, res_idx=3
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[0], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[0], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[1], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[1], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_1, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 1 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[2], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[2], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_2, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 2 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[3], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[3], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_3, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 3 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[0], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[0], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_4, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[1], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[1], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_5, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 1 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[2], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[2], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_6, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 2 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[3], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:1_K:0, offset=[3], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_7, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 3 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[0], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[0], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_8, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 16 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[1], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[1], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_9, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 17 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[2], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[2], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_10, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 18 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[3], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:0_K:0, offset=[3], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_11, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 19 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[0], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[0], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_12, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 16 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[1], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[1], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_13, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 17 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[2], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[2], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_14, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 18 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
-    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[3], size=[1], stride=[1])
+    # CHECK-NEXT: extract_slice(register_=get_result_M:1_N:1_K:0, offset=[3], size=[1], stride=[1], index={{.*}})
     # CHECK-NEXT: write(register_=extract_slice_15, memory=c, elements_per_thread=1,
     # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) + 19 : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 48 : 1 : 1})
 

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1767,13 +1767,18 @@ class Read(CustomOp):
 
         mapping = self.mapping
 
-        mem_shape = get_custom(self.memory).type.symbolic_shape
+        memory = get_custom(self.memory)
+        symbolic_shape = memory.type.symbolic_shape
+        array_shape = symbolic_shape
+        if memory.type.address_space == SHARED_ADDRESS_SPACE:
+            array_shape = memory.distributed_shape
 
         from ..wave.utils.mapping_utils import check_is_mapping_contiguous
 
         return check_is_mapping_contiguous(
             mapping=mapping,
-            symbolic_shape=mem_shape,
+            symbolic_shape=symbolic_shape,
+            array_shape=array_shape,
             index=self.index,
             elements_per_thread=self.elements_per_thread,
             is_read=True,
@@ -2105,13 +2110,18 @@ class Write(CustomOp):
             return True
         mapping = self.mapping
 
-        mem_shape = get_custom(self.memory).type.symbolic_shape
+        memory = get_custom(self.memory)
+        symbolic_shape = memory.type.symbolic_shape
+        array_shape = symbolic_shape
+        if memory.type.address_space == SHARED_ADDRESS_SPACE:
+            array_shape = memory.distributed_shape
 
         from ..wave.utils.mapping_utils import check_is_mapping_contiguous
 
         return check_is_mapping_contiguous(
             mapping=mapping,
-            symbolic_shape=mem_shape,
+            symbolic_shape=symbolic_shape,
+            array_shape=array_shape,
             index=self.index,
             elements_per_thread=self.elements_per_thread,
             is_read=False,

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1770,10 +1770,10 @@ class Read(CustomOp):
 
         from ..wave.utils.mapping_utils import (
             check_is_mapping_contiguous,
-            check_is_dynamic_vals_broadcted,
+            check_is_dynamic_vals_broadcasted,
         )
 
-        if not check_is_dynamic_vals_broadcted(self.mapping_dynamic_vals):
+        if not check_is_dynamic_vals_broadcasted(self.mapping_dynamic_vals):
             return False
 
         mapping = self.mapping
@@ -2123,10 +2123,10 @@ class Write(CustomOp):
 
         from ..wave.utils.mapping_utils import (
             check_is_mapping_contiguous,
-            check_is_dynamic_vals_broadcted,
+            check_is_dynamic_vals_broadcasted,
         )
 
-        if not check_is_dynamic_vals_broadcted(self.mapping_dynamic_vals):
+        if not check_is_dynamic_vals_broadcasted(self.mapping_dynamic_vals):
             return False
 
         mapping = self.mapping

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1765,6 +1765,17 @@ class Read(CustomOp):
         if self.has_identity_mapping():
             return True
 
+        if self.elements_per_thread == 1:
+            return True
+
+        from ..wave.utils.mapping_utils import (
+            check_is_mapping_contiguous,
+            check_is_dynamic_vals_broadcted,
+        )
+
+        if not check_is_dynamic_vals_broadcted(self.mapping_dynamic_vals):
+            return False
+
         mapping = self.mapping
 
         memory = get_custom(self.memory)
@@ -1772,8 +1783,6 @@ class Read(CustomOp):
         array_shape = symbolic_shape
         if memory.type.address_space == SHARED_ADDRESS_SPACE:
             array_shape = memory.distributed_shape
-
-        from ..wave.utils.mapping_utils import check_is_mapping_contiguous
 
         return check_is_mapping_contiguous(
             mapping=mapping,
@@ -2108,6 +2117,18 @@ class Write(CustomOp):
         If False we will have to lower it to gather"""
         if self.has_identity_mapping():
             return True
+
+        if self.elements_per_thread == 1:
+            return True
+
+        from ..wave.utils.mapping_utils import (
+            check_is_mapping_contiguous,
+            check_is_dynamic_vals_broadcted,
+        )
+
+        if not check_is_dynamic_vals_broadcted(self.mapping_dynamic_vals):
+            return False
+
         mapping = self.mapping
 
         memory = get_custom(self.memory)
@@ -2115,8 +2136,6 @@ class Write(CustomOp):
         array_shape = symbolic_shape
         if memory.type.address_space == SHARED_ADDRESS_SPACE:
             array_shape = memory.distributed_shape
-
-        from ..wave.utils.mapping_utils import check_is_mapping_contiguous
 
         return check_is_mapping_contiguous(
             mapping=mapping,

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -439,6 +439,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                     raise NotImplementedError(f"Unsupported op type: {custom}")
 
                 # Update new_node information
+                custom.infer_type()
                 new_node.index = new_index
                 new_node.vector_shapes = custom.vector_shapes
                 ops_to_combine.append(new_node)

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -202,6 +202,7 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
                     )
                     for j, dim in enumerate(symbolic_shape)
                 }
+                extract.index = write.index
                 write.vector_shapes = vector_shapes
                 ops_to_combine.append(write)
 
@@ -329,6 +330,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                             extract = ExtractSlice(
                                 dyn_val, [cur_gpr_start_id], [gpr_size], [1]
                             ).add_to_graph(custom.graph)
+                            extract.index = updated_index_with_gpr_offset
                             new_dynamic_vals.append(extract)
                         else:
                             new_dynamic_vals.append(dyn_val)
@@ -431,6 +433,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                     extract = ExtractSlice(dynamic_val, [i], [1], [1]).add_to_graph(
                         custom.graph
                     )
+                    extract.index = new_index
                     new_dynamic_vals.append(extract)
 
                 # Generate new Read/Write that has contiguous VGPR elements.

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -479,5 +479,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                 # detect if op was part of `gpr_offset` partition.
                 reshape.index = index
                 custom.replace_all_uses_with(reshape)
+            else:
+                raise NotImplementedError(f"Unsupported op type: {custom}")
 
-            custom.graph.erase_node(custom.fx_node)
+            custom.erase()

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -439,6 +439,8 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                 for dynamic_val in custom.mapping_dynamic_vals:
                     _, size = get_largest_index_and_size(dynamic_val.index)
                     if size == 1:
+                        # If size is 1, it means we are broadcasting same dynamic value to all
+                        # vector elements.
                         new_dynamic_vals.append(dynamic_val)
                         continue
 
@@ -446,6 +448,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                         size == elements_per_thread
                     ), f"Expected size to be equal to {elements_per_thread}, got {size}"
 
+                    # Otherwise, we need to extract the dynamic value for the current vector element.
                     extract = ExtractSlice(dynamic_val, [i], [1], [1]).add_to_graph(
                         custom.graph
                     )

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -459,7 +459,6 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
                     raise NotImplementedError(f"Unsupported op type: {custom}")
 
                 # Update new_node information
-                custom.infer_type()
                 new_node.index = new_index
                 new_node.vector_shapes = custom.vector_shapes
                 ops_to_combine.append(new_node)

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -392,11 +392,8 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
         read more than a single element.
         """
         custom = get_custom(node)
-        # if isinstance(custom, (Read, Write)):
-        if isinstance(custom, Write):
-            is_contiguous = custom.is_contiguous_vec()
-            print(f"Partitioning gather like op: {node}: {is_contiguous}")
-            return not is_contiguous
+        if isinstance(custom, (Read, Write)):
+            return not custom.is_contiguous_vec()
 
         return False
 
@@ -404,7 +401,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
     for operator in strided_operators:
         custom = get_custom(operator)
         index = custom.index
-        elements_per_thread = custom.elements_per_thread
+        elements_per_thread = subs_idxc(custom.elements_per_thread)
 
         # Break apart Reads/Writes that has non-contiguous GPR Read/Writes.
         with custom.graph.inserting_before(operator):

--- a/wave_lang/kernel/wave/codegen/read_write.py
+++ b/wave_lang/kernel/wave/codegen/read_write.py
@@ -50,9 +50,9 @@ from ...ops.wave_ops import (
     write,
     scatter_add,
 )
-from ..utils.general_utils import get_fastest_index, infer_dim, linearize_index
+from ..utils.general_utils import get_fastest_index, linearize_index
 from ..utils.mapping_utils import transform_index_on_mapping
-from ..utils.symbol_utils import safe_subs, subs_idxc, is_literal
+from ..utils.symbol_utils import safe_subs
 from .emitter import (
     WaveEmitter,
     add_emitter_subs,
@@ -198,158 +198,6 @@ def _get_splat_const(vec_type: IrType, value: Any) -> Value:
 
 def _constant_mask(vec_type: IrType) -> Value:
     return _get_splat_const(vec_type, 1)
-
-
-def _construct_gather_scatter_indices(
-    emitter: WaveEmitter,
-    symbolic_shape: tuple[IndexExpr],
-    index: tuple[IndexExpr],
-    mapping: IndexMapping,
-    elements_per_thread: int,
-    is_read: bool,
-    dynamic_vals: tuple[Any, ...],
-    is_contiguous: bool,
-    memory: CustomOp,
-    bounds: Optional[dict[IndexSymbol, IndexExpr]],
-) -> tuple[list[OpResult], list[OpResult], list[OpResult], OpResult, OpResult]:
-    # Apply symbolic_shape order to indices, e.g. if original mapping is
-    # {M: iter(0), N: iter(1)} and symbolic_shape is (N, M), result will
-    # be (iter(1), iter(0))
-    if is_read:
-        assert (
-            mapping.is_output_identity()
-        ), "non-identity output mapping is not supported yet"
-        symbolic_dims = [infer_dim(dim_size) for dim_size in symbolic_shape]
-        index_mapping = mapping.map_input_indices(symbolic_dims)
-    else:
-        assert (
-            mapping.is_input_identity()
-        ), "non-identity input mapping is not supported yet"
-        index_mapping = mapping.map_output_indices(symbolic_shape)
-
-    idxc = IndexingContext.current()
-    index_mapping = tuple(i.subs(idxc.subs) for i in index_mapping)
-
-    iters = mapping.iters
-
-    # As we only support identity input/output mapping for now, we can directly
-    # substitute iterators with corresponding expanded index.
-    subs = [
-        (sym, expr.start) for sym, expr in zip(iters.keys(), index.values())
-    ] + list(idxc.subs.items())
-
-    # Contruct input/output index, substituting iterators in input mapping with
-    # expanded index.
-    result_index = {key: m.subs(subs) for key, m in zip(symbolic_shape, index_mapping)}
-
-    mask = _build_mask(emitter, index, elements_per_thread, bounds)
-    if mask is None:
-        mask_vec_type = VectorType.get(
-            [elements_per_thread], IntegerType.get_signless(1)
-        )
-        mask = _constant_mask(mask_vec_type)
-
-    def extract0(src):
-        static_pos = [0] * src.type.rank
-        return vector_d.extract(src, static_position=static_pos, dynamic_position=[])
-
-    dynamic_vals_map_start = {
-        sym: extract0(val)
-        for sym, val in zip(mapping.dynamic_val_indices.keys(), dynamic_vals)
-    }
-    if is_contiguous:
-        start_indices, start_indices_wg, start_indices_th = _build_start_indices(
-            emitter, result_index, dynamic_vals_map_start
-        )
-        return start_indices, start_indices_wg, start_indices_th, None, mask
-
-    start_indices = _get_start_indices(result_index)
-    start_indices_orig = _get_start_indices(index)
-    fastest_dim = get_fastest_index(index)
-    need_dynamic_offsets = False
-    for val in dynamic_vals:
-        shape = val.type.shape
-        assert shape in (
-            [1],
-            [elements_per_thread],
-        ), f"Dynamic val shape must be {[1]} or {[elements_per_thread]} but got {shape}"
-        if shape[0] > 1:
-            need_dynamic_offsets = True
-
-    offsets = []
-    if memory.type.address_space == SHARED_ADDRESS_SPACE:
-        symbolic_shape = memory.distributed_shape
-    strides = strides_from_symbolic_shape(idxc, symbolic_shape, allow_mixed_shapes=True)
-    start_indices_offset = _compute_offset(start_indices, strides)
-    for i in range(elements_per_thread):
-        # Update fastest dim, i.e. in case of identity mapping it will
-        # be equivalent to just vector.load
-        subs = [(sym, idx) for sym, idx in zip(iters.keys(), start_indices_orig)]
-        subs[fastest_dim] = (subs[fastest_dim][0], start_indices_orig[fastest_dim] + i)
-        indices = [i.subs(subs) for i in index_mapping]
-
-        # First, we build indices as if resulting gather/scatter `start_indices`
-        # are 0 as mapping expression may depend on absolute value of index
-        # (e.g. `index % 32`). Then we adjust for the non-0 `start_indices` by
-        # subtracting computed previously linear `start_indices_offset`. For
-        # simple cases like transpose, the resulting expression should fold into
-        # simple constant while more complex expressions may requires actual
-        # arith ops on dynamic values.
-        offset = _compute_offset(indices, strides) - start_indices_offset
-        offset = subs_idxc(offset)
-
-        if is_literal(offset):
-            # If resulted offset sympy expr is convertible to int constant it
-            # will be directly encoded into `arith.constant`.
-            # For non-constant expressions, we will generate a real sequence of
-            # arith ops and then `vector.insertelement` them into offsets vec.
-            offset = int(offset)
-        else:
-            need_dynamic_offsets = True
-            break
-
-        offsets.append(offset)
-
-    offsets_vec_type = VectorType.get([elements_per_thread], IndexType.get())
-    if need_dynamic_offsets:
-        # In case we need dynamic `offsets_vec`, set all `start_indices` to 0
-        # and encode entire index info in `offsets_vec`.
-        result_index = {key: 0 for key in symbolic_shape}
-        start_indices, start_indices_wg, start_indices_th = _build_start_indices(
-            emitter, result_index, dynamic_vals_map_start
-        )
-        subs = [(sym, idx) for sym, idx in zip(iters.keys(), start_indices_orig)]
-        # Last item in `subs` corresponds to last item in `start_indices_orig`
-        # which is fastest changing dim.
-        # Replacing last element with `idxc.iota(elements_per_thread)` will
-        # generate vectorized index code, each element in it corresponding to
-        # individual vector element index.
-        subs[-1] = (
-            subs[-1][0],
-            start_indices_orig[-1] + idxc.iota(elements_per_thread),
-        )
-        dynamic_vals_map = {
-            sym: val
-            for sym, val in zip(mapping.dynamic_val_indices.keys(), dynamic_vals)
-        }
-        indices = [i.subs(subs) for i in index_mapping]
-        offsets_vec = gen_sympy_index(
-            add_emitter_subs(emitter, dynamic_vals_map),
-            _compute_offset(indices, strides),
-        )
-    else:
-        start_indices, start_indices_wg, start_indices_th = _build_start_indices(
-            emitter, result_index, dynamic_vals_map_start
-        )
-        if offsets == list(range(elements_per_thread)):
-            return start_indices, start_indices_wg, start_indices_th, None, mask
-
-        offsets = [IntegerAttr.get(IndexType.get(), off) for off in offsets]
-        offsets_vec = arith_d.ConstantOp(
-            offsets_vec_type, DenseElementsAttr.get(offsets, offsets_vec_type)
-        )
-
-    return start_indices, start_indices_wg, start_indices_th, offsets_vec, mask
 
 
 def _get_max_buffer_size(elem_type: IrType) -> int:
@@ -568,7 +416,6 @@ def _create_vec_read_write(
     elements_per_thread: int,
     memory: CustomOp,
     mask: Optional[Value],
-    offsets_vec: Optional[Value],
     node_index: Optional[IndexSequence] = None,
 ) -> Optional[Value]:
     is_read = value is None
@@ -597,14 +444,14 @@ def _create_vec_read_write(
     no_masked_load_store_ops = buffer_ops_enabled
 
     mask_splat = _get_splat_input(mask)
-    splatted_mask = offsets_vec is None and mask_splat is not None
+    splatted_mask = mask_splat is not None
 
     if vector_type is None:
         vector_type = value.type
 
     element_type = vector_type.element_type
     # Case 1: Generate load/stores with no mask and no offset
-    if mask is None and offsets_vec is None:
+    if mask is None:
         offset_th = None
         if buffer_ops_enabled:
             # TODO: If strides cannot be converted into integers, means they are dynamic
@@ -636,176 +483,91 @@ def _create_vec_read_write(
         )
         mask = _constant_mask(mask_vec_type)
 
-    # Case 2: Generate load/stores with no offset
-    if offsets_vec is None:
-        # make offsets 0, 1, 2 ...
-        offsets_vec_type = VectorType.get(vector_type.shape, IndexType.get())
-        vals = [IntegerAttr.get(IndexType.get(), v) for v in range(elements_per_thread)]
+    # make offsets 0, 1, 2 ...
+    offsets_vec_type = VectorType.get(vector_type.shape, IndexType.get())
+    vals = [IntegerAttr.get(IndexType.get(), v) for v in range(elements_per_thread)]
 
-        offsets_vec = arith_d.constant(
-            offsets_vec_type, DenseElementsAttr.get(vals, offsets_vec_type)
+    offsets_vec = arith_d.constant(
+        offsets_vec_type, DenseElementsAttr.get(vals, offsets_vec_type)
+    )
+
+    if buffer_ops_enabled:
+        mem, offset_th = _linearize_memref(
+            mem, start_indices_wg, start_indices_th, strides
+        )
+        mem = _cast_buffer_and_encode_stride(mem, strides, element_type, emitter)
+
+    indices = [offset_th] if buffer_ops_enabled else start_indices
+
+    if no_masked_load_store_ops:
+        # find the index at which memory out of bounds of buffer
+        oob_index_value = _get_out_of_bounds_index(element_type)
+        oob_index = arith_d.constant(IndexType.get(), oob_index_value)
+
+        oob_index = vector_d.broadcast(
+            VectorType.get(vector_type.shape, IndexType.get()), oob_index
         )
 
-        if buffer_ops_enabled:
-            mem, offset_th = _linearize_memref(
-                mem, start_indices_wg, start_indices_th, strides
-            )
-            mem = _cast_buffer_and_encode_stride(mem, strides, element_type, emitter)
+        offset_th = vector_d.broadcast(
+            VectorType.get(vector_type.shape, IndexType.get()), offset_th
+        )
 
-        indices = [offset_th] if buffer_ops_enabled else start_indices
+        uint32_vec_type = VectorType.get([elements_per_thread], uint32)
+        indexvec_type = VectorType.get([elements_per_thread], IndexType.get())
 
-        if no_masked_load_store_ops:
-            # find the index at which memory out of bounds of buffer
-            oob_index_value = _get_out_of_bounds_index(element_type)
-            oob_index = arith_d.constant(IndexType.get(), oob_index_value)
+        offsets_vec = arith_d.index_cast(uint32_vec_type, offsets_vec)
+        offset_th = arith_d.index_cast(uint32_vec_type, offset_th)
 
-            oob_index = vector_d.broadcast(
-                VectorType.get(vector_type.shape, IndexType.get()), oob_index
-            )
+        # add the thread offset and the vec offsets
+        offsets_vec = arith_d.addi(offsets_vec, offset_th)
+        offsets_vec = arith_d.index_cast(indexvec_type, offsets_vec)
 
-            offset_th = vector_d.broadcast(
-                VectorType.get(vector_type.shape, IndexType.get()), offset_th
-            )
+        # based on mask, select between the offsets_vec and out of bounds. In this case all 3 operands can be vectors
+        selected_index = arith_d.select(mask, offsets_vec, oob_index)
+        elems = list()
 
-            uint32_vec_type = VectorType.get([elements_per_thread], uint32)
-            indexvec_type = VectorType.get([elements_per_thread], IndexType.get())
-
-            offsets_vec = arith_d.index_cast(uint32_vec_type, offsets_vec)
-            offset_th = arith_d.index_cast(uint32_vec_type, offset_th)
-
-            # add the thread offset and the vec offsets
-            offsets_vec = arith_d.addi(offsets_vec, offset_th)
-            offsets_vec = arith_d.index_cast(indexvec_type, offsets_vec)
-
-            # based on mask, select between the offsets_vec and out of bounds. In this case all 3 operands can be vectors
-            selected_index = arith_d.select(mask, offsets_vec, oob_index)
-            elems = list()
-
-            if splatted_mask:
-                # mask is same for all of them, can just pick the first index
-                selected_index = extract(selected_index, 0)
-
-                if is_read:
-                    return vector_d.load(vector_type, mem, indices=[selected_index])
-
-                else:
-                    vector_d.store(value, mem, indices=[selected_index])
-                    return
-
-            for i in range(elements_per_thread):
-                # mask is not same for all elements, need to unroll
-                this_index = extract(selected_index, i)  # this element
-
-                # Unmasked load, using selected_index
-                singlenumvec_type = VectorType.get([1], vector_type.element_type)
-                if is_read:
-                    elem = vector_d.load(singlenumvec_type, mem, indices=[this_index])
-                    elem = extract(elem, 0)
-                    elems.append(elem)
-                else:
-                    elem = extract(value, i)
-                    single_num_vector = vector_d.broadcast(singlenumvec_type, elem)
-                    vector_d.store(single_num_vector, mem, indices=[this_index])
+        if splatted_mask:
+            # mask is same for all of them, can just pick the first index
+            selected_index = extract(selected_index, 0)
 
             if is_read:
-                # now make a vector from all the elements loaded
-                return vector_d.from_elements(vector_type, elems)
+                return vector_d.load(vector_type, mem, indices=[selected_index])
 
-            else:  # it was a store, return
-                return
-
-        else:
-            # normal masked load/store
-
-            if is_read:
-                passthru = vector_d.broadcast(vector_type, zero)
-                return vector_d.maskedload(vector_type, mem, indices, mask, passthru)
             else:
-                vector_d.maskedstore(mem, indices, mask, value)
+                vector_d.store(value, mem, indices=[selected_index])
                 return
 
-    # Case 3: Generate efficient "unrolled" gather and scatter using vector.load/store if strides are constants.
-    #
-    # Per vector.gather/vector.scatter ABI, case 3 and 4 takes N-d indices as base offset,
-    # and offset_vec which is vector of linearized indices as additional offsets.
-    # TODO: Drop case 3 and case 4, by adding support for non-trivial mapping and readOps on partition_strided_operator.
-    if has_int_strides:
-        vec1 = VectorType.get([1], element_type)
-        vec1_mask = VectorType.get([1], IntegerType.get_signless(1))
-        # TODO: Need static strides for linearize to work.
-        mem, _ = _linearize_memref(
-            mem, start_indices, (0,) * len(start_indices), strides
-        )
-        if buffer_ops_enabled:
-            mem = _cast_buffer_and_encode_stride(mem, strides, element_type, emitter)
+        for i in range(elements_per_thread):
+            # mask is not same for all elements, need to unroll
+            this_index = extract(selected_index, i)  # this element
 
-        # Unroll gather/scatter into individual masked ops.
-        # Vector canonicalizations will convert them into unmasked later if
-        # mask is constant.
-        if is_read:
-            passthru = vector_d.broadcast(vec1, zero)
-            elements = []
-
-            for i in range(elements_per_thread):
-                mask_elem = extract(mask, i)
-                offset_th = extract(offsets_vec, i)
-
-                if no_masked_load_store_ops:
-                    oob_index_value = _get_out_of_bounds_index(element_type)
-                    oob_index = arith_d.constant(IndexType.get(), oob_index_value)
-
-                    offsets_vec_type = (
-                        VectorType.get(vector_type.shape, IndexType.get())
-                        if offsets_vec is None
-                        else offsets_vec.type
-                    )
-
-                    # each of these are single element
-                    selected_index = arith_d.select(mask_elem, offset_th, oob_index)
-                    indices = [selected_index]
-                    elem = vector_d.load(vec1, mem, indices)
-
-                else:
-                    mask_elem = vector_d.broadcast(vec1_mask, mask_elem)
-                    elem = vector_d.maskedload(
-                        vec1, mem, [offset_th], mask_elem, passthru
-                    )
-                elements.append(elem)
-
-            elements = [extract(v, 0) for v in elements]
-            return vector_d.from_elements(vector_type, elements)
-        else:
-            for i in range(elements_per_thread):
-                mask_elem = extract(mask, i)
-
-                offset_th = extract(offsets_vec, i)
-
+            # Unmasked load, using selected_index
+            singlenumvec_type = VectorType.get([1], vector_type.element_type)
+            if is_read:
+                elem = vector_d.load(singlenumvec_type, mem, indices=[this_index])
+                elem = extract(elem, 0)
+                elems.append(elem)
+            else:
                 elem = extract(value, i)
-                elem = vector_d.broadcast(vec1, elem)
+                single_num_vector = vector_d.broadcast(singlenumvec_type, elem)
+                vector_d.store(single_num_vector, mem, indices=[this_index])
 
-                if no_masked_load_store_ops:
-                    oob_index_value = _get_out_of_bounds_index(element_type)
-                    oob_index = arith_d.constant(IndexType.get(), oob_index_value)
+        if is_read:
+            # now make a vector from all the elements loaded
+            return vector_d.from_elements(vector_type, elems)
 
-                    selected_index = arith_d.select(mask_elem, offset_th, oob_index)
-                    vector_d.store(elem, mem, [selected_index])
-
-                else:
-                    mask_elem = vector_d.broadcast(vec1_mask, mask_elem)
-
-                    vector_d.maskedstore(mem, [offset_th], mask_elem, elem)
-
+        else:  # it was a store, return
             return
 
-    # Case 4: Default gather scatter case (slowest path).
-    if is_read:
-        passthru = vector_d.broadcast(vector_type, zero)
-        return vector_d.gather(
-            vector_type, mem, start_indices, offsets_vec, mask, passthru
-        )
     else:
-        vector_d.scatter(mem, start_indices, offsets_vec, mask, value)
-        return
+        # normal masked load/store
+
+        if is_read:
+            passthru = vector_d.broadcast(vector_type, zero)
+            return vector_d.maskedload(vector_type, mem, indices, mask, passthru)
+        else:
+            vector_d.maskedstore(mem, indices, mask, value)
+            return
 
 
 @handle_op(read)
@@ -833,64 +595,28 @@ def handle_read(emitter: WaveEmitter, node: fx.Node):
         cast_vector(emitter, reg, element_type=IndexType.get()) for reg in dyn_vals
     )
     dynamic_vals_map_start = _build_dyn_vals_map(mapping, dyn_vals)
-    if True or get_custom(node).has_identity_mapping():
-        mask = _build_mask(emitter, index, elements_per_thread, bounds)
-        if mapping:
-            index = transform_index_on_mapping(
-                mapping, input_shape, index, is_read=True
-            )
 
-        start_indices, start_indices_wg, start_indices_th = _build_start_indices(
-            emitter, index, dynamic_vals_map_start
-        )
-        result = _create_vec_read_write(
-            emitter,
-            input_shape,
-            kb_src,
-            None,
-            vector_type,
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            elements_per_thread,
-            get_custom(memory),
-            mask,
-            node_index=index,
-            offsets_vec=None,
-        )
-    else:
-        (
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            offsets_vec,
-            mask,
-        ) = _construct_gather_scatter_indices(
-            emitter=emitter,
-            symbolic_shape=input_shape,
-            index=index,
-            mapping=mapping,
-            elements_per_thread=elements_per_thread,
-            is_read=True,
-            dynamic_vals=dyn_vals,
-            is_contiguous=get_custom(node).is_contiguous_vec(),
-            memory=get_custom(memory),
-            bounds=bounds,
-        )
-        result = _create_vec_read_write(
-            emitter,
-            input_shape,
-            kb_src,
-            None,
-            vector_type,
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            elements_per_thread,
-            get_custom(memory),
-            mask,
-            offsets_vec,
-        )
+    mask = _build_mask(emitter, index, elements_per_thread, bounds)
+    if mapping:
+        index = transform_index_on_mapping(mapping, input_shape, index, is_read=True)
+
+    start_indices, start_indices_wg, start_indices_th = _build_start_indices(
+        emitter, index, dynamic_vals_map_start
+    )
+    result = _create_vec_read_write(
+        emitter,
+        input_shape,
+        kb_src,
+        None,
+        vector_type,
+        start_indices,
+        start_indices_wg,
+        start_indices_th,
+        elements_per_thread,
+        get_custom(memory),
+        mask,
+        node_index=index,
+    )
 
     emitter.bind_node_proxy(node, IRProxyValue(result))
 
@@ -928,72 +654,28 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
         cast_vector(emitter, reg, element_type=IndexType.get()) for reg in dyn_vals
     )
     dynamic_vals_map_start = _build_dyn_vals_map(mapping, dyn_vals)
-    if True or get_custom(node).has_identity_mapping():
-        mask = _build_mask(emitter, index, elements_per_thread, bounds)
-        if mapping:
-            index = transform_index_on_mapping(
-                mapping, output_shape, index, is_read=False
-            )
 
-        start_indices, start_indices_wg, start_indices_th = _build_start_indices(
-            emitter, index, dynamic_vals_map_start
-        )
-        _create_vec_read_write(
-            emitter,
-            output_shape,
-            kb_dest,
-            insert_vector,
-            None,
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            elements_per_thread,
-            get_custom(memory),
-            mask,
-            node_index=index,
-            offsets_vec=None,
-        )
-    else:
-        assert (
-            input_shape == mapping.input_shape
-        ), f"non-identity input mapping is not supported yet. \nFound input_shape as {input_shape} and mapping.input_shape as {mapping.input_shape}."
+    mask = _build_mask(emitter, index, elements_per_thread, bounds)
+    if mapping:
+        index = transform_index_on_mapping(mapping, output_shape, index, is_read=False)
 
-        dyn_vals = tuple(
-            cast_vector(emitter, reg, element_type=IndexType.get()) for reg in dyn_vals
-        )
-        (
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            offsets_vec,
-            mask,
-        ) = _construct_gather_scatter_indices(
-            emitter=emitter,
-            symbolic_shape=output_shape,
-            index=index,
-            mapping=mapping,
-            elements_per_thread=elements_per_thread,
-            is_read=False,
-            dynamic_vals=dyn_vals,
-            is_contiguous=get_custom(node).is_contiguous_vec(),
-            memory=get_custom(memory),
-            bounds=bounds,
-        )
-
-        _create_vec_read_write(
-            emitter,
-            output_shape,
-            kb_dest,
-            insert_vector,
-            None,
-            start_indices,
-            start_indices_wg,
-            start_indices_th,
-            elements_per_thread,
-            get_custom(memory),
-            mask,
-            offsets_vec,
-        )
+    start_indices, start_indices_wg, start_indices_th = _build_start_indices(
+        emitter, index, dynamic_vals_map_start
+    )
+    _create_vec_read_write(
+        emitter,
+        output_shape,
+        kb_dest,
+        insert_vector,
+        None,
+        start_indices,
+        start_indices_wg,
+        start_indices_th,
+        elements_per_thread,
+        get_custom(memory),
+        mask,
+        node_index=index,
+    )
 
 
 def assume_index_subgroup_uniform(value: Value, element_type: IrType) -> Value:

--- a/wave_lang/kernel/wave/utils/general_utils.py
+++ b/wave_lang/kernel/wave/utils/general_utils.py
@@ -354,24 +354,6 @@ def evaluate_with_assumptions(constraints: list[Constraint], expr: IndexExpr) ->
     return True if any(result.equals(x) for x in facts) else None
 
 
-def _get_start_index(i: IndexSequence | IndexExpr) -> IndexExpr:
-    if isinstance(i, IndexSequence):
-        i = i.start
-
-    return i
-
-
-def _get_start_indices(
-    src_indices: dict[IndexExpr, IndexSequence | IndexExpr],
-) -> list[IndexExpr]:
-    start_indices = []
-    for dim_indexing in src_indices:
-        i = _get_start_index(src_indices[dim_indexing])
-        start_indices.append(i)
-
-    return start_indices
-
-
 def get_fastest_index(indices: dict[IndexExpr, IndexSequence]):
     """
     This function takes in indices of a Node, extract their sizes

--- a/wave_lang/kernel/wave/utils/mapping_utils.py
+++ b/wave_lang/kernel/wave/utils/mapping_utils.py
@@ -274,7 +274,7 @@ def check_is_mapping_contiguous(
         return True
 
     fastest_dim = list(index.keys())[get_fastest_index(index)]
-    index = transform_index_on_mapping(mapping, symbolic_shape, index)
+    index = transform_index_on_mapping(mapping, symbolic_shape, index, is_read=is_read)
 
     idxc = IndexingContext.current()
     strides = strides_from_symbolic_shape(idxc, array_shape, allow_mixed_shapes=True)

--- a/wave_lang/kernel/wave/utils/mapping_utils.py
+++ b/wave_lang/kernel/wave/utils/mapping_utils.py
@@ -269,14 +269,16 @@ def check_is_mapping_contiguous(
     if expected_diff == diff:
         return True
 
+    fastest_dim = list(index.keys())[get_fastest_index(index)]
+    index = transform_index_on_mapping(mapping, symbolic_shape, index)
+
     idxc = IndexingContext.current()
     strides = strides_from_symbolic_shape(idxc, array_shape, allow_mixed_shapes=True)
-    fastest_dim = list(index.keys())[get_fastest_index(index)]
-    prev_offset = _compute_offset([index[d].start for d in symbolic_shape], strides)
+    prev_offset = _compute_offset([index[d] for d in symbolic_shape], strides)
     for i in range(1, elements_per_thread):
         new_index = deepcopy(index)
-        new_index[fastest_dim].start += i
-        offset = _compute_offset([new_index[d].start for d in symbolic_shape], strides)
+        new_index[fastest_dim] += i
+        offset = _compute_offset([new_index[d] for d in symbolic_shape], strides)
         if (offset - prev_offset) != 1:
             return False
 

--- a/wave_lang/kernel/wave/utils/mapping_utils.py
+++ b/wave_lang/kernel/wave/utils/mapping_utils.py
@@ -280,14 +280,18 @@ def check_is_mapping_contiguous(
     new_index = transform_index_on_mapping(
         mapping, symbolic_shape, index, is_read=is_read
     )
-    prev_offset = _compute_offset([new_index[d] for d in symbolic_shape], strides)
+    prev_offset = _compute_offset(
+        [new_index[infer_dim(d)] for d in symbolic_shape], strides
+    )
     for i in range(1, elements_per_thread):
         new_index = deepcopy(index)
         new_index[fastest_dim].start += i
         new_index = transform_index_on_mapping(
             mapping, symbolic_shape, new_index, is_read=is_read
         )
-        offset = _compute_offset([new_index[d] for d in symbolic_shape], strides)
+        offset = _compute_offset(
+            [new_index[infer_dim(d)] for d in symbolic_shape], strides
+        )
         if (offset - prev_offset) != 1:
             return False
 
@@ -303,6 +307,7 @@ def transform_index_on_mapping(
     is_read: bool = True,
 ) -> tuple[IndexExpr, ...]:
     """Transforms the index according to the specified mapping"""
+    symbolic_shape = tuple(infer_dim(d) for d in symbolic_shape)
     if is_read:
         index_mapping = mapping.map_input_indices(symbolic_shape)
     else:

--- a/wave_lang/kernel/wave/utils/mapping_utils.py
+++ b/wave_lang/kernel/wave/utils/mapping_utils.py
@@ -223,9 +223,11 @@ def _compute_offset(indices: list[IndexExpr], strides: list[IndexExpr]) -> Index
     return sum(i * s for i, s in zip(indices, strides))
 
 
-def check_is_dynamic_vals_broadcted(nodes: list[fx.Node]) -> bool:
+def check_is_dynamic_vals_broadcasted(nodes: list[fx.Node]) -> bool:
     for node in nodes:
-        if any(subs_idxc(i.size) > 1 for i in node.index.values()):
+        index = node.index
+        assert index is not None, f"Node {node} has no index"
+        if any(subs_idxc(i.size) > 1 for i in index.values()):
             return False
     return True
 

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -39,6 +39,7 @@ from .analysis.index_sequence_analysis import (
     set_post_expansion_indices,
 )
 from .analysis.partition_strided_operators import (
+    partition_gather_like_ops,
     partition_ops_with_gpr_offsets,
     partition_strided_operators,
 )
@@ -720,6 +721,7 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(partition_ops_with_gpr_offsets, trace, self.constraints),
             partial(partition_strided_operators, trace, self.constraints),
+            partial(partition_gather_like_ops, trace, self.constraints),
             partial(remove_chained_extractslice, trace),
         ]
 

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -721,7 +721,6 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(partition_ops_with_gpr_offsets, trace, self.constraints),
             partial(partition_strided_operators, trace, self.constraints),
-            partial(partition_gather_like_ops, trace, self.constraints),
             partial(remove_chained_extractslice, trace),
         ]
 
@@ -763,6 +762,7 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(add_shared_memory_barriers, trace),
             partial(compute_shared_memory_usage, trace, options.kernel_launch_info),
+            partial(partition_gather_like_ops, trace, self.constraints),
             partial(generate_bounds_exprs, trace, self.constraints),
         ]
 


### PR DESCRIPTION
Move gather/scatter decomposition into dedicated pass. This allows to cleanup a lot of code in read/write handlers and get rid of last traces of `vector.gather`/`scatter` there.