### PR TITLE
Fix bug in update_write_dependencies

### DIFF
--- a/wave_lang/kernel/wave/minimize_global_loads.py
+++ b/wave_lang/kernel/wave/minimize_global_loads.py
@@ -331,13 +331,12 @@ def update_write_dependencies(
 
         replaceable_writes = trace.walk(is_replaceable_write)
         for replaceable_write in replaceable_writes:
-            for user in replaceable_write.users:
+            for user in list(replaceable_write.users):
                 idx = user.args.index([replaceable_write])
                 custom_user = get_custom(user)
                 custom_user.update_arg(idx, writes)
                 if is_shared_read(custom_user) and shared_read_metadata:
                     update_shared_memory_read(writes, shared_read_metadata, custom_user)
-                break
 
     DCE(trace)
 


### PR DESCRIPTION
This PR fixes an issue in update_write_dependencies where once the first user of a replaceable write
was being updates.