### PR TITLE
[Synchronization] gfx12 split barriers support

### DIFF
--- a/gemm_test.py
+++ b/gemm_test.py
@@ -1,0 +1,91 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.wave.utils.general_utils import (
+    get_default_scheduling_params,
+)
+from wave_lang.kernel.wave.utils.run_utils import (
+    set_default_run_config,
+)
+from wave_lang.kernel.wave.utils.torch_utils import (
+    device_randn,
+    device_randint,
+    device_zeros,
+)
+from wave_lang.kernel.wave.iree_utils import generate_iree_ref
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
+from wave_lang.kernel.wave.constraints import MMAType, MMAOperand, GenericDot
+from wave_lang.kernel.wave.templates.gemm import get_gemm_kernel
+from wave_lang.kernel.lang import DataType
+import os
+import json
+from torch.testing import assert_close
+
+
+enable_scheduling=SchedulingType.PREFETCH
+shape = (4096, 4096, 4096)
+mfma_variant = MMAType.RDNA4_WAVE32_F32_16x16x16_F16
+threads_per_wave = 32
+datatype = torch.float16
+dynamic_dims = False
+run_bench = False
+
+def testPureGemm():
+    gemm, hyperparams, dynamic_symbols = get_gemm_kernel(
+        shape, dynamic_dims, mfma_variant, datatype, threads_per_wave=threads_per_wave
+    )
+
+    multibuffer = enable_scheduling in [
+        SchedulingType.FOUR_STAGE,
+        SchedulingType.MODULO,
+    ]
+    UNROLL_FACTOR = tkl.sym.UNROLL_FACTOR
+    hyperparams[UNROLL_FACTOR] = 2 if multibuffer else 1
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        dynamic_symbols=dynamic_symbols,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        # print_mlir=True
+        # dump_intermediates="./dump/intermediates-pp/"
+
+    )
+    options.postprocess = """
+    module attributes {transform.with_named_sequence} {
+        transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+            %0 = transform.structured.match ops{["scf.for"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+            transform.loop.unroll %0 { factor = %%UNROLL_FACTOR%% } : !transform.any_op
+            transform.yield
+        }
+    }
+    """
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm)
+
+    a = device_randn(shape[0], shape[2], dtype=datatype)
+    b = device_randn(shape[1], shape[2], dtype=datatype)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    gemm(a, b, c)
+
+    # if run_bench:
+        # options.benchmark_results_file = perf_filename_iree
+#
+    # iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    # generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    # assert_close(c, iree_ref, check_device=False)
+
+if __name__ == "__main__":
+    testPureGemm()

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -122,6 +122,10 @@ def set_wave_prio(priority: int): ...
 
 def shared_memory_barrier(wait_async_ops: bool = False): ...
 
+def shared_memory_barrier_signal(barId: int = 0): ...
+
+def shared_memory_barrier_wait(barId: int = 0): ...
+
 
 def workgroup_barrier(): ...
 
@@ -1416,6 +1420,35 @@ class SharedMemoryBarrier(CustomOp):
     """
 
     wait_async_ops: bool = False
+
+    @property
+    def has_side_effects(self) -> bool:
+        return True
+
+@define_op("shared_memory_barrier_signal")
+@dataclass
+class SharedMemoryBarrierSignal(CustomOp):
+    """
+    Represents a shared memory barrier signal in the graph. (gfx12)
+    Argument specifies which barrier to signal. (-1 for WG barrier; -2 for trap barrier)
+    """
+
+    barId: int = 0
+
+    @property
+    def has_side_effects(self) -> bool:
+        return True
+
+@define_op("shared_memory_barrier_wait")
+@dataclass
+class SharedMemoryBarrierWait(CustomOp):
+    """
+    Wait for all waves in a WG to signal the barrier before proceeding. (gfx12)
+    synchronize waves within a WG.
+    Argument specifies which barrier to signal. (-1 for WG barrier; -2 for trap barrier)
+    """
+
+    barId: int = 0
 
     @property
     def has_side_effects(self) -> bool:

--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -38,6 +38,8 @@ from ...ops.wave_ops import (
     SelectOp,
     SetWavePrio,
     SharedMemoryBarrier,
+    SharedMemoryBarrierSignal,
+    SharedMemoryBarrierWait,
     WorkgroupBarrier,
     Write,
     get_custom,
@@ -214,7 +216,7 @@ def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
             continue
         if isinstance(custom, (Output, NestedRegionOp)):
             continue
-        if isinstance(custom, (SharedMemoryBarrier, SetWavePrio, WorkgroupBarrier)):
+        if isinstance(custom, (SharedMemoryBarrier, SharedMemoryBarrierSignal, SharedMemoryBarrierWait, SetWavePrio, WorkgroupBarrier)):
             continue
         if isinstance(custom.type, DataType):
             continue

--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -99,6 +99,8 @@ from ...ops.wave_ops import (
     set_symbol,
     set_wave_prio,
     shared_memory_barrier,
+    shared_memory_barrier_signal,
+    shared_memory_barrier_wait,
     shuffle,
     sin,
     sinh,
@@ -1606,6 +1608,26 @@ def handle_shared_memory_barrier(emitter: WaveEmitter, node: fx.Node):
         waitcnt(0)
 
     amdgpu_d.lds_barrier()
+
+
+@handle_op(shared_memory_barrier_signal)
+def handle_shared_memory_barrier_signal(emitter: WaveEmitter, node: fx.Node):
+    try:
+       barId = node.args[0]
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+
+    rocdl_d.s_barrier_signal(barId)
+
+
+@handle_op(shared_memory_barrier_wait)
+def handle_shared_memory_barrier_wait(emitter: WaveEmitter, node: fx.Node):
+    try:
+       barId = node.args[0]
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+
+    rocdl_d.s_barrier_wait(barId)
 
 
 @handle_op(scheduling_barrier)

--- a/wave_lang/kernel/wave/templates/gemm.py
+++ b/wave_lang/kernel/wave/templates/gemm.py
@@ -42,8 +42,8 @@ def get_gemm_kernel(
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K)]
-    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
-    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 8)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
 
     constraints += [
         tkw.HardwareConstraint(threads_per_wave=threads_per_wave, mma_type=mfma_variant)
@@ -85,9 +85,9 @@ def get_gemm_kernel(
 
     hyperparams = {
         ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        BLOCK_M: 64,
-        BLOCK_N: 64,
-        BLOCK_K: 32,
+        BLOCK_M: 128,
+        BLOCK_N: 256,
+        BLOCK_K: 64,
         M: shape[0],
         N: shape[1],
         K: shape[2],


### PR DESCRIPTION
draft

RDNA4 ISA introduces barrier_signal and barrier_wait.
This PR supports them in schedule reordering, demonstrating improvement in pure gemm pingpong.

reproduce:
```bash
WAVE_CACHE_ON=0 python gemm_test.py
```