### PR TITLE
[Runtime] t.dlpack fallback support for pytorch compatibility

### DIFF
--- a/wave_lang/runtime/device.py
+++ b/wave_lang/runtime/device.py
@@ -550,7 +550,7 @@ def _device_import_torch_tensor_cuda_hip(
     # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
-    capsule = t.__dlpack__(None)
+    capsule = t.__dlpack__(stream=None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv
 


### PR DESCRIPTION
Some PyTorch versions allowed calling `dlpack` with stream or accepted a None. Some versions expect no arguments (just `t.dlpack()`). This PR provides a quick fix for compatibility.

This fixes the CI failure for 
```
wave_lang/kernel/wave/compile.py:121: in __call__
    return self.invoke(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wave_lang/kernel/wave/compile.py:205: in invoke
    self.launchable(*tensors, *scalar_args)
wave_lang/runtime/launch.py:225: in __call__
    arg_list.push_ref(turbine_device.import_torch_tensor(arg))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wave_lang/runtime/device.py:407: in <lambda>
    self.import_torch_tensor = lambda t: import_fn(self, t)
                                         ^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

device = <Turbine Device: hip>
t = tensor([[[-9.0137e-01,  4.8145e-01,  1.1982e+00,  ...,  9.1211e-01,
          -8.5352e-01,  3.3252e-01],
         [ 1.....5942e-01,  7.0557e-01,  ...,  6.2061e-01,
          -3.7817e-01, -2.2246e+00]]], device='cuda:0', dtype=torch.float16)

    def _device_import_torch_tensor_cuda_hip(
        device: Device, t: torch.Tensor
    ) -> HalBufferView:
        # We currently only support contiguous, so ensure that.
        if not t.is_contiguous():
            t = t.contiguous()
        # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
        # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
        # streams, the user is expected to properly manage stream synchronization.
>       capsule = t.__dlpack__(None)
                  ^^^^^^^^^^^^^^^^^^
E       TypeError: Tensor.__dlpack__() takes 1 positional argument but 2 were given

wave_lang/runtime/device.py:553: TypeError
```