### PR TITLE
Fix argument type for `amdgpu.fat_raw_buffer_cast` op

### DIFF
--- a/lit_tests/kernel/wave/scaled_gemm.py
+++ b/lit_tests/kernel/wave/scaled_gemm.py
@@ -845,7 +845,7 @@ def test_mxfp4_scaled_mma_unaligned_16x16x128():
     # CHECK-DAG:        %[[CST2:.*]] = arith.constant dense<2147483647> : vector<16xindex>
     # CHECK-DAG:        %[[C0:.*]] = arith.constant 0 : index
     # CHECK-DAG:        %[[C8192:.*]] = arith.constant 8192 : index
-    # CHECK-DAG:        %[[C2147483646_I64:.*]] = arith.constant 2147483646 : i64
+    # CHECK-DAG:        %[[C2147483646_I32:.*]] = arith.constant 2147483646 : i32
     # CHECK-DAG:        %[[C2147483646:.*]] = arith.constant 2147483646 : index
     # CHECK-DAG:        %[[C_NEG_8192_I14:.*]] = arith.constant -8192 : i14
     # CHECK-DAG:        %[[BLOCK_ID_X:.*]] = gpu.block_id  x
@@ -859,7 +859,7 @@ def test_mxfp4_scaled_mma_unaligned_16x16x128():
     # CHECK:            %[[MUL1:.*]] = arith.muli %[[BLOCK_ID_Z]], %[[AFFINE_APPLY2]] overflow<nsw> : index
     # CHECK:            %{{.*}}, %[[OFFSET_TO_TENSOR:.+]], %{{.*}}, %{{.*}} = memref.extract_strided_metadata %[[SPAN0]] : memref<?x?x8192xi8, strided<[?, 8192, 1], offset: ?>> -> memref<i8>, index, index, index, index, index, index, index
     # CHECK:            %[[REINTERPRET_CAST:.*]] = memref.reinterpret_cast %[[SPAN0]] to offset: [%[[OFFSET_TO_TENSOR]]], sizes: [%[[C2147483646]]], strides: [1] : memref<?x?x8192xi8, strided<[?, 8192, 1], offset: ?>> to memref<?xi8, strided<[1], offset: ?>>
-    # CHECK:            %[[BUFF_CAST:.*]] = amdgpu.fat_raw_buffer_cast %[[REINTERPRET_CAST]] validBytes(%[[C2147483646_I64]]) cacheSwizzleStride(%[[C_NEG_8192_I14]]) resetOffset : memref<?xi8, strided<[1], offset: ?>> to memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK:            %[[BUFF_CAST:.*]] = amdgpu.fat_raw_buffer_cast %[[REINTERPRET_CAST]] validBytes(%[[C2147483646_I32]]) cacheSwizzleStride(%[[C_NEG_8192_I14]]) resetOffset : memref<?xi8, strided<[1], offset: ?>> to memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>
     # CHECK:            %[[AFFINE_APPLY3:.*]] = affine.apply #[[MAP6]]()[%[[THREAD_ID_X]], %[[THREAD_ID_Y]], %[[BLOCK_ID_X]]]
     # CHECK:            %[[CMP1:.*]] = arith.cmpi slt, %[[AFFINE_APPLY3]], %arg6 : index
     # CHECK:            %[[BROADCAST1:.*]] = vector.broadcast %[[CMP1]] : i1 to vector<16xi1>

--- a/wave_lang/kernel/wave/codegen/read_write.py
+++ b/wave_lang/kernel/wave/codegen/read_write.py
@@ -367,14 +367,14 @@ def _get_constant_value(candidate: Value):
 def _cast_buffer_and_encode_stride(
     ptr: Value, strides: tuple[Value], elem_type: IrType, emitter: WaveEmitter
 ) -> Value:
-    uint64 = IntegerType.get_signless(64)
+    uint32 = IntegerType.get_signless(32)
     uint14 = IntegerType.get_signless(14)
 
     valid_bytes = _valid_bytes_buffer(
         elem_type
     )  # max bytes that are in range to be addressed from a buffer
-    valid_bytes_constant = get_constant_attr(valid_bytes, uint64)
-    valid_bytes_constant = arith_d.constant(uint64, valid_bytes_constant)
+    valid_bytes_constant = get_constant_attr(valid_bytes, uint32)
+    valid_bytes_constant = arith_d.constant(uint32, valid_bytes_constant)
     stride_rank = len(strides)
     swizzle_stride = None
 


### PR DESCRIPTION
The commit hash of LLVM used by IREE does not yet include the upstream
change (2195fe7e) that updated the integer type for the `validBytes`
from i32 to i64.  So when Wave emits `amdgpu.fat_raw_buffer_cast` ops,
we get a compilation failure.

This patch fixes the type to match the LLVM commit used by IREE/Wave,
although in a few weeks when the upstream change is pulled into Wave,
we'll need to revert this patch.