### PR TITLE
Simplify hardware transpose index calculation

### DIFF
--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -46,6 +46,7 @@ from .common.utils import (
     require_cdna3,
     require_e2e,
     require_cdna_2_or_3_or_4,
+    require_cdna4,
     require_rdna4,
 )
 from .common.shapes import get_test_shapes as get_common_test_shape
@@ -459,6 +460,96 @@ def test_transpose_write(shape, use_buffer_ops, run_bench):
     ):
         res = tkw.read(a)
         tkw.write(res, b, mapping=mapping)
+
+    a = device_randn(shape, dtype=torch.float16)
+    b = device_zeros(shape[::-1], dtype=torch.float16)
+    options = WaveCompileOptions(
+        subs={
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+        use_buffer_ops=use_buffer_ops,
+    )
+    options = set_default_run_config(options)
+    test = wave_compile(options, test)
+
+    test(a, b)
+    assert_close(a.T, b)
+
+
+@require_e2e
+@require_cdna4
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # Square matrices
+        (64, 64),
+        (256, 256),
+        (512, 512),
+        (1024, 1024),
+        # Rectangular (power of 2)
+        (512, 256),
+        (256, 512),
+        (1024, 512),
+        (512, 1024),
+        (2048, 1024),
+        # Aligned but not power of 2 (meet Tm%4==0, Tk%4==0 for f16)
+        (384, 256),  # 3*128 x 256
+        (768, 512),  # 3*256 x 512
+        (1280, 512),  # 5*256 x 512
+        (512, 768),  # 512 x 3*256
+        # Extreme aspect ratios
+        (64, 1024),  # Very wide (1:16 ratio)
+        (1024, 64),  # Very tall (16:1 ratio)
+        (128, 2048),  # Ultra-wide (1:16 ratio)
+        (2048, 128),  # Ultra-tall (16:1 ratio)
+    ],
+)
+@param_bool("use_buffer_ops", "buf_ops")
+def test_arbitrary_transpose(shape, use_buffer_ops, run_bench):
+    """
+    Test transposing arbitrary shaped 2D tensors using transpose read.
+
+    This test validates the unified transpose formula works correctly for:
+    - Aligned and unaligned matrix dimensions
+    - Various aspect ratios (square, wide, tall)
+    - Edge cases and boundary conditions
+    """
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    wave_size = 64
+    BLOCK_N = 1
+    BLOCK_M = sympy.Max(sympy.Min(M, 256), wave_size)
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            vector_shapes={N: BLOCK_N, M: BLOCK_M},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(
+        num_iterators=2, inputs={N: i, M: j}, outputs={N: i, M: j}
+    )
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f16],
+    ):
+        res = tkw.read(a, mapping=mapping)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -2226,9 +2226,19 @@ def testI8HwTransposeGemm(shape: tuple[int], mfma_variant: MMAType, request):
     assert_close(c.to(torch.int32), torch_ref, atol=1e-2, rtol=1e-2, check_device=False)
 
 
-@require_e2e
 @require_cdna4
-@pytest.mark.parametrize("shape", [(4096, 4096, 4096)])
+@require_e2e
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4096, 4096, 4096),  # Aligned baseline
+        (3072, 4096, 2048),  # M not power of 2
+        (4096, 3584, 4096),  # N not power of 2
+        (2560, 2560, 1536),  # All unaligned
+        (1280, 5120, 2048),  # Wide N
+        (5120, 1280, 2048),  # Tall M
+    ],
+)
 @pytest.mark.parametrize(
     "mfma_variant",
     [

--- a/wave_lang/kernel/wave/hardware_transpose.py
+++ b/wave_lang/kernel/wave/hardware_transpose.py
@@ -24,48 +24,85 @@ from ..wave.constraints import Constraint
 from .compile_options import WaveCompileOptions
 
 
-def fetch_delinearized_indices(shape, dtype_width, thread_id):
-    if shape == (16, 32) and dtype_width == 8:
-        return [
-            (thread_id % 2) * 8 + (sympy.floor(thread_id / 16) % 2) * 16,
-            sympy.floor((thread_id % 64) / 32) * 8 + sympy.floor((thread_id % 16) / 2),
-        ]
+def _calculate_wide_tile_offset(Tm, dtype_width, vw):
+    """Calculate offset for wide tile transpose operations."""
+    if Tm > 8 and dtype_width == 16:
+        return vw * 2
+    return vw
 
-    if shape == (32, 16) and dtype_width == 8:
-        return [
-            (thread_id % 2) * 8,
-            sympy.floor((thread_id % 64) / 2),
-        ]
 
-    if shape == (16, 16) and dtype_width == 16:
-        return [
-            (thread_id % 4) * 4,
-            sympy.floor((thread_id % 64) / 4),
-        ]
+def compute_transpose_indices(shape, dtype_width, thread_id, threads_per_wave):
+    """
+    Uses tile classification to determine the appropriate index pattern.
+    Classifies tiles as wide, tall, or base based on shape parameters.
+    """
+    Tm, Tk = shape
 
-    if shape == (8, 32) and dtype_width == 16:
-        return [
-            (thread_id % 4) * 4 + sympy.floor((thread_id % 32) / 16) * 16,
-            sympy.floor((thread_id % 16) / 4) + sympy.floor((thread_id % 64) / 32) * 4,
-        ]
+    # Hardware constants
+    TILE_THRESHOLD = 16
 
-    if shape == (32, 16) and dtype_width == 16:
-        return [
-            (thread_id % 4) * 4,
-            sympy.floor((thread_id % 64) / 4) + 4 * sympy.floor((thread_id % 64) / 16),
-        ]
+    # Vector width in elements (4 for 16-bit, 8 for 8-bit)
+    vw = threads_per_wave // dtype_width
 
-    if shape == (16, 32) and dtype_width == 16:
-        return [
-            (thread_id % 4) * 4 + sympy.floor((thread_id % 32) / 16) * 16,
-            sympy.floor((thread_id % 16) / 4) + sympy.floor((thread_id % 64) / 32) * 8,
-        ]
+    # Group size for first dimension cycling (4 for 16-bit, 2 for 8-bit)
+    group_size = vw if dtype_width == 16 else vw // 4
 
-    # XXX: Uncomment following line for debugging
-    # assert False, "Unhandled shape and datatype!"
+    # Precompute common thread ID modulo operations
+    tid_mod_group = thread_id % group_size
+    tid_mod_16 = thread_id % 16
+    tid_mod_32 = thread_id % 32
+    tid_mod_wave = thread_id % threads_per_wave
 
-    # Signal to caller that we should not use the transposed load operation
-    return None
+    # Base pattern components
+    base_first = tid_mod_group * vw
+    base_second = sympy.floor(tid_mod_wave / group_size)
+
+    # Tile classification
+    is_wide_tile = Tm <= TILE_THRESHOLD and Tk > TILE_THRESHOLD
+    is_tall_tile = Tm > TILE_THRESHOLD and Tk <= vw * group_size and dtype_width == 16
+
+    if is_wide_tile:
+        # Wide tiles: multiple wave-groups horizontally
+        first_dim = (
+            base_first + sympy.floor(tid_mod_32 / TILE_THRESHOLD) * TILE_THRESHOLD
+        )
+        wide_second_base = sympy.floor(tid_mod_16 / group_size)
+        offset = _calculate_wide_tile_offset(Tm, dtype_width, vw)
+        second_dim = wide_second_base + sympy.floor(tid_mod_wave / 32) * offset
+    elif is_tall_tile:
+        # Tall tiles: multiple wave-groups vertically
+        first_dim = base_first
+        second_dim = base_second + group_size * sympy.floor(
+            tid_mod_wave / TILE_THRESHOLD
+        )
+    else:
+        # Base case: single wave-group (16x16 or smaller)
+        first_dim = base_first
+        second_dim = base_second
+
+    return [first_dim, second_dim]
+
+
+def fetch_delinearized_indices(shape, dtype_width, thread_id, threads_per_wave):
+    """
+    Returns delinearized indices for hardware transpose operations.
+
+    Now uses unified formula with tile classification instead of 6 hardcoded cases.
+    All shapes meeting basic alignment constraints are supported.
+    """
+    # Validate supported configurations
+    if dtype_width not in (8, 16):
+        return None
+
+    Tm, Tk = shape
+    vw = threads_per_wave // dtype_width
+
+    # Check if shape is supported (must be compatible with base unit)
+    if Tm % 4 != 0 or Tk % vw != 0:
+        return None
+
+    # All aligned shapes now supported via tile classification
+    return compute_transpose_indices(shape, dtype_width, thread_id, threads_per_wave)
 
 
 def modify_index(index, elems_per_thread, delinearized):
@@ -156,7 +193,9 @@ def mark_hardware_transpose_candidates(
         mem_type = custom_node.memory_type
         width = mem_type.dtype.bitwidth()
         concrete_shape = tuple(map(sub, custom_node.memory_type.symbolic_shape))
-        maybe_indices = fetch_delinearized_indices(concrete_shape, width, thread_id)
+        maybe_indices = fetch_delinearized_indices(
+            concrete_shape, width, thread_id, hardware_constraint.threads_per_wave
+        )
         if not maybe_indices:
             continue
 


### PR DESCRIPTION
This PR adds a different way of categorizing tiles based on whether they are tall, wide or 16x16 or smaller. Currently, only handles aligned shapes. This PR adds more shapes and e2e tests that validate the transposed instruction in a pure transpose test.