### PR TITLE
Add GEMM template for C = transpose(A) * B

### DIFF
--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -10,6 +10,9 @@ from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
 from wave_lang.kernel.wave.utils.general_utils import (
     run_test,
 )
+from wave_lang.kernel.wave.templates.gemm import (
+    get_gemm_kernel_transpose_a_b,
+)
 
 M = tkl.sym.M
 N = tkl.sym.N
@@ -2103,3 +2106,25 @@ def test_batched_gemm_with_permute():
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]
+
+
+@run_test
+def test_gemm_with_transpose_a_b_gfx950():
+    gemm, hyperparams, _ = get_gemm_kernel_transpose_a_b(
+        shape=(64, 256, 64),
+        dynamic_dims=False,
+        mfma_variant=tkw.MMAType.F32_16x16x16_F16,
+    )
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        compile_to_mlir=True,
+        target="gfx950",
+    )
+    gemm = wave_compile(options, gemm)
+    print(gemm.asm)
+    # CHECK-LABEL:    test_gemm_with_transpose_a_b
+    # CHECK:          func.func @gemm
+    # Ensure that the transpose loads and mma are present.
+    # CHECK-COUNT-8:    amdgpu.transpose_load {{.*}} : memref<{{.*}}xf16, #gpu.address_space<workgroup>> -> vector<{{.*}}xf16>
+    # CHECK-COUNT-8:    amdgpu.mfma {{.*}} * {{.*}} + {{.*}} {blocks = {{.*}} : i32, k = {{.*}} : i32, m = {{.*}} : i32, n = {{.*}} : i32} blgp = none : vector<{{.*}}xf16>, vector<{{.*}}xf16>, vector<{{.*}}xf32>

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -37,6 +37,8 @@ from .common.utils import (
 )
 from wave_lang.kernel.wave.constraints import MMAType, MMAOperand, GenericDot
 from wave_lang.kernel.wave.templates.gemm import get_gemm_kernel
+from wave_lang.kernel.wave.templates.gemm import get_gemm_kernel_transpose_a_b
+
 from wave_lang.kernel.wave.templates.test_kernels import (
     get_gemm_prefetch_kernel_and_schedule,
 )
@@ -2394,3 +2396,59 @@ def test_gemm_prefetch_manual_schedule(shape: tuple[int], mfma_variant: MMAType)
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref], options)
     assert_close(c, iree_ref, check_device=False)
+
+
+# TODO: This fails on the builder for rdna4, but when I run it locally it works.
+#       Investigate further. (Succeeded on rocm6.4, 7.0, pytorch2.9)
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize(
+    "enable_scheduling",
+    [
+        SchedulingType.NONE,
+        _xfail(SchedulingType.PREFETCH),
+        SchedulingType.FOUR_STAGE,
+        SchedulingType.MODULO,
+    ],
+)
+@param_bool("dynamic_dims", "dyn")
+@pytest.mark.parametrize(
+    "mfma_variant, threads_per_wave",
+    [
+        pytest.param(MMAType.F32_16x16x16_F16, 64, marks=require_cdna_3_or_4),
+        pytest.param(MMAType.F32_32x32x8_F16, 64, marks=require_cdna_3_or_4),
+    ],
+)
+def testGemmTransposeAB(
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    threads_per_wave: int,
+    run_bench,
+    perf_filename_tk,
+    perf_filename_iree,
+):
+    gemm, hyperparams, dynamic_symbols = get_gemm_kernel_transpose_a_b(
+        shape, dynamic_dims, mfma_variant, threads_per_wave=threads_per_wave
+    )
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        dynamic_symbols=dynamic_symbols,
+    )
+    options = set_default_run_config(options)
+
+    gemm = wave_compile(options, gemm)
+    a = device_randn(shape[2], shape[0], dtype=torch.float16)
+    b = device_randn(shape[2], shape[1], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    gemm(a, b, c)
+
+    torch_ref = torch.matmul(a.T, b)
+    assert_close(
+        c.to(torch.float16), torch_ref, atol=1e-3, rtol=1e-3, check_device=False
+    )

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -48,10 +48,15 @@ IGNORED_KEYWORDS = ["tag"]
 
 
 def read_meets_hw_transpose_requirements(
-    read: Read, constraints: list[Constraint]
+    read: Read, constraints: list[Constraint], target: str
 ) -> bool:
     from ..wave.minimize_global_loads import is_transposed_read
     from ..wave.utils.general_utils import find_index_bounds
+
+    # Check if target architecture supports amdgpu.transpose_load
+    # Only gfx950 and newer architectures support this operation
+    if not target.startswith("gfx95") and not target.startswith("gfx12"):
+        return False
 
     if read.bounds is not None:
         return False
@@ -1918,11 +1923,11 @@ class Read(CustomOp):
 
         return False
 
-    def is_contiguous_vec(self, constraints) -> bool:
+    def is_contiguous_vec(self, constraints, target: str) -> bool:
         """Check if op can be lowered to contiguous vector ops
 
         If False we will have to lower it to gather"""
-        if read_meets_hw_transpose_requirements(self, constraints):
+        if read_meets_hw_transpose_requirements(self, constraints, target):
             return True
 
         if self.has_identity_mapping():
@@ -2280,7 +2285,7 @@ class Write(CustomOp):
 
         return False
 
-    def is_contiguous_vec(self, constraints) -> bool:
+    def is_contiguous_vec(self, constraints, target: str) -> bool:
         """Check if op can be lowered to contiguous vector ops
 
         If False we will have to lower it to gather"""

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -389,7 +389,9 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
             custom.graph.erase_node(custom.fx_node)
 
 
-def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint]):
+def partition_gather_like_ops(
+    trace: CapturedTrace, constraints: list[Constraint], target: str
+):
     """
     This pass partitions gather-like operations (reads/writes with non-contiguous access patterns) into
     multiple contiguous operations.
@@ -413,7 +415,7 @@ def partition_gather_like_ops(trace: CapturedTrace, constraints: list[Constraint
         """
         custom = get_custom(node)
         if isinstance(custom, (Read, Write)):
-            return not custom.is_contiguous_vec(constraints)
+            return not custom.is_contiguous_vec(constraints, target)
 
         return False
 

--- a/wave_lang/kernel/wave/codegen/read_write.py
+++ b/wave_lang/kernel/wave/codegen/read_write.py
@@ -602,7 +602,9 @@ def handle_read(emitter: WaveEmitter, node: fx.Node):
     start_indices, start_indices_wg, start_indices_th = _build_start_indices(
         emitter, index, dynamic_vals_map_start
     )
-    if read_meets_hw_transpose_requirements(get_custom(node), emitter.constraints):
+    if read_meets_hw_transpose_requirements(
+        get_custom(node), emitter.constraints, emitter.options.target
+    ):
         result = amdgpu_d.transpose_load(vector_type, kb_src, start_indices)
     else:
         result = _create_vec_read_write(

--- a/wave_lang/kernel/wave/hardware_transpose.py
+++ b/wave_lang/kernel/wave/hardware_transpose.py
@@ -150,7 +150,9 @@ def mark_hardware_transpose_candidates(
 
     for read in trace.walk(is_read):
         custom_node = get_custom(read)
-        if not read_meets_hw_transpose_requirements(custom_node, constraints):
+        if not read_meets_hw_transpose_requirements(
+            custom_node, constraints, options.target
+        ):
             continue
 
         mem_type = custom_node.memory_type

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -921,7 +921,7 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(add_shared_memory_barriers, trace),
             partial(compute_shared_memory_usage, trace, options.kernel_launch_info),
-            partial(partition_gather_like_ops, trace, self.constraints),
+            partial(partition_gather_like_ops, trace, self.constraints, options.target),
             partial(generate_bounds_exprs, trace, self.constraints),
         ]
 


### PR DESCRIPTION
This PR adds a GEMM template for C = transpose(A) * B.  Here both A and B are read in a transposed fashion because we want the K dimension to be the contiguous dimension. We add a lit test and end to end test.