### PR TITLE
Rewrite more reads and writes with gather-to-lds operations

### DIFF
--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -542,9 +542,7 @@ def test_attention_bshd_gather_to_shared():
 
     # CHECK-LABEL:       func.func @base_attention
     # CHECK:                    {{.*}} = scf.for
-    # CHECK-COUNT-2:            amdgpu.gather_to_lds
-    # CHECK:                    vector.load
-    # CHECK:                    vector.store
-    # CHECK:                    vector.load
-    # CHECK:                    vector.store
+    # CHECK-NOT:                vector.store
+    # CHECK-COUNT-4:            amdgpu.gather_to_lds
+    # CHECK-NOT:                vector.store
     # CHECK-DAG:                scf.yield

--- a/lit_tests/kernel/wave/gather_to_shared.py
+++ b/lit_tests/kernel/wave/gather_to_shared.py
@@ -362,3 +362,12 @@ def test_gather_to_shared_not_minimize_shared_allocs():
     # CHECK:            memref.view {{.*}} : memref<1024xi8, #gpu.address_space<workgroup>> to memref<32x8xi8, #gpu.address_space<workgroup>>
     # CHECK:            memref.alloc() : memref<32x128xi8, #gpu.address_space<workgroup>>
     # CHECK:            scf.for
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK-COUNT-4:      amdgpu.gather_to_lds {{.*}}
+    # CHECK-NOT:          vector.load
+    # CHECK-NOT:          vector.store
+    # CHECK:              rocdl.s.waitcnt
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK-COUNT-8:      vector.load
+    # CHECK-COUNT-2:      amdgpu.scaled_mfma
+    # CHECK-COUNT-4:    vector.store

--- a/wave_lang/kernel/wave/wave.py
+++ b/wave_lang/kernel/wave/wave.py
@@ -859,11 +859,11 @@ class LaunchableWave(Launchable):
             graph_passes += [
                 partial(hoist_loop_invariant_ops, trace, self.constraints),
                 partial(tensor_load_to_shared, trace, self.constraints, options),
-                partial(gather_to_shared, trace, self.constraints, options),
-                partial(gather_to_shared_swizzling, trace, self.constraints, options),
                 partial(in_thread_transpose, trace, self.constraints, options),
                 partial(global_to_shared_gathers, trace, self.constraints),
                 partial(minimize_global_loads, trace, self.constraints),
+                partial(gather_to_shared, trace, self.constraints, options),
+                partial(gather_to_shared_swizzling, trace, self.constraints, options),
                 partial(
                     mark_hardware_transpose_candidates, trace, self.constraints, options
                 ),


### PR DESCRIPTION
This patch makes three main changes.  First, it moves the
gather-to-shared passes to run after the minimize-global-loads pass.
Doing so uncovers new opportunities for rewriting read/write operations.
Second, this patch fixes a bug in the handling of dynamic values map
where we were incorrectly using the same map for both source and
destination values.  Third, this patch fixes a bug in the rewriting of
read and write index values, where instead of the `symbolic_shape`, we
should have used `indexing_dims`.

The net effect of these changes is that Wave discovers more
opportunities for optimizations in several attention kernels.