### PR TITLE
[water] remove wg_constraint parameter from wave_constraint

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -225,9 +225,7 @@ def WaveConstraintAttr : AttrDef<WaveDialect, "WaveConstraint"> {
   let description = [{
     A constraint of the form:
     ```mlir
-    #wave.wave_constraint<dim = <"K">,
-                          tile_size = <[WAVE_K] -> (WAVE_K)>,
-                          wg_constraint = #wg_constraint>
+    #wave.wave_constraint<dim = <"K">, tile_size = <[WAVE_K] -> (WAVE_K)>>
     ```
 
     that we want distribute the K dimension among multiple waves with
@@ -238,8 +236,7 @@ def WaveConstraintAttr : AttrDef<WaveDialect, "WaveConstraint"> {
     is given by BLOCK_K // WAVE_K.
   }];
   let parameters = (ins "::wave::WaveSymbolAttr":$dim,
-                        "::wave::WaveExprListAttr":$tile_size,
-                        OptionalParameter<"::wave::WorkgroupConstraintAttr">:$wg_constraint);
+                        "::wave::WaveExprListAttr":$tile_size);
 
   let assemblyFormat = "`<` struct(params) `>`";
   let genVerifyDecl = 1;

--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -211,9 +211,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirWorkgroupConstraintAttrGetTypeID();
 MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveConstraintAttr(MlirAttribute attr);
 
 /// Creates a new WaveConstraintAttr
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirWaveConstraintAttrGet(MlirContext mlirCtx, MlirAttribute dim,
-                          MlirAttribute tileSize, MlirAttribute wgConstraint);
+MLIR_CAPI_EXPORTED MlirAttribute mlirWaveConstraintAttrGet(
+    MlirContext mlirCtx, MlirAttribute dim, MlirAttribute tileSize);
 
 /// Returns the typeID of a WaveConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveConstraintAttrGetTypeID();

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -303,16 +303,11 @@ bool mlirAttributeIsAWaveConstraintAttr(MlirAttribute attr) {
 }
 
 MlirAttribute mlirWaveConstraintAttrGet(MlirContext mlirCtx, MlirAttribute dim,
-                                        MlirAttribute tileSize,
-                                        MlirAttribute wgConstraint) {
+                                        MlirAttribute tileSize) {
   mlir::MLIRContext *ctx = unwrap(mlirCtx);
   auto dimAttr = llvm::cast<wave::WaveSymbolAttr>(unwrap(dim));
   auto tileSizeAttr = llvm::cast<wave::WaveExprListAttr>(unwrap(tileSize));
-  auto wgConstraintAttr = llvm::cast_if_present<wave::WorkgroupConstraintAttr>(
-      unwrap(wgConstraint));
-
-  return wrap(wave::WaveConstraintAttr::get(ctx, dimAttr, tileSizeAttr,
-                                            wgConstraintAttr));
+  return wrap(wave::WaveConstraintAttr::get(ctx, dimAttr, tileSizeAttr));
 }
 
 MlirTypeID mlirWaveConstraintAttrGetTypeID() {

--- a/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -327,16 +327,7 @@ WorkgroupConstraintAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult
 WaveConstraintAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                           WaveSymbolAttr dim, WaveExprListAttr tile_size,
-                           WorkgroupConstraintAttr wg_constraint) {
-  if (wg_constraint && wg_constraint.getDim() != dim)
-    return emitError()
-           << "the dimension of the workgroup constraint in wg_constraint: "
-           << wg_constraint.getDim()
-           << " should match the dimension of the wave "
-              "constraint: "
-           << dim;
-
+                           WaveSymbolAttr dim, WaveExprListAttr tile_size) {
   if (tile_size.getSize() != 1) {
     return emitError() << "invalid ExpressionList size, expected 1";
   }

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -431,17 +431,13 @@ NB_MODULE(_waterDialects, m) {
       .def_classmethod(
           "get",
           [](const nb::object &cls, const std::string &dim,
-             MlirAttribute tileSize, std::optional<MlirAttribute> wgConstraint,
-             MlirContext context) {
+             MlirAttribute tileSize, MlirContext context) {
             MlirStringRef dimStrRef =
                 mlirStringRefCreate(dim.c_str(), dim.size());
             MlirAttribute dimAttr = mlirWaveSymbolAttrGet(context, dimStrRef);
-            return cls(mlirWaveConstraintAttrGet(
-                context, dimAttr, tileSize,
-                wgConstraint.value_or(MlirAttribute())));
+            return cls(mlirWaveConstraintAttrGet(context, dimAttr, tileSize));
           },
           nb::arg("cls"), nb::arg("dim"), nb::arg("tile_size"),
-          nb::arg("wg_constraint") = nb::none(),
           nb::arg("context") = nb::none(),
           "Gets a wave.WaveConstraintAttr from parameters.");
 

--- a/water/test/Dialect/Wave/attr-constraint-invalid.mlir
+++ b/water/test/Dialect/Wave/attr-constraint-invalid.mlir
@@ -19,16 +19,6 @@ func.func private @test_num_dimensions_mismatch2() attributes { wave.constraints
 // -----
 
 #hyperparams = #wave.hyperparameters<{M = 1024, K = 1024, BLOCK_M = 128, BLOCK_K = 128}>
-#wg_constraint1 = #wave.workgroup_constraint<dim = <"M">, tile_size = <[BLOCK_M] -> (BLOCK_M)>, workgroup_dim = <x>>
-#wg_constraint2 = #wave.workgroup_constraint<dim = <"K">, tile_size = <[BLOCK_K] -> (BLOCK_K)>, workgroup_dim = <x>>
-// expected-error @below {{the dimension of the workgroup constraint in wg_constraint: #wave.symbol<"K"> should match the dimension of the wave constraint: #wave.symbol<"M">}}
-#wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = <[BLOCK_M] -> (BLOCK_M floordiv 4)>,
-                                       wg_constraint = #wg_constraint2>
-func.func private @test_wrong_wg_attr() attributes { wave.hyperparameters = #hyperparams, wave.constraints = [#wg_constraint1, #wg_constraint2, #wv_constraint] }
-
-// -----
-
-#hyperparams = #wave.hyperparameters<{M = 1024, K = 1024, BLOCK_M = 128, BLOCK_K = 128}>
 #wg_constraint = #wave.workgroup_constraint<dim = <"K">, tile_size = <[BLOCK_K] -> (BLOCK_K)>, workgroup_dim = <x>>
 #wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = <[BLOCK_M] -> (BLOCK_M floordiv 4)>>
 // expected-error @below {{missing corresponding workgroup constraint for dimension: #wave.symbol<"M">}}

--- a/water/test/Dialect/Wave/attr-constraint.mlir
+++ b/water/test/Dialect/Wave/attr-constraint.mlir
@@ -56,14 +56,6 @@ func.func private @test_tiling() attributes { wave.hyperparameters = #tl_hyperpa
 #wv_hyperparams = #wave.hyperparameters<{M = 1024, BLOCK_M = 128}>
 func.func private @test_wave1() attributes { wave.hyperparameters = #wv_hyperparams, wave.constraints = [#wg_constraint1, #wv_constraint1] }
 
-// CHECK-LABEL: @test_wave2
-// CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[BLOCK_M] -> (BLOCK_M floordiv 4)>,
-// CHECK:   wg_constraint = <dim = <"M">, tile_size = <[BLOCK_M] -> (BLOCK_M)>, workgroup_dim = <x>>
-#wv_constraint2 = #wave.wave_constraint<dim = <"M">,
-                                        tile_size = <[BLOCK_M] -> (BLOCK_M floordiv 4)>,
-                                        wg_constraint = #wg_constraint1>
-func.func private @test_wave2() attributes { wave.hyperparameters = #wv_hyperparams, wave.constraints = [#wg_constraint2, #wv_constraint2] }
-
 // CHECK-LABEL: @test_device
 // CHECK: #wave.device_constraint<dim = <"M">, tile_size = <[DEVICE_M] -> (DEVICE_M)>, device_dim = 0>
 #dv_constraint = #wave.device_constraint<dim = <"M">, tile_size = <[DEVICE_M] -> (DEVICE_M)>, device_dim = 0>

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -190,10 +190,11 @@ try:
         print(wave.DeviceConstraintAttr.get(dim="M", tile_size=expr_attr, device_dim=0))
 
         # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>>
-        wg_constraint = wave.WorkgroupConstraintAttr.get(
-            dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x
+        print(
+            wave.WorkgroupConstraintAttr.get(
+                dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x
+            )
         )
-        print(wg_constraint)
 
         # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>, primary = false>
         print(
@@ -204,13 +205,6 @@ try:
 
         # CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>>
         print(wave.WaveConstraintAttr.get(dim="M", tile_size=expr_attr))
-
-        # CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>, wg_constraint = <dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>>>
-        print(
-            wave.WaveConstraintAttr.get(
-                dim="M", tile_size=expr_attr, wg_constraint=wg_constraint
-            )
-        )
 
         # CHECK: #wave.tiling_constraint<dim = <"M">, tile_size = <[M, BLOCK_M] -> (M floordiv BLOCK_M)>>
         print(wave.TilingConstraintAttr.get(dim="M", tile_size=expr_attr))


### PR DESCRIPTION
Stacked PRs:
 * #422
 * #426
 * __->__#425


--- --- ---

### [water] remove wg_constraint parameter from wave_constraint


- wg_constraint is an implementation detail and never set in the wave DSL, so don't expose it on the IR level.

Signed-off-by: Tim Gymnich <tim@gymni.ch>
