### PR TITLE
Add trace to WaveKernel even when only compile to MLIR

### DIFF
--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -369,6 +369,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
                 None,
                 bound_scalar_symbols,
                 symbols_args_map,
+                trace,
                 debug_arg_info,
                 debug_handlers,
             )


### PR DESCRIPTION
This is required to emit Water dialect