### PR TITLE
Added C-style modulo/remainder operator

### DIFF
--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -259,6 +259,9 @@ def atan2(lhs: "Register", rhs: "Register") -> "Register": ...
 def powf(lhs: "Register", rhs: "Register") -> "Register": ...
 
 
+def mod(lhs: "Register", rhs: "Register") -> "Register": ...
+
+
 def cbrt(src: "Register") -> "Register": ...
 
 
@@ -976,6 +979,7 @@ class BinaryOpBase(CustomOp, ABC):
 @define_py_op(operator.and_)
 @define_py_op(operator.or_)
 @define_py_op(operator.truediv)
+@define_py_op(operator.mod)
 @define_interface_op("maximum")
 @define_interface_op("minimum")
 @define_interface_op("atan2")

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -727,6 +727,18 @@ def handle_div(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     return result
 
 
+@handle_binary_op(operator.mod)
+def handle_mod(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
+    element_type = get_type_or_element_type(lhs.type)
+    if _is_float_type(element_type):
+        result = arith_d.remf(lhs, rhs, fastmath=get_fast_math_flags(options))
+    elif _is_integer_like_type(element_type):
+        result = arith_d.remsi(lhs, rhs)
+    else:
+        raise ValidationError(f"Found unhandled operand type for mod: {element_type}")
+    return result
+
+
 @handle_binary_op(operator.and_)
 def handle_and(lhs: Value, rhs: Value, options: WaveCompileOptions) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)


### PR DESCRIPTION
- Added operator.mod to BinaryPyOp class
- Added lit_test cases for integer/float and binary lowerings
- Supports element-wise modulo on matrices/tensors