### PR TITLE
hip-iree-target parsing non-colon fix

### DIFF
--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -114,7 +114,9 @@ def get_default_arch() -> str:
 
     # The gcnArchName comes back like gfx90a:sramecc+:xnack.
     colon_pos = gcnArch.find(":")
-    return gcnArch[0:colon_pos]
+    if colon_pos > 0:
+        return gcnArch[0:colon_pos]
+    return gcnArch
 
 
 # Whether to dump the generated MLIR module.


### PR DESCRIPTION
This fixes the parsing of gpu's base name for radeon-gpu's which does not have semicolon and extra features included
the gpu-name full name that is returned by the pytorch method that wave-lang uses:

    torch.cuda.get_device_properties(device).gcnArchName

Depending from the gpu-model, it may or may not include the extra properties after the gpu's base name. For example:
- "gfx90a:sramecc+:xnack", contains extra parameters after the base name "gfx90a" which tell whether or not the NACK and ecc-corrections are enabled for the gfx90a.
- "gfx1100" does not does not show the state of extra features after it's base name.

Current code parsing the gpu's base name expects that the semicolon is always included in the gpu's full name. This causes the parsing of base-name to return base-name with one character missing for the GPU's which does not have semicolon in the full name  For example, gfx1100 was set to options.target property in wave
as a "gfx110" instead of "gfx1100".

This causes then the iree-compiler invocations for gfx1100 for example to fail for unknown gpu-name because the iree-hip-target tried to use was "gfx110" instead of "gfx1100".

iree-compile therock/experimental/rockbuilder/.venv/lib/python3.12/site-packages/iree/compiler/tools/../_mlir_libs/iree-compile - --iree-input-type=auto --iree-vm-bytecode-module-output-format=flatbuffer-binary --iree-hal-target-backends=rocm --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false --iree-hal-target-backends=rocm --iree-vm-bytecode-module-strip-source-map=true --iree-opt-strip-assertions=true --iree-vm-target-truncate-unsupported-floats --iree-hip-target=gfx110

After the fix the iree-hip-target is set to correctly to gfx1100 and compiler will try build the kernel for gfx1100-architecture. (Compilation may then itself still fail for other reasons like trying to use kernels having assembly instructions that are not available on rdna3 for example)