### PR TITLE
Use dynamic values for AtomicOps

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2455,8 +2455,6 @@ def test_no_map_atomic_add():
             ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
         },
         canonicalize=True,
-        print_ir_after="all",
-        print_ir_before="all",
     )
     iterated_gemm = wave_compile(options, iterated_gemm)
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2408,6 +2408,7 @@ def test_debug_log_iteration_dims():
 
 
 @require_e2e
+@require_cdna_2_or_3_or_4
 def test_no_map_atomic_add():
     M = tkl.sym.M
     B = tkl.sym.B
@@ -2470,6 +2471,7 @@ def test_no_map_atomic_add():
 
 
 @require_e2e
+@require_cdna_2_or_3_or_4
 @pytest.mark.parametrize("shape", [(64, 4)])
 def test_dyn_atomic_add(shape):
     # Input sizes

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -23,6 +23,7 @@ from wave_lang.kernel.wave.utils.general_utils import (
     ceildiv,
     check_leaks,
     get_default_scheduling_params,
+    torch_dtype_to_wave,
 )
 from wave_lang.kernel.wave.utils.run_utils import (
     set_default_run_config,
@@ -2404,3 +2405,105 @@ def test_debug_log_iteration_dims():
         assert torch.equal(debug_logs["acc"]["value"][-1], c)
         # Meanwhile the first element should be quite different.
         assert not torch.allclose(debug_logs["acc"]["value"][0], c)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", [(64, 4)])
+def test_atomic_add(shape):
+    # Input sizes
+    NUMEL = tkl.sym.NUMEL
+    NUM_EXPERTS = tkl.sym.NUM_EXPERTS
+
+    constraints: list[tkw.Constraint] = []
+
+    # one workgroup to handle the worload
+    constraints += [tkw.WorkgroupConstraint(NUMEL, NUMEL, 0)]
+    constraints += [tkw.WorkgroupConstraint(NUM_EXPERTS, NUM_EXPERTS, 1)]
+    # one wave to handle the workload
+    constraints += [tkw.WaveConstraint(NUMEL, NUMEL)]
+    constraints += [tkw.WaveConstraint(NUM_EXPERTS, NUM_EXPERTS)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={NUMEL: NUMEL, NUM_EXPERTS: NUM_EXPERTS},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    d0 = tkw.IndexMapping.dynamic_val(0)
+
+    histogram_read = tkw.IndexMapping(
+        num_iterators=1,
+        inputs={NUM_EXPERTS: d0},
+        outputs={NUM_EXPERTS: i},
+        dynamic_val_mappings={NUM_EXPERTS: i},
+    )
+
+    tdtype = torch.int32
+    dtype = torch_dtype_to_wave(tdtype)
+
+    @tkw.wave(constraints)
+    def create_histogram(
+        indices: tkl.Memory[NUMEL, tkl.global_symbols.GLOBAL_ADDRESS_SPACE, dtype],
+        experts: tkl.Memory[
+            NUM_EXPERTS, tkl.global_symbols.GLOBAL_ADDRESS_SPACE, dtype
+        ],
+    ):
+
+        # create a vector of zeros and ones
+        zero_vec = tkl.Register[NUM_EXPERTS, dtype](0)
+        one_vec = tkw.Register[NUM_EXPERTS, dtype](1)
+
+        # read the index in the range [0, NUM_EXPERTS)
+        idx = tkw.read(indices, elements_per_thread=1)
+
+        # allocate shared memory for the histogram
+        shmem = tkw.allocate(
+            shape=(NUM_EXPERTS,),
+            distributed_shape=(NUM_EXPERTS,),
+            dtype=dtype,
+        )
+
+        # initialize the histogram to zero
+        tkw.write(zero_vec, shmem)
+
+        # atomic add 1 to the index read
+        tkw.atomic_add(
+            one_vec,
+            shmem,
+            mapping=histogram_read,
+            mapping_dynamic_vals=(idx,),
+            elements_per_thread=1,
+        )
+
+        # write back the result
+        counts = tkw.read(shmem)
+        tkw.write(
+            counts,
+            experts,
+        )
+
+    num_indices = shape[0]
+    num_experts = shape[1]
+    indices = device_randint(0, num_experts, (num_indices,), dtype=torch.int32)
+    experts = device_zeros((num_experts,), dtype=torch.int32)
+
+    hyperparams = {
+        NUMEL: num_indices,
+        NUM_EXPERTS: num_experts,
+    }
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        minimize_shared_allocs=False,
+    )
+    options = set_default_run_config(options)
+    compiled_fn = wave_compile(options, create_histogram)
+    compiled_fn(indices, experts)
+
+    # verify the result
+    expected_experts = torch.bincount(indices, minlength=num_experts).to(dtype=tdtype)
+    assert_close(experts, expected_experts)
+    assert experts.sum() == num_indices

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2435,7 +2435,7 @@ def test_no_map_atomic_add():
     constraints += [tkw.TilingConstraint(B)]
 
     @tkw.wave(constraints)
-    def iterated_gemm(
+    def atomic_add_one(
         a: tkl.Memory[M, ADDRESS_SPACE, tkl.i32],
         c: tkl.Memory[M, ADDRESS_SPACE_0, tkl.i32],
     ):
@@ -2457,14 +2457,15 @@ def test_no_map_atomic_add():
         },
         canonicalize=True,
     )
-    iterated_gemm = wave_compile(options, iterated_gemm)
+    options = set_default_run_config(options)
+    atomic_add_one = wave_compile(options, atomic_add_one)
 
     # generate random input tensors between -1 and 1
     a = torch.randint(0, 10, (64,), dtype=torch.int32).cuda()
     c = torch.zeros((64,), dtype=torch.int32).cuda()
     a_expected = a.clone() + 1
     a_original = a.clone()
-    iterated_gemm(a, c)
+    atomic_add_one(a, c)
 
     assert torch.equal(c, a_original)
     assert torch.equal(a, a_expected)

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -270,6 +270,16 @@ def atomic_min(
     rhs: "Memory",
     elements_per_thread: Optional[IndexExpr | int] = None,
     mapping: Optional[IndexMapping] = None,
+    mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
+) -> "Register": ...
+
+
+def atomic_add(
+    lhs: "Register",
+    rhs: "Memory",
+    elements_per_thread: Optional[IndexExpr | int] = None,
+    mapping: Optional[IndexMapping] = None,
+    mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
 ) -> "Register": ...
 
 
@@ -1436,6 +1446,7 @@ class AtomicOp(BinaryOpBase, ABC):
 
     elements_per_thread: Optional[Any] = None
     mapping: Optional[IndexMapping] = None
+    mapping_dynamic_vals: tuple[fx.Node, ...] = ()
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:
@@ -1449,6 +1460,12 @@ class AtomicOp(BinaryOpBase, ABC):
     @property
     def memory_type(self) -> "Memory":
         return get_custom(self.lhs).type
+
+
+@define_op("atomic_add")
+@dataclass
+class AtomicAddOp(AtomicOp):
+    pass
 
 
 @define_op("scheduling_group_barrier")

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1436,7 +1436,7 @@ class SchedulingBarrier(CustomOp):
 
 @define_op("atomic_min")
 @dataclass
-class AtomicOp(BinaryOpBase, ABC):
+class AtomicOp(BinaryOpBase):
     """
     Represents an atomic operation in the graph. Takes in Register and
     Memory as inputs and writes the modified value back on to the buffer.

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -57,6 +57,7 @@ from ...ops.wave_ops import (
     apply_expr,
     atan2,
     atomic_min,
+    atomic_add,
     bitcast,
     broadcast,
     cast,
@@ -486,7 +487,7 @@ def handle_atomic_op(op):
         @handle_op(op)
         def handle_generic_atomic(emitter: WaveEmitter, node: fx.Node):
             try:
-                lhs, rhs, elements_per_thread, mapping = node.args
+                (lhs, rhs, elements_per_thread, mapping, dyn_vals, *rest) = node.args
             except ValueError as e:
                 raise ValidationError("Malformed arguments") from e
             lhs = cast_py_value(emitter, lhs)
@@ -528,15 +529,35 @@ def handle_atomic_op(op):
                     mapping, symbolic_shape, start_index
                 )
 
+            # convert registers in dyn_vals to vectors of index type
+            dynamic_vals = tuple(
+                cast_vector(emitter, reg, element_type=IndexType.get())
+                for reg in dyn_vals
+            )
+
+            # helper function to extract the scalar (index) from the vector <1xindex>
+            def extract0(src):
+                static_pos = [0] * src.type.rank
+                return vector_d.extract(
+                    src, static_position=static_pos, dynamic_position=[]
+                )
+
+            # create the dictionary of dynamic symbol and corresponding scalar value
+            dynamic_vals = {
+                sym: extract0(val)
+                for sym, val in zip(mapping.dynamic_val_indices.keys(), dynamic_vals)
+            }
+
             # Get start indices for every element in thread and unroll the op
             atomic_results = []
             keys = list(start_index.keys())
             fastest_dim = get_fastest_index(node.index)
+
             for i in range(elements_per_thread):
                 new_index = copy.deepcopy(start_index)
                 key = keys[fastest_dim]
                 new_index[key] += i
-                start_idx = _build_start_indices(emitter, new_index)
+                start_idx = _build_start_indices(emitter, new_index, dynamic_vals)
                 lhs_val = vector_d.extract(
                     lhs, static_position=[i], dynamic_position=[]
                 )
@@ -896,6 +917,27 @@ def handle_atomic_min(
         value_element_type
     ):
         atomic_kind = arith_d.AtomicRMWKind.mins
+    else:
+        raise ValidationError(
+            f"Found unsupported type in atomic min: {value_element_type}"
+        )
+    result = memref_d.atomic_rmw(atomic_kind, val, buffer, idx)
+    return result
+
+
+@handle_atomic_op(atomic_add)
+def handle_atomic_add(
+    val: Value, buffer: Value, idx: list[Value], options: WaveCompileOptions
+) -> OpResult:
+    value_element_type = get_type_or_element_type(val.type)
+    atomic_kind = None
+    # Only scalars are supported currently
+    if _is_float_type(value_element_type):
+        atomic_kind = arith_d.AtomicRMWKind.addf
+    elif _is_integer_like_type(value_element_type) and _is_signed_or_signless_type(
+        value_element_type
+    ):
+        atomic_kind = arith_d.AtomicRMWKind.addi
     else:
         raise ValidationError(
             f"Found unsupported type in atomic min: {value_element_type}"

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -528,6 +528,10 @@ def handle_atomic_op(op):
                 start_index = transform_index_on_mapping(
                     mapping, symbolic_shape, start_index
                 )
+            else:
+                start_index = {
+                    dim: _get_start_index(v) for dim, v in start_index.items()
+                }
 
             # convert registers in dyn_vals to vectors of index type
             dynamic_vals = tuple(
@@ -543,10 +547,16 @@ def handle_atomic_op(op):
                 )
 
             # create the dictionary of dynamic symbol and corresponding scalar value
-            dynamic_vals = {
-                sym: extract0(val)
-                for sym, val in zip(mapping.dynamic_val_indices.keys(), dynamic_vals)
-            }
+            dynamic_vals = (
+                {
+                    sym: extract0(val)
+                    for sym, val in zip(
+                        mapping.dynamic_val_indices.keys(), dynamic_vals
+                    )
+                }
+                if mapping
+                else {}
+            )
 
             # Get start indices for every element in thread and unroll the op
             atomic_results = []


### PR DESCRIPTION
Add dynamic indexing support for atomic operations in MoE alignment

For the MoE align block, we need support for dynamically indexed values in atomic operations. This change introduces `mapping_dynamic_vals` parameter to AtomicOp and updates the atomic operation handler to support dynamic indexing.

Key changes:
- Add `mapping_dynamic_vals` parameter to atomic operations 
- Update `handle_atomic_op` decorator to process dynamic values
- Convert dynamic registers to index-typed vectors and extract scalar indices
- Pass dynamic value dictionary to `_build_start_indices` for proper index computation

This enables atomic operations like `atomic_add` to use runtime-computed indices from input data