### PR TITLE
improve lit compatability for sharktank_integration test

### DIFF
--- a/lit_tests/kernel/wave/sharktank_integration.py
+++ b/lit_tests/kernel/wave/sharktank_integration.py
@@ -1,4 +1,4 @@
-# RUN: python %s | FileCheck %s --check-prefix=CHECK,CHECK-%target
+# RUN: python %s | FileCheck %s --check-prefixes=CHECK,CHECK-%target
 
 import textwrap
 from typing import Optional


### PR DESCRIPTION
The test has been failing for me locally, I believe it is due to a difference in `FileCheck` version (IE python vs c++ implementation).  This change should make it work for both.