### PR TITLE
Add initial support for RDNA 4 `wmma`

### DIFF
--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -33,6 +33,10 @@ require_cdna_3_or_4 = pytest.mark.skipif(
         get_default_arch()
     ),
 )
+require_rdna4 = pytest.mark.skipif(
+    not get_default_arch().startswith("gfx12"),
+    reason=f"Default architecture is not RDNA4, default architecture is {get_default_arch()}",
+)
 
 # Add test shapes for validation and performance testing.
 perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -204,9 +204,7 @@ def testPureGemm(
 # the RDNA 4 ISA documentation
 @pytest.mark.parametrize(
     "mfma_variant",
-    [
-        MMAType.F32_16x16x16_F16,
-    ],
+    [MMAType.RDNA4_WAVE32_F32_16x16x16_F16, MMAType.RDNA4_WAVE32_F32_16x16x16_BF16],
 )
 @pytest.mark.parametrize("datatype", [torch.float16, torch.bfloat16])
 def test_rdna4_wmma(

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -200,7 +200,8 @@ def testPureGemm(
     ],
 )
 @param_bool("dynamic_dims", "dyn")
-# TODO(paulzzy): Not an exhaustive list of `wmma` instructions in RDNA 4
+# TODO(paulzzy): Not an exhaustive list of `wmma` instructions in RDNA 4, see
+# the RDNA 4 ISA documentation
 @pytest.mark.parametrize(
     "mfma_variant",
     [

--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -19,6 +19,7 @@ from ..._support.indexing import IndexSequence, IndexSymbol
 from ..._support.tracing import CapturedTrace
 from ...lang.global_symbols import *
 from ...ops.wave_ops import (
+    MMA,
     Allocate,
     AtomicOp,
     BinaryPyOp,
@@ -27,7 +28,6 @@ from ...ops.wave_ops import (
     GetResult,
     IterArg,
     Iterate,
-    MMA,
     MMABase,
     NestedRegionOp,
     Output,
@@ -68,7 +68,6 @@ from ..utils.print_utils import (
     print_trace,
     try_apply_pass,
 )
-from ..compile_options import WaveCompileOptions
 
 logger = get_logger("wave.index_sequence_analysis")
 
@@ -89,9 +88,9 @@ def combine_derived_index(
         if old_idx == new_idx:
             continue
 
-        assert (
-            old_idx.start == 0 or old_idx.start == old_idx.start
-        ), f"Index conflict: {old_idx} and {new_idx}"
+        assert old_idx.start == 0 or old_idx.start == old_idx.start, (
+            f"Index conflict: {old_idx} and {new_idx}"
+        )
         new_index[dim] = new_idx
 
     return new_index
@@ -173,12 +172,12 @@ def resolve_scaled_indices(trace):
             if scale_type == ScalingType.DIVIDE:
                 # Index can be shared between multiple users, so we copy before modifying.
                 dim_index = deepcopy(source.index[dim])
-                assert (
-                    dim_index.size % scale_factor == 0
-                ), f"Size({dim_index.size}) needs to be divisible by scale ({scale_factor})."
-                assert (
-                    source.vector_shapes[dim] % scale_factor == 0
-                ), "Expected vector_shape to be divisble by scale."
+                assert dim_index.size % scale_factor == 0, (
+                    f"Size({dim_index.size}) needs to be divisible by scale ({scale_factor})."
+                )
+                assert source.vector_shapes[dim] % scale_factor == 0, (
+                    "Expected vector_shape to be divisble by scale."
+                )
                 dim_index.start = dim_expr.subs({dim: dim_index.start})
                 dim_index.size = int(dim_expr.subs({dim: dim_index.size}))
                 source.index[dim] = dim_index
@@ -187,9 +186,9 @@ def resolve_scaled_indices(trace):
                 )
                 custom = get_custom(source)
                 if isinstance(custom, (Read, Write)):
-                    assert (
-                        custom.elements_per_thread % scale_factor == 0
-                    ), "elem per thread needs to be divisble by scale."
+                    assert custom.elements_per_thread % scale_factor == 0, (
+                        "elem per thread needs to be divisble by scale."
+                    )
                     scaled_elem_per_thread = int(
                         custom.elements_per_thread / scale_factor
                     )
@@ -223,9 +222,9 @@ def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
         if not custom.vector_shapes:
             # If vector_shapes is not set, see if it can be derived from the hardware constraints.
             hw_constraint = get_hardware_constraint(constraints)
-            assert (
-                hw_constraint.vector_shapes
-            ), f"Vector shapes for node {custom.fx_node} cannot be derived from hardware constraints: {custom}"
+            assert hw_constraint.vector_shapes, (
+                f"Vector shapes for node {custom.fx_node} cannot be derived from hardware constraints: {custom}"
+            )
 
             update_vector_shapes = [
                 dim for dim in custom.index if dim in hw_constraint.vector_shapes
@@ -234,15 +233,14 @@ def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
                 custom.vector_shapes = {}
                 for dim in update_vector_shapes:
                     custom.vector_shapes[dim] = hw_constraint.vector_shapes[dim]
-        assert (
-            custom.vector_shapes
-        ), f"Vector shapes not set for node {custom.fx_node}: {custom}"
+        assert custom.vector_shapes, (
+            f"Vector shapes not set for node {custom.fx_node}: {custom}"
+        )
 
 
 def set_node_indices(
     trace: CapturedTrace,
     constraints: list[Constraint],
-    options: WaveCompileOptions,
     print_ir_before: Sequence[str] = [],
     print_ir_after: Sequence[str] = [],
 ):
@@ -270,7 +268,6 @@ def set_node_indices(
                 constraints,
                 mma_mapping,
                 trace,
-                options,
             )
         ]
     elif reduce_mapping := get_reduce_mapping(trace, constraints):
@@ -388,7 +385,6 @@ def populate_mma_source_indices(
     node: MMA,
     mma_index: dict[MMA, dict[IndexSymbol, int]],
     hardware_constraint: HardwareConstraint,
-    options: WaveCompileOptions,
 ):
     """
     Initialize the sources with the LHS, RHS, ACC and MMA node
@@ -399,7 +395,7 @@ def populate_mma_source_indices(
     mapping = mma_index[node]
     for dim, dim_index in mapping.items():
         index[dim] = hardware_constraint.apply_mma_mapping(
-            dim, dim_index, node.mma_type, options
+            dim, dim_index, node.mma_type
         )
     node.index = combine_indices(node.index, index)
     lhs_tuple = (
@@ -735,7 +731,6 @@ def set_thread_dependent_index_from_mma(
     constraints: Sequence[Constraint],
     mma_mapping: dict[MMABase, dict[IndexSymbol, int]],
     trace: CapturedTrace,
-    options: WaveCompileOptions,
 ):
     """
     Set the thread dependent index based on the hardware constraint.
@@ -759,7 +754,7 @@ def set_thread_dependent_index_from_mma(
             )
         elif isinstance(source, MMA):
             new_sources = populate_mma_source_indices(
-                source, mma_mapping, hardware_constraint, options
+                source, mma_mapping, hardware_constraint
             )
         else:
             assert False, "Invalid MMA type"
@@ -838,9 +833,9 @@ def get_reduce_mapping(
         # threads per wave and the vector size.
         threads_per_wave = hardware_constraint.threads_per_wave
         vector_size = hardware_constraint.vector_shapes[dim]
-        assert (
-            vector_size % threads_per_wave == 0
-        ), f"Vector size {dim}={vector_size} must be divisible by threads per wave {threads_per_wave}"
+        assert vector_size % threads_per_wave == 0, (
+            f"Vector size {dim}={vector_size} must be divisible by threads per wave {threads_per_wave}"
+        )
         elements_per_thread = vector_size // threads_per_wave
         stride = compute_stride(
             custom.indexing_dims, hardware_constraint.vector_shapes, dim
@@ -855,9 +850,9 @@ def get_reduce_mapping(
                 custom.indexing_dims, hardware_constraint.vector_shapes, dim
             )
             wg_constraint = [x for x in workgroup_constraints if x.dim == dim]
-            assert (
-                len(wg_constraint) <= 1
-            ), f"Multiple workgroup constraints for dimension {dim}"
+            assert len(wg_constraint) <= 1, (
+                f"Multiple workgroup constraints for dimension {dim}"
+            )
             if wg_constraint:
                 workgroup_dim = wg_constraint[0].workgroup_dim
             else:

--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -88,9 +88,9 @@ def combine_derived_index(
         if old_idx == new_idx:
             continue
 
-        assert old_idx.start == 0 or old_idx.start == old_idx.start, (
-            f"Index conflict: {old_idx} and {new_idx}"
-        )
+        assert (
+            old_idx.start == 0 or old_idx.start == old_idx.start
+        ), f"Index conflict: {old_idx} and {new_idx}"
         new_index[dim] = new_idx
 
     return new_index
@@ -172,12 +172,12 @@ def resolve_scaled_indices(trace):
             if scale_type == ScalingType.DIVIDE:
                 # Index can be shared between multiple users, so we copy before modifying.
                 dim_index = deepcopy(source.index[dim])
-                assert dim_index.size % scale_factor == 0, (
-                    f"Size({dim_index.size}) needs to be divisible by scale ({scale_factor})."
-                )
-                assert source.vector_shapes[dim] % scale_factor == 0, (
-                    "Expected vector_shape to be divisble by scale."
-                )
+                assert (
+                    dim_index.size % scale_factor == 0
+                ), f"Size({dim_index.size}) needs to be divisible by scale ({scale_factor})."
+                assert (
+                    source.vector_shapes[dim] % scale_factor == 0
+                ), "Expected vector_shape to be divisble by scale."
                 dim_index.start = dim_expr.subs({dim: dim_index.start})
                 dim_index.size = int(dim_expr.subs({dim: dim_index.size}))
                 source.index[dim] = dim_index
@@ -186,9 +186,9 @@ def resolve_scaled_indices(trace):
                 )
                 custom = get_custom(source)
                 if isinstance(custom, (Read, Write)):
-                    assert custom.elements_per_thread % scale_factor == 0, (
-                        "elem per thread needs to be divisble by scale."
-                    )
+                    assert (
+                        custom.elements_per_thread % scale_factor == 0
+                    ), "elem per thread needs to be divisble by scale."
                     scaled_elem_per_thread = int(
                         custom.elements_per_thread / scale_factor
                     )
@@ -222,9 +222,9 @@ def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
         if not custom.vector_shapes:
             # If vector_shapes is not set, see if it can be derived from the hardware constraints.
             hw_constraint = get_hardware_constraint(constraints)
-            assert hw_constraint.vector_shapes, (
-                f"Vector shapes for node {custom.fx_node} cannot be derived from hardware constraints: {custom}"
-            )
+            assert (
+                hw_constraint.vector_shapes
+            ), f"Vector shapes for node {custom.fx_node} cannot be derived from hardware constraints: {custom}"
 
             update_vector_shapes = [
                 dim for dim in custom.index if dim in hw_constraint.vector_shapes
@@ -233,9 +233,9 @@ def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
                 custom.vector_shapes = {}
                 for dim in update_vector_shapes:
                     custom.vector_shapes[dim] = hw_constraint.vector_shapes[dim]
-        assert custom.vector_shapes, (
-            f"Vector shapes not set for node {custom.fx_node}: {custom}"
-        )
+        assert (
+            custom.vector_shapes
+        ), f"Vector shapes not set for node {custom.fx_node}: {custom}"
 
 
 def set_node_indices(
@@ -833,9 +833,9 @@ def get_reduce_mapping(
         # threads per wave and the vector size.
         threads_per_wave = hardware_constraint.threads_per_wave
         vector_size = hardware_constraint.vector_shapes[dim]
-        assert vector_size % threads_per_wave == 0, (
-            f"Vector size {dim}={vector_size} must be divisible by threads per wave {threads_per_wave}"
-        )
+        assert (
+            vector_size % threads_per_wave == 0
+        ), f"Vector size {dim}={vector_size} must be divisible by threads per wave {threads_per_wave}"
         elements_per_thread = vector_size // threads_per_wave
         stride = compute_stride(
             custom.indexing_dims, hardware_constraint.vector_shapes, dim
@@ -850,9 +850,9 @@ def get_reduce_mapping(
                 custom.indexing_dims, hardware_constraint.vector_shapes, dim
             )
             wg_constraint = [x for x in workgroup_constraints if x.dim == dim]
-            assert len(wg_constraint) <= 1, (
-                f"Multiple workgroup constraints for dimension {dim}"
-            )
+            assert (
+                len(wg_constraint) <= 1
+            ), f"Multiple workgroup constraints for dimension {dim}"
             if wg_constraint:
                 workgroup_dim = wg_constraint[0].workgroup_dim
             else:

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -75,8 +75,8 @@ from ...ops.wave_ops import (
     gt,
     iterate,
     le,
-    log10,
     log2,
+    log10,
     lt,
     maximum,
     minimum,
@@ -114,7 +114,6 @@ from ..scheduling.resources import get_scheduling_mask
 from ..utils.classes import ShuffleMode
 from ..utils.general_utils import get_fastest_index
 from ..utils.mapping_utils import transform_index_on_mapping
-from ..utils.run_utils import get_default_arch
 from ..utils.symbol_utils import subs_idxc
 from .emitter import (
     WaveEmitter,
@@ -400,7 +399,7 @@ def handle_mma(emitter: WaveEmitter, node: fx.Node):
     m, n, k = hardware_constraints[0].mma_matrix_shapes(mma_type)
     result = (
         emit_wmma(acc, values)
-        if get_default_arch().startswith("gfx12")
+        if emitter.options.target.startswith("gfx12")
         else emit_mfma(m, n, k, acc, values)
     )
     emitter.bind_node_proxy(node, IRProxyValue(result))

--- a/wave_lang/kernel/wave/constraints.py
+++ b/wave_lang/kernel/wave/constraints.py
@@ -42,6 +42,7 @@ Values: 0xABCD where:
   * 3 = 8-bit float (incl. f8E5M2, f8E4M3, and "FNUZ" variants)
   * 4 = MX float (incl. F8E5M2, F8E4M3FN, F6E2M3FN, F6E3M2FN, F4E2M1FN variants)
   * C = 8-bit integer (any signedness)
+  * D = 4-bit integer (any signedness)
 * D enumerates intrinsics that share the same 0xABC* bits.
 """
 
@@ -74,16 +75,16 @@ class MMAType(Enum):
     RDNA4_WAVE32_F16_16x16x16_F16 = 0x1922
     RDNA4_WAVE32_BF16_16x16x16_BF16 = 0x1923
     RDNA4_WAVE32_I32_16x16x16_I8 = 0x19C0
-    RDNA4_WAVE32_I32_16x16x16_I4 = 0x19C1
-    RDNA4_WAVE32_I32_16x16x32_I4 = 0x19C2
+    RDNA4_WAVE32_I32_16x16x16_I4 = 0x19D0
+    RDNA4_WAVE32_I32_16x16x32_I4 = 0x19D1
 
     RDNA4_WAVE64_F32_16x16x16_F16 = 0x1924
     RDNA4_WAVE64_F32_16x16x16_BF16 = 0x1925
     RDNA4_WAVE64_F16_16x16x16_F16 = 0x1926
     RDNA4_WAVE64_BF16_16x16x16_BF16 = 0x1927
     RDNA4_WAVE64_I32_16x16x16_I8 = 0x19C3
-    RDNA4_WAVE64_I32_16x16x16_I4 = 0x19C4
-    RDNA4_WAVE64_I32_16x16x32_I4 = 0x19C5
+    RDNA4_WAVE64_I32_16x16x16_I4 = 0x19D0
+    RDNA4_WAVE64_I32_16x16x32_I4 = 0x19D1
 
 
 class ScaledMMAType(Enum):
@@ -640,9 +641,9 @@ class HardwareConstraint(Constraint):
             case _:
                 raise ValueError("Unsupported MMA type")
 
-        assert isinstance(
-            constraint_index, MMAOperand
-        ), f"Invalid MMA operand {constraint_index}"
+        assert isinstance(constraint_index, MMAOperand), (
+            f"Invalid MMA operand {constraint_index}"
+        )
         return IndexSequence(
             offset[constraint_index.value],
             size[constraint_index.value],
@@ -859,9 +860,9 @@ class WaveConstraint(DistributionConstraint):
         # all threads in a wave are handled in wg_dim_0.
         if workgroup_constraint.workgroup_dim == 0:
             self.wave_id = floor(self.wave_id / hardware_constraint.threads_per_wave)
-        assert (
-            old_wave_id is None or self.wave_id == old_wave_id
-        ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
+        assert old_wave_id is None or self.wave_id == old_wave_id, (
+            f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
+        )
         self.wg_constraint = workgroup_constraint
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:

--- a/wave_lang/kernel/wave/templates/gemm.py
+++ b/wave_lang/kernel/wave/templates/gemm.py
@@ -22,6 +22,7 @@ def get_gemm_kernel(
     dynamic_dims: bool | tuple[bool, bool, bool],
     mfma_variant: MMAType,
     dtype: torch.dtype = torch.float16,
+    threads_per_wave: int = 64,
 ):
     if not isinstance(dynamic_dims, Sequence):
         dynamic_dims = (dynamic_dims,) * 3
@@ -44,7 +45,9 @@ def get_gemm_kernel(
     constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
 
-    constraints += [tkw.HardwareConstraint(threads_per_wave=64, mma_type=mfma_variant)]
+    constraints += [
+        tkw.HardwareConstraint(threads_per_wave=threads_per_wave, mma_type=mfma_variant)
+    ]
 
     # With dynamic dimensions, we need to add an assumption on how big
     # the iterate dimension is to determine whether we can schedule or not.

--- a/wave_lang/kernel/wave/utils/general_utils.py
+++ b/wave_lang/kernel/wave/utils/general_utils.py
@@ -6,9 +6,9 @@
 import functools
 import glob
 import os
+import warnings
 from collections import deque
 from typing import Any, Callable, Optional, Sequence
-import warnings
 
 import sympy
 import torch
@@ -31,9 +31,9 @@ from ...ops.wave_ops import (
 from ..assumptions import Assumption
 from ..constraints import (
     Constraint,
-    IteratorBindings,
     DistributionConstraint,
     HardwareConstraint,
+    IteratorBindings,
     TilingConstraint,
     WorkgroupConstraint,
 )

--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -3,8 +3,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from __future__ import annotations
-
 import functools
 import os
 from itertools import chain
@@ -13,6 +11,8 @@ from typing import Any, Callable
 import torch
 
 from wave_lang.kernel.lang import IndexSymbol
+
+from ..compile_options import WaveCompileOptions
 
 
 @functools.lru_cache

--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -3,16 +3,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations
+
 import functools
 import os
 from itertools import chain
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 
 from wave_lang.kernel.lang import IndexSymbol
 
-from ..compile_options import WaveCompileOptions
+# Avoid circular import
+if TYPE_CHECKING:
+    from ..compile_options import WaveCompileOptions
 
 
 @functools.lru_cache

--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -8,15 +8,11 @@ from __future__ import annotations
 import functools
 import os
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 import torch
 
 from wave_lang.kernel.lang import IndexSymbol
-
-# Avoid circular import
-if TYPE_CHECKING:
-    from ..compile_options import WaveCompileOptions
 
 
 @functools.lru_cache

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -294,28 +294,28 @@ class LaunchableWave(Launchable):
             wave_size = wave_map[dim] if dim in wave_map else None
             workgroup_size = workgroup_map[dim] if dim in workgroup_map else None
 
-            assert workgroup_size is not None, (
-                f"expected non-empty tile size in `WorkgroupConstraint` for dimension {dim}"
-            )
+            assert (
+                workgroup_size is not None
+            ), f"expected non-empty tile size in `WorkgroupConstraint` for dimension {dim}"
 
             if wave_size is None:
                 continue
 
-            assert wave_size > 0, (
-                f"expected non-zero tile in `WaveConstraint` for dimension {dim}"
-            )
+            assert (
+                wave_size > 0
+            ), f"expected non-zero tile in `WaveConstraint` for dimension {dim}"
 
-            assert workgroup_size > 0, (
-                f"expected non-zero tile in `WorkgroupConstraint` for dimension {dim}"
-            )
+            assert (
+                workgroup_size > 0
+            ), f"expected non-zero tile in `WorkgroupConstraint` for dimension {dim}"
 
-            assert workgroup_size >= wave_size, (
-                f"expected workgroup tile size to be the same or larger than wavefront tile size for dimension {dim}"
-            )
+            assert (
+                workgroup_size >= wave_size
+            ), f"expected workgroup tile size to be the same or larger than wavefront tile size for dimension {dim}"
 
-            assert workgroup_size % wave_size == 0, (
-                f"expected workgroup tile size to be an integral multiple of wavefront tile size for dimension {dim}"
-            )
+            assert (
+                workgroup_size % wave_size == 0
+            ), f"expected workgroup tile size to be an integral multiple of wavefront tile size for dimension {dim}"
 
         workgroup_dims = set(
             [cons.workgroup_dim for cons in self.workgroup_constraints]
@@ -323,9 +323,9 @@ class LaunchableWave(Launchable):
 
         min_dim = min(workgroup_dims)
         max_dim = max(workgroup_dims)
-        assert max_dim - min_dim + 1 == len(workgroup_dims), (
-            "expected contiguous indices for `workgroup_dim` field in workgroup constraints"
-        )
+        assert max_dim - min_dim + 1 == len(
+            workgroup_dims
+        ), "expected contiguous indices for `workgroup_dim` field in workgroup constraints"
 
         return
 

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -294,28 +294,28 @@ class LaunchableWave(Launchable):
             wave_size = wave_map[dim] if dim in wave_map else None
             workgroup_size = workgroup_map[dim] if dim in workgroup_map else None
 
-            assert (
-                workgroup_size is not None
-            ), f"expected non-empty tile size in `WorkgroupConstraint` for dimension {dim}"
+            assert workgroup_size is not None, (
+                f"expected non-empty tile size in `WorkgroupConstraint` for dimension {dim}"
+            )
 
             if wave_size is None:
                 continue
 
-            assert (
-                wave_size > 0
-            ), f"expected non-zero tile in `WaveConstraint` for dimension {dim}"
+            assert wave_size > 0, (
+                f"expected non-zero tile in `WaveConstraint` for dimension {dim}"
+            )
 
-            assert (
-                workgroup_size > 0
-            ), f"expected non-zero tile in `WorkgroupConstraint` for dimension {dim}"
+            assert workgroup_size > 0, (
+                f"expected non-zero tile in `WorkgroupConstraint` for dimension {dim}"
+            )
 
-            assert (
-                workgroup_size >= wave_size
-            ), f"expected workgroup tile size to be the same or larger than wavefront tile size for dimension {dim}"
+            assert workgroup_size >= wave_size, (
+                f"expected workgroup tile size to be the same or larger than wavefront tile size for dimension {dim}"
+            )
 
-            assert (
-                workgroup_size % wave_size == 0
-            ), f"expected workgroup tile size to be an integral multiple of wavefront tile size for dimension {dim}"
+            assert workgroup_size % wave_size == 0, (
+                f"expected workgroup tile size to be an integral multiple of wavefront tile size for dimension {dim}"
+            )
 
         workgroup_dims = set(
             [cons.workgroup_dim for cons in self.workgroup_constraints]
@@ -323,9 +323,9 @@ class LaunchableWave(Launchable):
 
         min_dim = min(workgroup_dims)
         max_dim = max(workgroup_dims)
-        assert max_dim - min_dim + 1 == len(
-            workgroup_dims
-        ), "expected contiguous indices for `workgroup_dim` field in workgroup constraints"
+        assert max_dim - min_dim + 1 == len(workgroup_dims), (
+            "expected contiguous indices for `workgroup_dim` field in workgroup constraints"
+        )
 
         return
 
@@ -630,7 +630,6 @@ class LaunchableWave(Launchable):
                 set_node_indices,
                 trace,
                 self.constraints,
-                options,
                 print_ir_before,
                 print_ir_after,
             ),

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -48,20 +48,20 @@ from .codegen import WaveEmitter
 from .compile_options import WaveCompileOptions
 from .constraints import (
     Constraint,
+    DeviceConstraint,
     HardwareConstraint,
     ReorderingConstraint,
     TilingConstraint,
     WaveConstraint,
     WorkgroupConstraint,
-    DeviceConstraint,
-    get_grid_shape,
     get_device_layout,
+    get_grid_shape,
 )
 from .construct_index_mapping import construct_index_mapping
 from .debug_log_hoist import (
+    DebugArgInfo,
     debug_log_hoist,
     debug_log_write_replace,
-    DebugArgInfo,
 )
 from .decompose_dot_mma import decompose_dot_mma
 from .decompose_reduce_ops import decompose_reduce_ops
@@ -81,7 +81,7 @@ from .scheduling.schedule import schedule_graph
 from .shared_memory_indexing import apply_shared_memory_indexing_corrections
 from .symbolic_constraints import SymbolicAlias
 from .type_inference import infer_types
-from .utils.compile_utils import canonicalize_module, apply_transform
+from .utils.compile_utils import apply_transform, canonicalize_module
 from .utils.general_utils import (
     delinearize_index,
     get_hardware_constraint,
@@ -96,7 +96,7 @@ from .utils.graph_utils import (
 from .utils.print_utils import print_trace, try_apply_pass
 
 # Utils
-from .utils.symbol_utils import safe_subs, subs_idxc, get_induction_symbol
+from .utils.symbol_utils import get_induction_symbol, safe_subs, subs_idxc
 from .workgroup_reordering import reorder_workgroups
 
 logger = logging.getLogger(__name__)
@@ -630,6 +630,7 @@ class LaunchableWave(Launchable):
                 set_node_indices,
                 trace,
                 self.constraints,
+                options,
                 print_ir_before,
                 print_ir_after,
             ),


### PR DESCRIPTION
A first step towards proper Radeon support!

Ideally `MMAType` would be parameterized by M, N, K, input/output dtypes, architecture, etc. (maybe similar to `GenericDot`?) rather than the enum currently used. This would make it more flexible to changes, e.g. the architecture isn't specified in the enum name. Should be introduced in a subsequent commit.

The `wmma` test doesn't mean much without an RDNA 4 CI machine, but it does pass on my Navi 48. :)