### PR TITLE
[water] handle device constraint

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -122,7 +122,8 @@ static llvm::LogicalResult verifyAttributeHyperparamUses(
 
   // TODO: somehow get rid of these hardcoded magic names.
   static llvm::SmallVector<llvm::StringRef> fixmeMagicNames = {
-      "_GPR_NUM", "_T0", "_T1", "_T2", "_WG0", "_WG1", "_WG2"};
+      "_GPR_NUM", "_T0",  "_T1",  "_T2",  "_WG0",
+      "_WG1",     "_WG2", "_DD0", "_DD1", "_DD2"};
 
   mlir::WalkResult walkResult =
       namedAttr.getValue().walk([&](wave::WaveSymbolAttr symbolAttr) {

--- a/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
@@ -15,7 +15,9 @@
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
 
 #define DEBUG_TYPE "wave-lowering"
 #define LDBG() llvm::dbgs() << "[" DEBUG_TYPE "] "
@@ -88,6 +90,10 @@ materializeAffine(Location loc, ArrayRef<wave::WaveSymbolAttr> symbols,
       v = blockId(gpu::Dimension::y);
     else if (name == "_WG2")
       v = blockId(gpu::Dimension::z);
+    else if (llvm::is_contained({"_DD0", "_DD1", "_DD2"}, name))
+      return rewriter.notifyMatchFailure(
+          loc, "materialization of affine expressions containing device "
+               "dimension symbols is not implemented.");
     else if (std::optional<int64_t> value = hyper.getSymbolValue(name)) {
       v = rewriter.create<arith::ConstantIndexOp>(loc, *value);
     } else {


### PR DESCRIPTION
Stacked PRs:
 * #422
 * __->__#426


--- --- ---

### [water] handle device constraint


- make water symbol handling aware of the fixed magic names used for DeviceConstraint
- error out when encountering a device distribution symbol for now

Signed-off-by: Tim Gymnich <tim@gymni.ch>
