### PR TITLE
More code cleanup

### DIFF
--- a/wave_lang/kernel/wave/codegen/emitter.py
+++ b/wave_lang/kernel/wave/codegen/emitter.py
@@ -13,9 +13,9 @@ from typing import Any, Callable, ClassVar, List, Optional, Type
 import sympy
 import torch.fx as fx
 
-from wave_lang.aot.support.ir_utils import (
-    _is_float_type,
-    _is_integer_like_type,
+from .ir_utils import (
+    is_float_type,
+    is_integer_like_type,
 )
 
 from wave_lang.kernel.ops.wave_ops import get_custom
@@ -633,7 +633,7 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
                     operand = stack.pop()
                     _enforce_non_rational(operand, term)
                     operand = _get_ir_value(operand)
-                    if _is_integer_like_type(elem_type):
+                    if is_integer_like_type(elem_type):
                         res = arith_d.maxsi(*_broadcast(res, operand))
                     else:
                         res = arith_d.maximumf(*_broadcast(res, operand))
@@ -649,7 +649,7 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
                     operand = stack.pop()
                     _enforce_non_rational(operand, term)
                     operand = _get_ir_value(operand)
-                    if _is_integer_like_type(elem_type):
+                    if is_integer_like_type(elem_type):
                         res = arith_d.minsi(*_broadcast(res, operand))
                     else:
                         res = arith_d.minimumf(*_broadcast(res, operand))
@@ -712,9 +712,9 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
 
 
 def get_constant_attr(value: Any, element_type: IrType) -> Attribute:
-    if _is_integer_like_type(element_type):
+    if is_integer_like_type(element_type):
         return IntegerAttr.get(element_type, int(value))
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         return FloatAttr.get(element_type, float(value))
     raise CodegenError(f"Cannot create a constant attribute for type `{element_type}`")
 

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -13,10 +13,10 @@ import sympy
 import torch.fx as fx
 import torch.utils._pytree as pytree
 
-from wave_lang.aot.support.ir_utils import (
-    _is_float_type,
-    _is_integer_like_type,
-    _is_signed_or_signless_type,
+from .ir_utils import (
+    is_float_type,
+    is_integer_like_type,
+    is_signed_or_signless_type,
     get_conversion_op,
 )
 from wave_lang.kernel._support.shaped_type import ShapedType
@@ -508,7 +508,7 @@ def handle_atomic_op(op):
                     f"{op}\nGot\n"
                     f"lhs: {lhs_data_type} vs rhs: {rhs_data_type}\n"
                 )
-            if _is_float_type(lhs_data_type):
+            if is_float_type(lhs_data_type):
                 # TODO: To support float types, MLIR LLVM dialect needs to be updated with
                 # float types. LLVM already supports fmin and fmax (https://llvm.org/docs/LangRef.html#atomicrmw-instruction)
                 # and thus atomicrmw operation in MLIR dialect needs to target those instructions with "workgroup" scope.
@@ -669,9 +669,9 @@ def get_fast_math_flags(options: WaveCompileOptions) -> int | None:
 @handle_binary_op(operator.add)
 def handle_add(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.addf(lhs, rhs, fastmath=get_fast_math_flags(options))
-    elif _is_integer_like_type(element_type):
+    elif is_integer_like_type(element_type):
         result = arith_d.addi(lhs, rhs)
     else:
         raise ValidationError(f"Found unhandled operand type for add: {element_type}")
@@ -681,9 +681,9 @@ def handle_add(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(operator.sub)
 def handle_sub(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.subf(lhs, rhs, fastmath=get_fast_math_flags(options))
-    elif _is_integer_like_type(element_type):
+    elif is_integer_like_type(element_type):
         result = arith_d.subi(lhs, rhs)
     else:
         raise ValidationError(f"Found unhandled operand type for sub: {element_type}")
@@ -693,9 +693,9 @@ def handle_sub(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(operator.mul)
 def handle_mul(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.mulf(lhs, rhs, fastmath=get_fast_math_flags(options))
-    elif _is_integer_like_type(element_type):
+    elif is_integer_like_type(element_type):
         result = arith_d.muli(lhs, rhs)
     else:
         raise ValidationError(f"Found unhandled operand type for mul: {element_type}")
@@ -705,7 +705,7 @@ def handle_mul(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(powf)
 def handle_powf(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.powf(lhs, rhs, fastmath=get_fast_math_flags(options))
     else:
         raise ValidationError(f"Found unhandled operand type for powf: {element_type}")
@@ -715,9 +715,9 @@ def handle_powf(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult
 @handle_binary_op(operator.truediv)
 def handle_div(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.divf(lhs, rhs, fastmath=get_fast_math_flags(options))
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.divsi(lhs, rhs)
@@ -729,9 +729,7 @@ def handle_div(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(operator.and_)
 def handle_and(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_integer_like_type(element_type) and _is_signed_or_signless_type(
-        element_type
-    ):
+    if is_integer_like_type(element_type) and is_signed_or_signless_type(element_type):
         result = arith_d.andi(lhs, rhs)
     else:
         raise ValidationError(
@@ -743,9 +741,7 @@ def handle_and(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(operator.or_)
 def handle_or(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_integer_like_type(element_type) and _is_signed_or_signless_type(
-        element_type
-    ):
+    if is_integer_like_type(element_type) and is_signed_or_signless_type(element_type):
         result = arith_d.ori(lhs, rhs)
     else:
         raise ValidationError(
@@ -757,9 +753,9 @@ def handle_or(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([operator.gt, gt])
 def handle_gt(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.OGT, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.sgt, lhs, rhs)
@@ -771,9 +767,9 @@ def handle_gt(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([ge, operator.ge])
 def handle_ge(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.OGE, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.sge, lhs, rhs)
@@ -785,9 +781,9 @@ def handle_ge(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([operator.lt, lt])
 def handle_lt(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.OLT, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.slt, lhs, rhs)
@@ -799,9 +795,9 @@ def handle_lt(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([operator.le, le])
 def handle_le(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.OLE, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.sle, lhs, rhs)
@@ -813,9 +809,9 @@ def handle_le(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([operator.eq, eq])
 def handle_eq(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.OEQ, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.eq, lhs, rhs)
@@ -827,9 +823,9 @@ def handle_eq(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op([operator.ne, ne])
 def handle_ne(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.cmpf(arith_d.CmpFPredicate.ONE, lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.cmpi(arith_d.CmpIPredicate.ne, lhs, rhs)
@@ -841,9 +837,9 @@ def handle_ne(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
 @handle_binary_op(maximum)
 def handle_maximum(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.maximumf(lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.maxsi(lhs, rhs)
@@ -857,9 +853,9 @@ def handle_maximum(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpRes
 @handle_binary_op(minimum)
 def handle_minimum(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.minimumf(lhs, rhs)
-    elif _is_integer_like_type(element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(element_type) and is_signed_or_signless_type(
         element_type
     ):
         result = arith_d.minsi(lhs, rhs)
@@ -877,9 +873,9 @@ def handle_atomic_min(
     value_element_type = get_type_or_element_type(val.type)
     atomic_kind = None
     # Only scalars are supported currently
-    if _is_float_type(value_element_type):
+    if is_float_type(value_element_type):
         atomic_kind = arith_d.AtomicRMWKind.minimumf
-    elif _is_integer_like_type(value_element_type) and _is_signed_or_signless_type(
+    elif is_integer_like_type(value_element_type) and is_signed_or_signless_type(
         value_element_type
     ):
         atomic_kind = arith_d.AtomicRMWKind.mins
@@ -895,7 +891,7 @@ def handle_atomic_min(
 def handle_atan2(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
 
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.atan2(lhs, rhs, fastmath=get_fast_math_flags(options))
     else:
         raise ValidationError(f"Found unhandled operand type for atan2: {element_type}")
@@ -927,7 +923,7 @@ def handle_unary_op(op):
 @handle_unary_op(operator.neg)
 def handle_neg(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = arith_d.negf(source, fastmath=get_fast_math_flags(options))
     else:
         raise ValidationError(
@@ -939,7 +935,7 @@ def handle_neg(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(operator.invert)
 def handle_invert(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_integer_like_type(element_type):
+    if is_integer_like_type(element_type):
         if isinstance(source.type, VectorType):
             assert len(source.type.shape) == 1
             source = vector_d.extract(source, static_position=[0], dynamic_position=[])
@@ -953,7 +949,7 @@ def handle_invert(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(exp)
 def handle_exp(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.exp(source)
     else:
         raise ValidationError(f"Found unhandled operand type for exp: {element_type}")
@@ -963,7 +959,7 @@ def handle_exp(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(exp2)
 def handle_exp2(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.exp2(source)
     else:
         raise ValidationError(f"Found unhandled operand type for exp2: {element_type}")
@@ -973,7 +969,7 @@ def handle_exp2(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(sqrt)
 def handle_sqrt(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         return math_d.sqrt(source)
     raise ValidationError(f"Found unhandled operand type for sqrt: {element_type}")
 
@@ -981,7 +977,7 @@ def handle_sqrt(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(rsqrt)
 def handle_rsqrt(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         return math_d.rsqrt(source)
     raise ValidationError(f"Found unhandled operand type for sqrt: {element_type}")
 
@@ -989,7 +985,7 @@ def handle_rsqrt(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(log2)
 def handle_log2(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.log2(source)
     else:
         raise ValidationError(f"Found unhandled operand type for log2: {element_type}")
@@ -999,7 +995,7 @@ def handle_log2(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(log10)
 def handle_log10(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.log10(source)
     else:
         raise ValidationError(f"Found unhandled operand type for log10: {element_type}")
@@ -1009,7 +1005,7 @@ def handle_log10(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(reciprocal)
 def handle_reciprocal(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         splat_ones = DenseElementsAttr.get_splat(
             source.type, get_constant_attr(1.0, element_type)
         )
@@ -1025,9 +1021,9 @@ def handle_reciprocal(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(abs)
 def handle_abs(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         abs = math_d.absf(source)
-    elif _is_integer_like_type(element_type):
+    elif is_integer_like_type(element_type):
         abs = math_d.absi(source)
     else:
         raise ValidationError(f"Found unhandled operand type for abs: {element_type}")
@@ -1064,70 +1060,67 @@ def handle_tanh_approx(source: Value, options: WaveCompileOptions) -> OpResult:
     """
 
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
-        # a = x (source)
-        a = source
-
-        # s = |a|
-        s = math_d.absf(a)
-
-        # Constants:
-        # Compute log2(e)
-        log2e_val = math.log2(math.e)
-
-        # Compute factor = -2 * log2(e)
-        factor_val = -2.0 * log2e_val
-
-        factor = arith_d.ConstantOp(
-            source.type,
-            DenseElementsAttr.get_splat(
-                source.type, get_constant_attr(factor_val, element_type)
-            ),
-        )
-        # t = factor * s
-        t = arith_d.mulf(s, factor, fastmath=get_fast_math_flags(options))
-
-        # e = exp2(t) using fast hardware intrinsic via math_d
-        e = math_d.exp2(t)
-
-        one = arith_d.ConstantOp(
-            source.type,
-            DenseElementsAttr.get_splat(
-                source.type, get_constant_attr(1.0, element_type)
-            ),
-        )
-
-        # d = e + 1.0
-        d = arith_d.addf(e, one, fastmath=get_fast_math_flags(options))
-
-        # r = reciprocal(d)
-        r = arith_d.divf(one, d, fastmath=get_fast_math_flags(options))
-
-        neg_one = arith_d.ConstantOp(
-            source.type,
-            DenseElementsAttr.get_splat(
-                source.type, get_constant_attr(-1.0, element_type)
-            ),
-        )
-
-        # r = e * (-r) + r  (computes (e-1)/(e+1) without direct division)
-        neg_r = arith_d.mulf(r, neg_one, fastmath=get_fast_math_flags(options))
-        temp = arith_d.mulf(e, neg_r, fastmath=get_fast_math_flags(options))
-        r = arith_d.addf(temp, r, fastmath=get_fast_math_flags(options))
-
-        # # If s < threshold, then r = a (for small x, tanh(x) ~ x)
-        # thresh_val = 4.997253418e-3
-        # thresh = arith_d.ConstantOp(
-        #     source.type,
-        #     DenseElementsAttr.get_splat(source.type, get_constant_attr(thresh_val, element_type))
-        # )
-        # cmp = arith_d.cmpf(arith_d.CmpFPredicate.OLT, s, thresh)
-        # r = arith_d.select(cmp, a, r)
-
-        # Copy the sign of a to r: r = copysign(r, a)
-        result = math_d.copysign(r, a)
-    else:
+    if not is_float_type(element_type):
         raise ValidationError(f"Unhandled operand type for tanh_approx: {element_type}")
+
+    # a = x (source)
+    a = source
+
+    # s = |a|
+    s = math_d.absf(a)
+
+    # Constants:
+    # Compute log2(e)
+    log2e_val = math.log2(math.e)
+
+    # Compute factor = -2 * log2(e)
+    factor_val = -2.0 * log2e_val
+
+    factor = arith_d.ConstantOp(
+        source.type,
+        DenseElementsAttr.get_splat(
+            source.type, get_constant_attr(factor_val, element_type)
+        ),
+    )
+    # t = factor * s
+    t = arith_d.mulf(s, factor, fastmath=get_fast_math_flags(options))
+
+    # e = exp2(t) using fast hardware intrinsic via math_d
+    e = math_d.exp2(t)
+
+    one = arith_d.ConstantOp(
+        source.type,
+        DenseElementsAttr.get_splat(source.type, get_constant_attr(1.0, element_type)),
+    )
+
+    # d = e + 1.0
+    d = arith_d.addf(e, one, fastmath=get_fast_math_flags(options))
+
+    # r = reciprocal(d)
+    r = arith_d.divf(one, d, fastmath=get_fast_math_flags(options))
+
+    neg_one = arith_d.ConstantOp(
+        source.type,
+        DenseElementsAttr.get_splat(source.type, get_constant_attr(-1.0, element_type)),
+    )
+
+    # r = e * (-r) + r  (computes (e-1)/(e+1) without direct division)
+    neg_r = arith_d.mulf(r, neg_one, fastmath=get_fast_math_flags(options))
+    temp = arith_d.mulf(e, neg_r, fastmath=get_fast_math_flags(options))
+    r = arith_d.addf(temp, r, fastmath=get_fast_math_flags(options))
+
+    # # If s < threshold, then r = a (for small x, tanh(x) ~ x)
+    # thresh_val = 4.997253418e-3
+    # thresh = arith_d.ConstantOp(
+    #     source.type,
+    #     DenseElementsAttr.get_splat(source.type, get_constant_attr(thresh_val, element_type))
+    # )
+    # cmp = arith_d.cmpf(arith_d.CmpFPredicate.OLT, s, thresh)
+    # r = arith_d.select(cmp, a, r)
+
+    # Copy the sign of a to r: r = copysign(r, a)
+    result = math_d.copysign(r, a)
+
     return result
 
 
@@ -1189,7 +1182,7 @@ def handle_softsign(emitter: WaveEmitter, node: fx.Node) -> None:
 @handle_unary_op(tanh)
 def handle_tanh(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         result = math_d.tanh(source, fastmath=get_fast_math_flags(options))
     else:
         raise ValidationError(f"Found unhandled operand type for tanh: {element_type}")
@@ -1199,7 +1192,7 @@ def handle_tanh(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(roundeven)
 def handle_roundeven(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         roundeven = math_d.roundeven(source)
     else:
         raise ValidationError(
@@ -1211,7 +1204,7 @@ def handle_roundeven(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(sin)
 def handle_sin(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         sine_of_source = math_d.sin(source)
     else:
         raise ValidationError(f"Found unhandled operand type for sine: {element_type}")
@@ -1221,7 +1214,7 @@ def handle_sin(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(sinh)
 def handle_sin(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         sinh_of_source = math_d.sinh(source)
     else:
         raise ValidationError(f"Found unhandled operand type for sinh: {element_type}")
@@ -1231,7 +1224,7 @@ def handle_sin(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(cos)
 def handle_cos(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         res = math_d.cos(source)
     else:
         raise ValidationError(f"Found unhandled operand type for cos: {element_type}")
@@ -1241,7 +1234,7 @@ def handle_cos(source: Value, options: WaveCompileOptions) -> OpResult:
 @handle_unary_op(cbrt)
 def handle_cbrt(source: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(source.type)
-    if _is_float_type(element_type):
+    if is_float_type(element_type):
         res = math_d.cbrt(source)
     else:
         raise ValidationError(

--- a/wave_lang/kernel/wave/codegen/ir_utils.py
+++ b/wave_lang/kernel/wave/codegen/ir_utils.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from functools import partial
+
+
+from wave_lang.support.ir_imports import (
+    BF16Type,
+    F16Type,
+    F32Type,
+    F64Type,
+    Float4E2M1FNType,
+    Float6E2M3FNType,
+    Float8E4M3FNType,
+    Float8E4M3FNUZType,
+    Float8E5M2FNUZType,
+    Float8E5M2Type,
+    Float8E8M0FNUType,
+    FloatAttr,
+    IndexType,
+    IntegerType,
+    RankedTensorType,
+    VectorType,
+    arith_d,
+    vector_d,
+)
+
+###############################################################################
+# Helpers
+###############################################################################
+
+
+# API name  inspired by mlir/python/mlir/dialects/_arith_ops_ext.py
+def is_float_type(type):
+    return isinstance(
+        type,
+        (
+            BF16Type,
+            F16Type,
+            F32Type,
+            F64Type,
+            Float8E4M3FNType,
+            Float8E4M3FNUZType,
+            Float8E5M2Type,
+            Float8E5M2FNUZType,
+            Float8E8M0FNUType,
+            Float8E8M0FNUType,
+            Float6E2M3FNType,
+            Float4E2M1FNType,
+        ),
+    )
+
+
+def is_index_type(type):
+    return isinstance(type, (IndexType))
+
+
+def is_integer_like_type(type):
+    return isinstance(type, (IntegerType, IndexType))
+
+
+def is_signed_or_signless_type(type):
+    return getattr(type, "is_signed", False) or getattr(type, "is_signless", False)
+
+
+def get_conversion_op(src_elem_type, dst_elem_type, fastmath=None):
+    is_src_float = is_float_type(src_elem_type)
+    is_dst_float = is_float_type(dst_elem_type)
+    is_src_int = is_integer_like_type(src_elem_type)
+    is_dst_int = is_integer_like_type(dst_elem_type)
+    if (
+        is_src_int
+        and is_dst_int
+        and (is_index_type(src_elem_type) or is_index_type(dst_elem_type))
+    ):
+        conversion_op = arith_d.index_cast
+        return conversion_op
+    # Special case of casting bool (IntergerType(i1) to float) so that when value is true is casted to 1 and when value is false to cast to 0
+    if (
+        isinstance(src_elem_type, IntegerType)
+        and src_elem_type.width == 1
+        and is_dst_float
+    ):
+
+        def bool_to_float_select(dst_type, vector_src):
+
+            # scalar constants
+            one_const = arith_d.constant(
+                dst_elem_type, FloatAttr.get(dst_elem_type, 1.0)
+            )
+            zero_const = arith_d.constant(
+                dst_elem_type, FloatAttr.get(dst_elem_type, 0.0)
+            )
+
+            # Broadcast to vector if the destination is a vector
+            if VectorType.isinstance(dst_type):
+                one = vector_d.broadcast(dst_type, one_const)
+                zero = vector_d.broadcast(dst_type, zero_const)
+            elif RankedTensorType.isinstance(dst_type):
+                raise NotImplementedError(
+                    "RankedTensorType broadcasting is not implemented for casting bool to float."
+                )
+            else:
+                one = one_const
+                zero = zero_const
+
+            return arith_d.select(vector_src, one, zero)
+
+        # return caller function for get_conversion op
+        return bool_to_float_select
+
+    conversion_ops = {
+        (True, False): arith_d.fptosi,
+        (False, True): arith_d.sitofp,
+    }
+
+    float_cast_ops = {
+        True: arith_d.extf,
+        False: arith_d.truncf,
+    }
+
+    int_cast_ops = {
+        True: arith_d.extsi,
+        False: arith_d.trunci,
+    }
+
+    if is_src_float and is_dst_float:
+        conversion_op = float_cast_ops[src_elem_type.width < dst_elem_type.width]
+        conversion_op = partial(conversion_op, fastmath=fastmath)
+    elif is_src_int and is_dst_int:
+        # Currently extsi/trunci do not support fast_math option.
+        conversion_op = int_cast_ops[src_elem_type.width < dst_elem_type.width]
+    else:
+        conversion_op = conversion_ops[(is_src_float, is_dst_float)]
+    return conversion_op

--- a/wave_lang/kernel/wave/codegen/read_write.py
+++ b/wave_lang/kernel/wave/codegen/read_write.py
@@ -32,8 +32,8 @@ from wave_lang.support.ir_imports import (
     func_d,
     Operation,
 )
-from wave_lang.aot.support.ir_utils import (
-    _is_float_type,
+from .ir_utils import (
+    is_float_type,
 )
 
 from ..._support.indexing import IndexExpr, IndexingContext, IndexSequence, IndexSymbol
@@ -1164,7 +1164,7 @@ def _handle_scatter_op(
 def handle_scatter_add(emitter: WaveEmitter, node: fx.Node):
     register_src = cast_py_value(emitter, node.args[0])
     src_data_type = get_type_or_element_type(register_src.ir_value.type)
-    if _is_float_type(src_data_type):
+    if is_float_type(src_data_type):
         rmw_kind = arith_d.AtomicRMWKind.addf
     else:
         rmw_kind = arith_d.AtomicRMWKind.addi


### PR DESCRIPTION
Move IR utils to codegen folder to get rid of `aot` dependency. Will remove `aot` in follow-up PR.