### PR TITLE
add locations to placeholder and output nodes based on kernel location

### DIFF
--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -21,6 +21,7 @@ from wave_lang.support.ir_imports import Context, Module, Operation
 
 from .._support.indexing import IndexExpr, IndexingContext, index_symbol
 from .._support.location_config import LocationCaptureConfig
+from .._support.location import add_placeholder_locations
 from .._support.tracing import (
     CapturedTrace,
     CompiledContext,
@@ -350,6 +351,7 @@ class LaunchableWave(Launchable):
             with region_graph.subtracer() as subtracer:
                 root_name, _ = subtracer.trace(self._f)
                 trace = CapturedTrace(region_graph, root_name)
+                trace = add_placeholder_locations(trace, self._f)
 
         return trace
 


### PR DESCRIPTION
This allows the initial trace of a kernel to have locations on 100% of nodes, at least for examples that I'm looking at so far.