### PR TITLE
[debugging] debug_log extra_iteration_dimensions

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -2458,8 +2458,10 @@ def test_debug_log_core(dynamic_dims: bool):
 @pytest.mark.parametrize(
     "mfma_variant, threads_per_wave",
     [
-        pytest.param(tkw.MMAType.F32_16x16x16_F16, 64),
-        pytest.param(tkw.MMAType.RDNA4_WAVE32_F32_16x16x16_F16, 32),
+        pytest.param(tkw.MMAType.F32_16x16x16_F16, 64, marks=require_cdna_2_or_3_or_4),
+        pytest.param(
+            tkw.MMAType.RDNA4_WAVE32_F32_16x16x16_F16, 32, marks=require_rdna4
+        ),
     ],
 )
 def test_debug_log_iteration_dims(mfma_variant, threads_per_wave):
@@ -2480,7 +2482,7 @@ def test_debug_log_iteration_dims(mfma_variant, threads_per_wave):
         tkw.WaveConstraint(M, BLOCK_M / 2),
         tkw.WaveConstraint(N, BLOCK_N / 2),
         tkw.HardwareConstraint(
-            threads_per_wave=64, mma_type=tkw.MMAType.F32_16x16x16_F16
+            threads_per_wave=threads_per_wave, mma_type=mfma_variant
         ),
     ]
 
@@ -2496,17 +2498,17 @@ def test_debug_log_iteration_dims(mfma_variant, threads_per_wave):
         b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
         c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
     ):
-        c_reg = Register[M, N, tkl.f32](0.0)
+        c_reg = tkw.Register[M, N, tkl.f32](0.0)
 
         @tkw.iterate(K, init_args=[c_reg])
-        def repeat(acc: Register[M, N, tkl.f32]) -> Register[M, N, tkl.f32]:
+        def repeat(acc: tkw.Register[M, N, tkl.f32]) -> tkw.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a)
             b_reg = tkw.read(b)
             acc = tkw.mma(a_reg, b_reg, acc)
-            debug_log(
+            tkw.debug_log(
                 acc,
                 "acc",
-                extra_iteration_dimensions=[(tkl.sym.iter, k, iterations)],
+                extra_iteration_dimensions=[(tkl.sym.iter, K, iterations)],
                 handler=handler,
             )
             return acc
@@ -2546,6 +2548,8 @@ def test_debug_log_iteration_dims(mfma_variant, threads_per_wave):
         assert torch.equal(debug_logs["acc"]["value"][-1], c)
         # Meanwhile the first element should be quite different.
         assert not torch.allclose(debug_logs["acc"]["value"][0], c)
+
+    test_gemm()
 
 
 @require_e2e

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -181,7 +181,7 @@ def write(
 def debug_log(
     register_: "Register",
     label: Optional[str],
-    extra_iter_dimensions: Optional[
+    extra_iteration_dimensions: Optional[
         list[tuple["IndexSymbol", "IndexSymbol", int]]
     ] = None,
     mapping: Optional[IndexMapping] = None,
@@ -2338,7 +2338,7 @@ class DebugLog(CustomOp):
     The optional `handler` argument should be a function that accepts the whole `debug_logs` object (IE all logs, not just one).
     The handler function gives a way to specify something like a viewer for all logs, but specify it inline among print functions rather than separately.
 
-    The optional `extra_iter_dimensions` argument allows you to add extra dimensions to capture values from multiple iterations of a loop.
+    The optional `extra_iteration_dimensions` argument allows you to add extra dimensions to capture values from multiple iterations of a loop.
     It takes a list of tuples, where each tuple contains `(dimension_name, iteration_axis, max_iterations)`.
     The `dimension_name` must be a unique symbol, and will be the name of the dimension in the symbolic shape of the output.
     The `iteration_axis` must be the axis of an `Iterate` operation, IE the dimension being reduced in the iteration.

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -179,7 +179,8 @@ class WaveKernel:
                     "value": memory,
                     "symbolic_shape": info_dict["symbolic_shape"],
                     "iteration_dimensions": [
-                        dim for dim, _, _ in info_dict["extra_iteration_dimensions"]
+                        dim
+                        for dim, _, _ in info_dict.get("extra_iteration_dimensions", [])
                     ],
                 }
                 debug_args.append(memory)


### PR DESCRIPTION
:facepalm: the test didn't fail because I left out the call to the core test function.
This fixes that.
It also fixes what broke that the test didn't catch because it didn't really run...
And it fixes a couple of typos and makes the test work on RDNA4.