### PR TITLE
Add latency based scheduling for asm backend

### DIFF
--- a/lit_tests/kernel/wave/asm.py
+++ b/lit_tests/kernel/wave/asm.py
@@ -248,7 +248,8 @@ def test_mma():
     # CHECK:              ds_read_b64 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}
     # CHECK:              ds_read_b64 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}
     # CHECK:              v_mfma_f32_16x16x16_f16 a[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], 0
-    # CHECK:              s_nop 6
+    # CHECK:              # MFMA issued, latency ~{{[0-9]+}} cycles
+    # CHECK:              s_nop {{[0-9]+}}
     # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
     # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
     # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}

--- a/tests/kernel/wave/latency_infrastructure_test.py
+++ b/tests/kernel/wave/latency_infrastructure_test.py
@@ -1,0 +1,547 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tests for latency infrastructure: database, provider, and scoreboard.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+from datetime import datetime, timezone
+
+from wave_lang.kernel.wave.asm.latency_database import (
+    LatencyDatabaseManager,
+    ArchitectureLatencyDB,
+    InstructionTiming,
+    MeasurementSource,
+)
+from wave_lang.kernel.wave.asm.latency_provider import LatencyProvider
+from wave_lang.kernel.wave.asm.scoreboard import (
+    Scoreboard,
+    InstructionCategory,
+    PendingInstruction,
+)
+
+
+class TestLatencyDatabase:
+    """Tests for LatencyDatabaseManager and ArchitectureLatencyDB."""
+
+    def test_instruction_timing_creation(self):
+        """Test creating InstructionTiming instances."""
+        timing = InstructionTiming(
+            latency_cycles=8.0,
+            throughput_ops_per_cycle=0.125,
+            measurement_source=MeasurementSource.ISA_MANUAL,
+            notes="Test timing",
+            stddev_latency=0.5,
+        )
+
+        assert timing.latency_cycles == 8.0
+        assert timing.throughput_ops_per_cycle == 0.125
+        assert timing.measurement_source == MeasurementSource.ISA_MANUAL
+        assert timing.notes == "Test timing"
+        assert timing.stddev_latency == 0.5
+
+    def test_instruction_timing_serialization(self):
+        """Test InstructionTiming to_dict and from_dict."""
+        timing = InstructionTiming(
+            latency_cycles=4.0,
+            throughput_ops_per_cycle=1.0,
+            measurement_source=MeasurementSource.LLVM_CODEGEN,
+            notes="LLVM pattern",
+            stddev_latency=0.0,
+        )
+
+        # Serialize
+        d = timing.to_dict()
+        assert d["latency_cycles"] == 4.0
+        assert d["measurement_source"] == "llvm_codegen"
+
+        # Deserialize
+        timing2 = InstructionTiming.from_dict(d)
+        assert timing2.latency_cycles == timing.latency_cycles
+        assert timing2.measurement_source == timing.measurement_source
+
+    def test_architecture_db_creation(self):
+        """Test creating ArchitectureLatencyDB."""
+        db = ArchitectureLatencyDB(
+            architecture="gfx942",
+            version="1.0",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            instructions={},
+            instruction_classes={},
+        )
+
+        assert db.architecture == "gfx942"
+        assert db.version == "1.0"
+        assert len(db.instructions) == 0
+        assert len(db.instruction_classes) == 0
+
+    def test_architecture_db_direct_assignment(self):
+        """Test directly assigning instructions to database."""
+        db = ArchitectureLatencyDB(
+            architecture="gfx942",
+            version="1.0",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            instructions={},
+            instruction_classes={},
+        )
+
+        # Direct dict assignment
+        db.instructions["v_add_u32"] = InstructionTiming(
+            latency_cycles=4.0,
+            throughput_ops_per_cycle=0.25,
+            measurement_source=MeasurementSource.ISA_MANUAL,
+            notes="Vector add",
+            stddev_latency=0.0,
+        )
+
+        assert "v_add_u32" in db.instructions
+        assert db.instructions["v_add_u32"].latency_cycles == 4.0
+
+    def test_architecture_db_get_timing(self):
+        """Test querying instruction timing."""
+        db = ArchitectureLatencyDB(
+            architecture="gfx942",
+            version="1.0",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            instructions={
+                "buffer_load_dwordx4": InstructionTiming(
+                    latency_cycles=80.0,
+                    throughput_ops_per_cycle=0.25,
+                    measurement_source=MeasurementSource.ESTIMATED,
+                    notes="",
+                    stddev_latency=0.0,
+                )
+            },
+            instruction_classes={},
+        )
+
+        # Direct lookup
+        timing = db.get_timing("buffer_load_dwordx4")
+        assert timing is not None
+        assert timing.latency_cycles == 80.0
+
+        # Not found returns None
+        timing = db.get_timing("unknown_instruction")
+        assert timing is None
+
+    def test_architecture_db_save_load(self):
+        """Test saving and loading database."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create database
+            db = ArchitectureLatencyDB(
+                architecture="gfx942",
+                version="1.0",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                instructions={
+                    "v_add_u32": InstructionTiming(
+                        latency_cycles=4.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="Test",
+                        stddev_latency=0.0,
+                    )
+                },
+                instruction_classes={},
+            )
+
+            # Save
+            db_path = Path(tmpdir) / "gfx942.json"
+            db.save(str(db_path))
+            assert db_path.exists()
+
+            # Load
+            loaded_db = ArchitectureLatencyDB.load(str(db_path))
+            assert loaded_db.architecture == "gfx942"
+            assert "v_add_u32" in loaded_db.instructions
+            assert loaded_db.instructions["v_add_u32"].latency_cycles == 4.0
+
+    def test_database_manager_load_save(self):
+        """Test LatencyDatabaseManager operations."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = LatencyDatabaseManager(db_root=tmpdir)
+
+            # Create and save
+            db = ArchitectureLatencyDB(
+                architecture="gfx942",
+                version="1.0",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                instructions={
+                    "v_add_u32": InstructionTiming(
+                        latency_cycles=4.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="",
+                        stddev_latency=0.0,
+                    )
+                },
+                instruction_classes={},
+            )
+            manager.save_architecture("gfx942", db)
+
+            # Load
+            loaded_db = manager.load_architecture("gfx942")
+            assert loaded_db.architecture == "gfx942"
+            assert "v_add_u32" in loaded_db.instructions
+
+
+class TestLatencyProvider:
+    """Tests for LatencyProvider."""
+
+    @pytest.fixture
+    def test_db_path(self):
+        """Create a test database."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = ArchitectureLatencyDB(
+                architecture="gfx942",
+                version="1.0",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                instructions={
+                    "v_add_u32": InstructionTiming(
+                        latency_cycles=4.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "buffer_load_dwordx4": InstructionTiming(
+                        latency_cycles=80.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ESTIMATED,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "buffer_load_dwordx2": InstructionTiming(
+                        latency_cycles=80.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ESTIMATED,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "v_mfma_f32_16x16x16_f16": InstructionTiming(
+                        latency_cycles=8.0,
+                        throughput_ops_per_cycle=0.125,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "mfma_to_agpr_read": InstructionTiming(
+                        latency_cycles=6.0,
+                        throughput_ops_per_cycle=1.0,
+                        measurement_source=MeasurementSource.LLVM_CODEGEN,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "s_mov_b32": InstructionTiming(
+                        latency_cycles=1.0,
+                        throughput_ops_per_cycle=1.0,
+                        measurement_source=MeasurementSource.LLVM_CODEGEN,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "ds_read_b64": InstructionTiming(
+                        latency_cycles=20.0,
+                        throughput_ops_per_cycle=0.5,
+                        measurement_source=MeasurementSource.ESTIMATED,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                },
+                instruction_classes={},
+            )
+
+            db_path = Path(tmpdir) / "gfx942.json"
+            db.save(str(db_path))
+
+            yield tmpdir
+
+    def test_provider_initialization(self, test_db_path):
+        """Test LatencyProvider initialization."""
+        provider = LatencyProvider(arch="gfx942")
+        # Provider uses default path, so create one there too
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = ArchitectureLatencyDB(
+                architecture="gfx942",
+                version="1.0",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                instructions={},
+                instruction_classes={},
+            )
+            db_path = Path(tmpdir) / "gfx942.json"
+            db.save(str(db_path))
+
+            manager = LatencyDatabaseManager(db_root=tmpdir)
+            loaded = manager.load_architecture("gfx942")
+            assert loaded.architecture == "gfx942"
+
+    def test_get_latency(self, test_db_path):
+        """Test querying instruction latency."""
+        # Need to create provider with test db path
+        # Since LatencyProvider uses hardcoded path, we test the database manager instead
+        manager = LatencyDatabaseManager(db_root=test_db_path)
+        db = manager.load_architecture("gfx942")
+
+        # Known instruction
+        timing = db.get_timing("v_add_u32")
+        assert timing is not None
+        assert timing.latency_cycles == 4.0
+
+        # MFMA instruction
+        timing = db.get_timing("v_mfma_f32_16x16x16_f16")
+        assert timing is not None
+        assert timing.latency_cycles == 8.0
+
+        # Hazard latency
+        timing = db.get_timing("mfma_to_agpr_read")
+        assert timing is not None
+        assert timing.latency_cycles == 6.0
+
+        # Unknown instruction returns None
+        timing = db.get_timing("unknown_instruction")
+        assert timing is None
+
+    def test_get_throughput(self, test_db_path):
+        """Test querying instruction throughput."""
+        manager = LatencyDatabaseManager(db_root=test_db_path)
+        db = manager.load_architecture("gfx942")
+
+        timing = db.get_timing("v_add_u32")
+        assert timing is not None
+        assert timing.throughput_ops_per_cycle == 0.25
+
+        timing = db.get_timing("v_mfma_f32_16x16x16_f16")
+        assert timing is not None
+        assert timing.throughput_ops_per_cycle == 0.125
+
+        # Unknown instruction returns None
+        timing = db.get_timing("unknown_instruction")
+        assert timing is None
+
+
+class TestScoreboard:
+    """Tests for Scoreboard-based hazard detection."""
+
+    @pytest.fixture
+    def test_provider(self):
+        """Create a test LatencyProvider with known latencies."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = ArchitectureLatencyDB(
+                architecture="gfx942",
+                version="1.0",
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                instructions={
+                    "buffer_load_dwordx4": InstructionTiming(
+                        latency_cycles=80.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ESTIMATED,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "v_add_u32": InstructionTiming(
+                        latency_cycles=4.0,
+                        throughput_ops_per_cycle=0.25,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "v_mfma_f32_16x16x16_f16": InstructionTiming(
+                        latency_cycles=8.0,
+                        throughput_ops_per_cycle=0.125,
+                        measurement_source=MeasurementSource.ISA_MANUAL,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "ds_read_b64": InstructionTiming(
+                        latency_cycles=20.0,
+                        throughput_ops_per_cycle=0.5,
+                        measurement_source=MeasurementSource.ESTIMATED,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                    "s_mov_b32": InstructionTiming(
+                        latency_cycles=1.0,
+                        throughput_ops_per_cycle=1.0,
+                        measurement_source=MeasurementSource.LLVM_CODEGEN,
+                        notes="",
+                        stddev_latency=0.0,
+                    ),
+                },
+                instruction_classes={},
+            )
+
+            db_path = Path(tmpdir) / "gfx942.json"
+            db.save(str(db_path))
+
+            # Create provider - note it uses hardcoded path, so we work around it
+            manager = LatencyDatabaseManager(db_root=tmpdir)
+            provider = LatencyProvider.__new__(LatencyProvider)
+            provider.arch = "gfx942"
+            provider.db_manager = manager
+            provider.db = manager.load_architecture("gfx942")
+            yield provider
+
+    def test_scoreboard_initialization(self, test_provider):
+        """Test Scoreboard initialization."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        assert scoreboard.current_cycle == 0
+        assert len(scoreboard.pending[InstructionCategory.VMEM]) == 0
+
+    def test_instruction_categorization(self, test_provider):
+        """Test instruction category inference."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        assert (
+            scoreboard._categorize_instruction("buffer_load_dwordx4")
+            == InstructionCategory.VMEM
+        )
+        assert (
+            scoreboard._categorize_instruction("buffer_store_dword")
+            == InstructionCategory.VMEM
+        )
+        assert (
+            scoreboard._categorize_instruction("ds_read_b64")
+            == InstructionCategory.LGKM
+        )
+        assert (
+            scoreboard._categorize_instruction("s_load_dwordx2")
+            == InstructionCategory.LGKM
+        )
+        assert (
+            scoreboard._categorize_instruction("v_mfma_f32_16x16x16_f16")
+            == InstructionCategory.MFMA
+        )
+        assert (
+            scoreboard._categorize_instruction("v_add_u32") == InstructionCategory.VALU
+        )
+        assert (
+            scoreboard._categorize_instruction("s_mov_b32") == InstructionCategory.SALU
+        )
+
+    def test_issue_instruction(self, test_provider):
+        """Test issuing instructions to scoreboard."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        pending = scoreboard.issue(
+            "buffer_load_dwordx4", writes={"v0", "v1", "v2", "v3"}, ticket=0
+        )
+
+        assert pending.instruction == "buffer_load_dwordx4"
+        assert pending.category == InstructionCategory.VMEM
+        assert pending.latency == 80.0
+        assert pending.writes == {"v0", "v1", "v2", "v3"}
+        assert pending.ticket == 0
+
+        # Check it's in pending list
+        assert len(scoreboard.pending[InstructionCategory.VMEM]) == 1
+
+    def test_advance_cycles(self, test_provider):
+        """Test advancing scoreboard and retiring instructions."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue a short-latency instruction
+        scoreboard.issue("v_add_u32", writes={"v0"})
+        assert len(scoreboard.pending[InstructionCategory.VALU]) == 1
+        assert scoreboard.current_cycle == 0
+
+        # Advance past latency (4 cycles)
+        scoreboard.advance(5)
+        assert scoreboard.current_cycle == 5
+
+        # Should be retired
+        assert len(scoreboard.pending[InstructionCategory.VALU]) == 0
+
+    def test_raw_hazard_detection(self, test_provider):
+        """Test Read-After-Write hazard detection."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue load that writes to v0-v3
+        scoreboard.issue(
+            "buffer_load_dwordx4", writes={"v0", "v1", "v2", "v3"}, ticket=0
+        )
+
+        # Check hazard for instruction reading v0
+        hazard = scoreboard.check_hazard(reads={"v0"})
+        assert hazard is not None
+        hazard_type, cycles_needed = hazard
+        assert hazard_type == "RAW"
+        assert cycles_needed == 80  # Full load latency
+
+        # Advance halfway
+        scoreboard.advance(40)
+        hazard = scoreboard.check_hazard(reads={"v0"})
+        assert hazard is not None
+        hazard_type, cycles_needed = hazard
+        assert cycles_needed == 40  # Remaining latency
+
+        # Advance past latency
+        scoreboard.advance(50)
+        hazard = scoreboard.check_hazard(reads={"v0"})
+        assert hazard is None  # No hazard, instruction complete
+
+    def test_waw_hazard_detection(self, test_provider):
+        """Test Write-After-Write hazard detection."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue instruction writing to v0
+        scoreboard.issue("v_add_u32", writes={"v0"})
+
+        # Check hazard for another instruction writing v0
+        hazard = scoreboard.check_hazard(writes={"v0"})
+        assert hazard is not None
+        hazard_type, cycles_needed = hazard
+        assert hazard_type == "WAW"
+        assert cycles_needed == 4
+
+    def test_no_hazard(self, test_provider):
+        """Test case with no hazards."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue instruction writing v0
+        scoreboard.issue("v_add_u32", writes={"v0"})
+
+        # Check for instruction using different registers
+        hazard = scoreboard.check_hazard(reads={"v1"}, writes={"v2"})
+        assert hazard is None
+
+    def test_vmem_wait_count(self, test_provider):
+        """Test VMEM ticket-based wait count calculation."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue multiple loads with tickets
+        scoreboard.issue("buffer_load_dwordx4", ticket=0)
+        scoreboard.issue("buffer_load_dwordx4", ticket=1)
+        scoreboard.issue("buffer_load_dwordx4", ticket=2)
+
+        # Wait for ticket 0: allows tickets 1 and 2 to be in-flight
+        vmcnt = scoreboard.get_vmem_wait_count(0)
+        assert vmcnt == 2
+
+        # Wait for ticket 1: allows ticket 2 to be in-flight
+        vmcnt = scoreboard.get_vmem_wait_count(1)
+        assert vmcnt == 1
+
+        # Wait for ticket 2: all must complete
+        vmcnt = scoreboard.get_vmem_wait_count(2)
+        assert vmcnt == 0
+
+    def test_lgkm_wait_count(self, test_provider):
+        """Test LGKM ticket-based wait count calculation."""
+        scoreboard = Scoreboard(latency_provider=test_provider)
+
+        # Issue multiple LDS reads with tickets
+        scoreboard.issue("ds_read_b64", ticket=0)
+        scoreboard.issue("ds_read_b64", ticket=1)
+
+        # Wait for ticket 0
+        lgkmcnt = scoreboard.get_lgkm_wait_count(0)
+        assert lgkmcnt == 1  # Ticket 1 can be in-flight
+
+        # Wait for ticket 1
+        lgkmcnt = scoreboard.get_lgkm_wait_count(1)
+        assert lgkmcnt == 0  # All must complete

--- a/tests/kernel/wave/ticketing_test.py
+++ b/tests/kernel/wave/ticketing_test.py
@@ -1,0 +1,531 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tests for VMEM and LGKM ticketing system.
+"""
+
+import pytest
+from wave_lang.kernel.wave.asm.ticketing import Ticketing
+
+
+class TestVMEMTicketing:
+    """Tests for VMEM (vector memory) ticketing."""
+
+    def test_vmem_ticket_initialization(self):
+        """Test initial state of VMEM ticketing."""
+        ticketing = Ticketing()
+
+        assert ticketing._vmem_last_ticket == -1
+        assert ticketing._vmem_last_wait_threshold is None
+
+    def test_vmem_ticket_issuance(self):
+        """Test issuing VMEM tickets."""
+        ticketing = Ticketing()
+
+        t0 = ticketing.next_vmem_ticket()
+        t1 = ticketing.next_vmem_ticket()
+        t2 = ticketing.next_vmem_ticket()
+
+        assert t0 == 0
+        assert t1 == 1
+        assert t2 == 2
+        assert ticketing._vmem_last_ticket == 2
+
+    def test_vmem_compute_wait_first_time(self):
+        """Test computing VMEM wait for the first time."""
+        ticketing = Ticketing()
+
+        # Issue 3 VMEM operations
+        ticketing.next_vmem_ticket()  # ticket 0
+        ticketing.next_vmem_ticket()  # ticket 1
+        ticketing.next_vmem_ticket()  # ticket 2
+
+        # Wait for ticket 0: allow tickets 1 and 2 to remain in-flight
+        threshold = ticketing.compute_vmem_wait(0)
+        assert threshold == 2  # max(0, 2 - 0) = 2
+        assert ticketing._vmem_last_wait_threshold == 2
+
+    def test_vmem_compute_wait_coalescing(self):
+        """Test VMEM wait coalescing (returns None for less strict waits)."""
+        ticketing = Ticketing()
+
+        # Issue 5 VMEM operations (tickets 0-4)
+        for _ in range(5):
+            ticketing.next_vmem_ticket()
+
+        # First wait for ticket 1: threshold = 4-1 = 3
+        threshold1 = ticketing.compute_vmem_wait(1)
+        assert threshold1 == 3
+
+        # Try to wait for ticket 0 (less strict): should return None
+        threshold2 = ticketing.compute_vmem_wait(0)
+        assert threshold2 is None  # Already waiting for 3, which is stricter
+
+        # Wait for ticket 3 (more strict): threshold = 4-3 = 1
+        threshold3 = ticketing.compute_vmem_wait(3)
+        assert threshold3 == 1  # More strict, so emitted
+
+    def test_vmem_ticket_invalidates_wait_threshold(self):
+        """Test that issuing a new ticket invalidates the wait threshold."""
+        ticketing = Ticketing()
+
+        # Issue and wait
+        ticketing.next_vmem_ticket()
+        ticketing.compute_vmem_wait(0)
+        assert ticketing._vmem_last_wait_threshold == 0
+
+        # Issue new ticket - should clear wait threshold
+        ticketing.next_vmem_ticket()
+        assert ticketing._vmem_last_wait_threshold is None
+
+    def test_vmem_zero_threshold(self):
+        """Test VMEM wait with zero threshold (drain all)."""
+        ticketing = Ticketing()
+
+        # Issue tickets
+        ticketing.next_vmem_ticket()
+        ticketing.next_vmem_ticket()
+
+        # Wait for last ticket: threshold should be 0
+        threshold = ticketing.compute_vmem_wait(1)
+        assert threshold == 0  # max(0, 1-1) = 0
+
+
+class TestLGKMTicketing:
+    """Tests for LGKM (LDS/scalar memory) ticketing."""
+
+    def test_lgkm_ticket_initialization(self):
+        """Test initial state of LGKM ticketing."""
+        ticketing = Ticketing()
+
+        assert ticketing._lgkm_last_ticket == -1
+        assert ticketing._lgkm_last_wait_threshold is None
+
+    def test_lgkm_ticket_issuance(self):
+        """Test issuing LGKM tickets."""
+        ticketing = Ticketing()
+
+        t0 = ticketing.next_lgkm_ticket()
+        t1 = ticketing.next_lgkm_ticket()
+        t2 = ticketing.next_lgkm_ticket()
+
+        assert t0 == 0
+        assert t1 == 1
+        assert t2 == 2
+        assert ticketing._lgkm_last_ticket == 2
+
+    def test_lgkm_compute_wait_first_time(self):
+        """Test computing LGKM wait for the first time."""
+        ticketing = Ticketing()
+
+        # Issue 3 LGKM operations
+        ticketing.next_lgkm_ticket()  # ticket 0
+        ticketing.next_lgkm_ticket()  # ticket 1
+        ticketing.next_lgkm_ticket()  # ticket 2
+
+        # Wait for ticket 0: allow tickets 1 and 2 to remain in-flight
+        threshold = ticketing.compute_lgkm_wait(0)
+        assert threshold == 2  # max(0, 2 - 0) = 2
+        assert ticketing._lgkm_last_wait_threshold == 2
+
+    def test_lgkm_compute_wait_coalescing(self):
+        """Test LGKM wait coalescing (returns None for less strict waits)."""
+        ticketing = Ticketing()
+
+        # Issue 4 LGKM operations
+        for _ in range(4):
+            ticketing.next_lgkm_ticket()
+
+        # First wait for ticket 1: threshold = 3-1 = 2
+        threshold1 = ticketing.compute_lgkm_wait(1)
+        assert threshold1 == 2
+
+        # Try to wait for ticket 0 (less strict): should return None
+        threshold2 = ticketing.compute_lgkm_wait(0)
+        assert threshold2 is None  # Already waiting for 2, which is stricter
+
+        # Wait for ticket 2 (more strict): threshold = 3-2 = 1
+        threshold3 = ticketing.compute_lgkm_wait(2)
+        assert threshold3 == 1  # More strict, so emitted
+
+    def test_lgkm_ticket_invalidates_wait_threshold(self):
+        """Test that issuing a new ticket invalidates the wait threshold."""
+        ticketing = Ticketing()
+
+        # Issue and wait
+        ticketing.next_lgkm_ticket()
+        ticketing.compute_lgkm_wait(0)
+        assert ticketing._lgkm_last_wait_threshold == 0
+
+        # Issue new ticket - should clear wait threshold
+        ticketing.next_lgkm_ticket()
+        assert ticketing._lgkm_last_wait_threshold is None
+
+    def test_lgkm_observe_wait(self):
+        """Test observing external LGKM waits."""
+        ticketing = Ticketing()
+
+        # No wait observed yet
+        assert ticketing._lgkm_last_wait_threshold is None
+
+        # Observe a wait to threshold 2
+        ticketing.observe_lgkm_wait(2)
+        assert ticketing._lgkm_last_wait_threshold == 2
+
+        # Observe a stricter wait (lower threshold)
+        ticketing.observe_lgkm_wait(1)
+        assert ticketing._lgkm_last_wait_threshold == 1
+
+        # Observe a less strict wait (higher threshold) - should be ignored
+        ticketing.observe_lgkm_wait(3)
+        assert ticketing._lgkm_last_wait_threshold == 1  # Unchanged
+
+
+class TestLGKMTicketingWithBarriers:
+    """Tests for LGKM ticketing with user-specified barriers."""
+
+    def test_barrier_with_outstanding_lgkm(self):
+        """Test barrier emits lgkmcnt(0) when LGKM ops are outstanding."""
+        ticketing = Ticketing()
+
+        # Issue some LGKM operations
+        t0 = ticketing.next_lgkm_ticket()
+        t1 = ticketing.next_lgkm_ticket()
+
+        assert t0 == 0
+        assert t1 == 1
+        assert ticketing._lgkm_last_ticket == 1
+        assert ticketing._lgkm_last_wait_threshold is None
+
+        # Simulate barrier: check if wait is needed
+        has_outstanding = (
+            ticketing._lgkm_last_ticket >= 0
+            and ticketing._lgkm_last_wait_threshold != 0
+        )
+        assert has_outstanding is True  # Should emit lgkmcnt(0)
+
+        # Observe the wait
+        ticketing.observe_lgkm_wait(0)
+        assert ticketing._lgkm_last_wait_threshold == 0
+
+    def test_barrier_without_outstanding_lgkm(self):
+        """Test barrier skips lgkmcnt(0) when no LGKM ops are outstanding."""
+        ticketing = Ticketing()
+
+        # No LGKM operations issued
+        assert ticketing._lgkm_last_ticket == -1
+
+        # Simulate barrier: check if wait is needed
+        has_outstanding = (
+            ticketing._lgkm_last_ticket >= 0
+            and ticketing._lgkm_last_wait_threshold != 0
+        )
+        assert has_outstanding is False  # Should NOT emit lgkmcnt(0)
+
+        # Still observe the wait (barrier implies drain)
+        ticketing.observe_lgkm_wait(0)
+        assert ticketing._lgkm_last_wait_threshold == 0
+
+    def test_consecutive_barriers_coalesce(self):
+        """Test consecutive barriers emit only one lgkmcnt(0)."""
+        ticketing = Ticketing()
+
+        # Issue LGKM operation
+        ticketing.next_lgkm_ticket()
+
+        # First barrier: should emit lgkmcnt(0)
+        has_outstanding_1 = (
+            ticketing._lgkm_last_ticket >= 0
+            and ticketing._lgkm_last_wait_threshold != 0
+        )
+        assert has_outstanding_1 is True
+        ticketing.observe_lgkm_wait(0)
+
+        # Second barrier immediately after: should NOT emit lgkmcnt(0)
+        has_outstanding_2 = (
+            ticketing._lgkm_last_ticket >= 0
+            and ticketing._lgkm_last_wait_threshold != 0
+        )
+        assert has_outstanding_2 is False  # Already drained
+        ticketing.observe_lgkm_wait(0)  # Still observe for consistency
+
+    def test_barrier_then_new_lgkm_then_barrier(self):
+        """Test barrier, new LGKM op, then another barrier."""
+        ticketing = Ticketing()
+
+        # Issue LGKM and barrier
+        ticketing.next_lgkm_ticket()
+        ticketing.observe_lgkm_wait(0)
+        assert ticketing._lgkm_last_wait_threshold == 0
+
+        # Issue new LGKM operation after barrier
+        t2 = ticketing.next_lgkm_ticket()
+        assert t2 == 1
+        assert ticketing._lgkm_last_wait_threshold is None  # Reset by next_lgkm_ticket
+
+        # Another barrier: should emit lgkmcnt(0) again for new LGKM op
+        has_outstanding = (
+            ticketing._lgkm_last_ticket >= 0
+            and ticketing._lgkm_last_wait_threshold != 0
+        )
+        assert has_outstanding is True
+        ticketing.observe_lgkm_wait(0)
+
+    def test_compute_lgkm_wait_after_observe(self):
+        """Test compute_lgkm_wait returns None after observe(0)."""
+        ticketing = Ticketing()
+
+        # Issue LGKM operations
+        t0 = ticketing.next_lgkm_ticket()
+        t1 = ticketing.next_lgkm_ticket()
+
+        # Observe lgkmcnt(0) (as barrier would)
+        ticketing.observe_lgkm_wait(0)
+
+        # Try to compute wait for any ticket - should return None (already drained)
+        wait = ticketing.compute_lgkm_wait(t0)
+        assert wait is None
+
+        wait = ticketing.compute_lgkm_wait(t1)
+        assert wait is None
+
+    def test_observe_does_not_reset_tickets(self):
+        """Test observe_lgkm_wait does not reset ticket counter."""
+        ticketing = Ticketing()
+
+        # Issue LGKM operations
+        ticketing.next_lgkm_ticket()  # ticket 0
+        ticketing.next_lgkm_ticket()  # ticket 1
+
+        # Observe wait
+        ticketing.observe_lgkm_wait(0)
+
+        # Ticket counter should remain unchanged
+        assert ticketing._lgkm_last_ticket == 1
+
+        # Next ticket should be 2, not 0
+        t_next = ticketing.next_lgkm_ticket()
+        assert t_next == 2
+
+
+class TestTicketingIndependence:
+    """Tests to ensure VMEM and LGKM ticketing are independent."""
+
+    def test_vmem_and_lgkm_independent_tickets(self):
+        """Test VMEM and LGKM ticket counters are independent."""
+        ticketing = Ticketing()
+
+        # Issue mixed operations
+        v0 = ticketing.next_vmem_ticket()
+        l0 = ticketing.next_lgkm_ticket()
+        v1 = ticketing.next_vmem_ticket()
+        l1 = ticketing.next_lgkm_ticket()
+
+        # Each counter tracks independently
+        assert v0 == 0 and v1 == 1
+        assert l0 == 0 and l1 == 1
+        assert ticketing._vmem_last_ticket == 1
+        assert ticketing._lgkm_last_ticket == 1
+
+    def test_vmem_wait_does_not_affect_lgkm(self):
+        """Test VMEM wait computation doesn't affect LGKM."""
+        ticketing = Ticketing()
+
+        # Issue both types
+        ticketing.next_vmem_ticket()
+        ticketing.next_lgkm_ticket()
+
+        # Compute VMEM wait
+        vmem_threshold = ticketing.compute_vmem_wait(0)
+        assert vmem_threshold == 0
+
+        # LGKM threshold should be unaffected
+        assert ticketing._lgkm_last_wait_threshold is None
+
+    def test_lgkm_wait_does_not_affect_vmem(self):
+        """Test LGKM wait computation doesn't affect VMEM."""
+        ticketing = Ticketing()
+
+        # Issue both types
+        ticketing.next_vmem_ticket()
+        ticketing.next_lgkm_ticket()
+
+        # Compute LGKM wait
+        lgkm_threshold = ticketing.compute_lgkm_wait(0)
+        assert lgkm_threshold == 0
+
+        # VMEM threshold should be unaffected
+        assert ticketing._vmem_last_wait_threshold is None
+
+
+class TestEmitterDrivenTicketing:
+    """Tests for automatic ticketing via emit_instruction."""
+
+    def test_vmem_instruction_issues_ticket(self):
+        """Test VMEM instructions automatically issue tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Initially no tickets issued
+        assert emitter.ticketing._vmem_last_ticket == -1
+
+        # Emit a VMEM instruction
+        class MockBufferLoad(Instruction):
+            def __init__(self):
+                super().__init__("buffer_load_dwordx4", ["v[0:3]", "v4", "s[0:3]", "0"])
+
+        emitter.emit_instruction(MockBufferLoad())
+
+        # Should have issued one VMEM ticket
+        assert emitter.ticketing._vmem_last_ticket == 0
+        assert emitter.ticketing._lgkm_last_ticket == -1  # LGKM unchanged
+
+    def test_lgkm_instruction_issues_ticket(self):
+        """Test LGKM instructions automatically issue tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Initially no tickets issued
+        assert emitter.ticketing._lgkm_last_ticket == -1
+
+        # Emit an LGKM instruction (LDS read)
+        class MockDSRead(Instruction):
+            def __init__(self):
+                super().__init__("ds_read_b64", ["v[0:1]", "v2"])
+
+        emitter.emit_instruction(MockDSRead())
+
+        # Should have issued one LGKM ticket
+        assert emitter.ticketing._lgkm_last_ticket == 0
+        assert emitter.ticketing._vmem_last_ticket == -1  # VMEM unchanged
+
+    def test_salu_instruction_no_ticket(self):
+        """Test SALU instructions don't issue tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Emit a SALU instruction
+        class MockSMov(Instruction):
+            def __init__(self):
+                super().__init__("s_mov_b32", ["s0", "s1"])
+
+        emitter.emit_instruction(MockSMov())
+
+        # No tickets should be issued
+        assert emitter.ticketing._vmem_last_ticket == -1
+        assert emitter.ticketing._lgkm_last_ticket == -1
+
+    def test_valu_instruction_no_ticket(self):
+        """Test VALU instructions don't issue tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Emit a VALU instruction
+        class MockVAdd(Instruction):
+            def __init__(self):
+                super().__init__("v_add_u32", ["v0", "v1", "v2"])
+
+        emitter.emit_instruction(MockVAdd())
+
+        # No tickets should be issued
+        assert emitter.ticketing._vmem_last_ticket == -1
+        assert emitter.ticketing._lgkm_last_ticket == -1
+
+    def test_mfma_instruction_no_ticket(self):
+        """Test MFMA instructions don't issue tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Emit an MFMA instruction
+        class MockMFMA(Instruction):
+            def __init__(self):
+                super().__init__(
+                    "v_mfma_f32_16x16x16_f16", ["a[0:3]", "v[0:1]", "v[2:3]", "a[0:3]"]
+                )
+
+        emitter.emit_instruction(MockMFMA())
+
+        # No tickets should be issued
+        assert emitter.ticketing._vmem_last_ticket == -1
+        assert emitter.ticketing._lgkm_last_ticket == -1
+
+    def test_mixed_instruction_sequence(self):
+        """Test mixed sequence issues tickets correctly."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Create mock instructions
+        class MockBufferLoad(Instruction):
+            def __init__(self):
+                super().__init__("buffer_load_dwordx4", ["v[0:3]", "v4", "s[0:3]", "0"])
+
+        class MockDSRead(Instruction):
+            def __init__(self):
+                super().__init__("ds_read_b64", ["v[0:1]", "v2"])
+
+        class MockVAdd(Instruction):
+            def __init__(self):
+                super().__init__("v_add_u32", ["v0", "v1", "v2"])
+
+        class MockBufferStore(Instruction):
+            def __init__(self):
+                super().__init__("buffer_store_dword", ["v0", "v1", "s[0:3]", "0"])
+
+        class MockDSWrite(Instruction):
+            def __init__(self):
+                super().__init__("ds_write_b32", ["v0", "v1"])
+
+        # Emit sequence: VMEM load, LGKM read, VALU, VMEM store, LGKM write
+        emitter.emit_instruction(MockBufferLoad())  # VMEM ticket 0
+        assert emitter.ticketing._vmem_last_ticket == 0
+        assert emitter.ticketing._lgkm_last_ticket == -1
+
+        emitter.emit_instruction(MockDSRead())  # LGKM ticket 0
+        assert emitter.ticketing._vmem_last_ticket == 0
+        assert emitter.ticketing._lgkm_last_ticket == 0
+
+        emitter.emit_instruction(MockVAdd())  # No ticket
+        assert emitter.ticketing._vmem_last_ticket == 0
+        assert emitter.ticketing._lgkm_last_ticket == 0
+
+        emitter.emit_instruction(MockBufferStore())  # VMEM ticket 1
+        assert emitter.ticketing._vmem_last_ticket == 1
+        assert emitter.ticketing._lgkm_last_ticket == 0
+
+        emitter.emit_instruction(MockDSWrite())  # LGKM ticket 1
+        assert emitter.ticketing._vmem_last_ticket == 1
+        assert emitter.ticketing._lgkm_last_ticket == 1
+
+    def test_scalar_load_issues_lgkm_ticket(self):
+        """Test scalar load (s_load) instructions issue LGKM tickets."""
+        from wave_lang.kernel.wave.asm.asm_emitter import AsmEmitter
+        from wave_lang.kernel.wave.asm.instructions import Instruction
+
+        emitter = AsmEmitter(targetid="gfx942", codeobj="COv5")
+
+        # Emit a scalar load
+        class MockSLoad(Instruction):
+            def __init__(self):
+                super().__init__("s_load_dwordx2", ["s[0:1]", "s[2:3]", "0x0"])
+
+        emitter.emit_instruction(MockSLoad())
+
+        # Should have issued one LGKM ticket
+        assert emitter.ticketing._lgkm_last_ticket == 0
+        assert emitter.ticketing._vmem_last_ticket == -1

--- a/wave_lang/kernel/wave/asm/instruction_categories.py
+++ b/wave_lang/kernel/wave/asm/instruction_categories.py
@@ -1,0 +1,77 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Instruction categorization for AMDGCN assembly.
+
+Shared utility for categorizing instructions by their functional class
+(VMEM, LGKM, VALU, SALU, MFMA, etc.), used by both the scoreboard and
+the assembler emitter for consistent ticketing and hazard detection.
+"""
+
+from enum import Enum
+
+
+class InstructionCategory(Enum):
+    """Categories of instructions for scoreboarding and ticketing."""
+
+    VMEM = "vmem"  # Vector memory (buffer_load/store)
+    LGKM = "lgkm"  # LDS/GDS/scalar memory/messages
+    VALU = "valu"  # Vector ALU
+    SALU = "salu"  # Scalar ALU
+    MFMA = "mfma"  # Matrix FMA
+    OTHER = "other"  # Unknown/other
+
+
+def categorize_instruction(instruction: str) -> InstructionCategory:
+    """
+    Categorize an instruction by its mnemonic.
+
+    Uses fast prefix-based rules to classify instructions into functional
+    categories. This categorization is used for both ticketing (VMEM/LGKM
+    operations need tickets) and hazard detection (scoreboard tracking).
+
+    Args:
+        instruction: Instruction mnemonic (e.g., "buffer_load_dwordx4", "ds_read_b64")
+
+    Returns:
+        InstructionCategory for the instruction
+
+    Examples:
+        >>> categorize_instruction("buffer_load_dwordx4")
+        InstructionCategory.VMEM
+        >>> categorize_instruction("ds_write_b32")
+        InstructionCategory.LGKM
+        >>> categorize_instruction("v_add_u32")
+        InstructionCategory.VALU
+        >>> categorize_instruction("s_mov_b32")
+        InstructionCategory.SALU
+        >>> categorize_instruction("v_mfma_f32_16x16x16_f16")
+        InstructionCategory.MFMA
+    """
+    # Vector memory operations (buffer loads/stores)
+    if instruction.startswith("buffer_"):
+        return InstructionCategory.VMEM
+
+    # LDS/GDS/scalar memory operations
+    # Includes: ds_read, ds_write, s_load, messages
+    elif instruction.startswith("ds_") or instruction.startswith("s_load"):
+        return InstructionCategory.LGKM
+
+    # Matrix FMA operations (must check before generic v_ prefix)
+    elif instruction.startswith("v_mfma"):
+        return InstructionCategory.MFMA
+
+    # Vector ALU operations
+    elif instruction.startswith("v_"):
+        return InstructionCategory.VALU
+
+    # Scalar ALU operations
+    elif instruction.startswith("s_"):
+        return InstructionCategory.SALU
+
+    # Everything else (NOPs, waits, barriers, etc.)
+    else:
+        return InstructionCategory.OTHER

--- a/wave_lang/kernel/wave/asm/latency_database.py
+++ b/wave_lang/kernel/wave/asm/latency_database.py
@@ -1,0 +1,161 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Instruction Latency and Throughput Database.
+
+Stores measured or documented latency/throughput values per architecture.
+
+Database Schema:
+{
+  "architecture": "gfx942",
+  "version": "1.0",
+  "timestamp": "2025-11-01T12:00:00Z",
+  "instructions": {
+    "buffer_load_dword": {
+      "latency_cycles": 80,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "measured",
+      "notes": "Average latency from microbench"
+    },
+    ...
+  },
+  "instruction_classes": {
+    "vmem_load": {
+      "latency_cycles": 80,
+      "throughput_ops_per_cycle": 0.25
+    },
+    ...
+  }
+}
+"""
+
+import json
+from dataclasses import dataclass, asdict
+from typing import Dict, Optional
+from pathlib import Path
+from enum import Enum
+
+
+class MeasurementSource(Enum):
+    """Source of latency/throughput data."""
+
+    MEASURED = "measured"  # From microbenchmarks
+    ISA_MANUAL = "isa_manual"  # From AMD ISA documentation
+    ESTIMATED = "estimated"  # Conservative estimate
+    PROFILED = "profiled"  # From rocprof/rocblas data
+    LLVM_CODEGEN = "llvm_codegen"  # From LLVM compiler codegen patterns
+
+
+@dataclass
+class InstructionTiming:
+    """Timing characteristics for an instruction."""
+
+    latency_cycles: float
+    throughput_ops_per_cycle: float
+    measurement_source: MeasurementSource
+    notes: str
+    stddev_latency: float
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        d = asdict(self)
+        d["measurement_source"] = self.measurement_source.value
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "InstructionTiming":
+        """Create from dictionary."""
+        return cls(
+            latency_cycles=d["latency_cycles"],
+            throughput_ops_per_cycle=d["throughput_ops_per_cycle"],
+            measurement_source=MeasurementSource(d["measurement_source"]),
+            notes=d.get("notes", ""),
+            stddev_latency=d.get("stddev_latency", 0.0),
+        )
+
+
+@dataclass
+class ArchitectureLatencyDB:
+    """Latency database for a specific architecture."""
+
+    architecture: str
+    version: str
+    timestamp: str
+    instructions: Dict[str, InstructionTiming]
+    instruction_classes: Dict[str, InstructionTiming]
+
+    def get_timing(self, instruction: str) -> Optional[InstructionTiming]:
+        """Get timing for an instruction."""
+        return self.instructions.get(instruction)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "architecture": self.architecture,
+            "version": self.version,
+            "timestamp": self.timestamp,
+            "instructions": {k: v.to_dict() for k, v in self.instructions.items()},
+            "instruction_classes": {
+                k: v.to_dict() for k, v in self.instruction_classes.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ArchitectureLatencyDB":
+        """Create from dictionary."""
+        instructions = {
+            name: InstructionTiming.from_dict(timing_dict)
+            for name, timing_dict in d["instructions"].items()
+        }
+        instruction_classes = {
+            name: InstructionTiming.from_dict(timing_dict)
+            for name, timing_dict in d.get("instruction_classes", {}).items()
+        }
+        return cls(
+            architecture=d["architecture"],
+            version=d["version"],
+            timestamp=d["timestamp"],
+            instructions=instructions,
+            instruction_classes=instruction_classes,
+        )
+
+    def save(self, path: str):
+        """Save database to JSON file."""
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def load(cls, path: str) -> "ArchitectureLatencyDB":
+        """Load database from JSON file."""
+        with open(path, "r") as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+
+
+class LatencyDatabaseManager:
+    """Manages latency databases for multiple architectures."""
+
+    def __init__(self, db_root: str):
+        """Initialize database manager."""
+        self.db_root = Path(db_root)
+        self.databases: Dict[str, ArchitectureLatencyDB] = {}
+
+    def load_architecture(self, arch: str) -> ArchitectureLatencyDB:
+        """Load database for a specific architecture."""
+        if arch in self.databases:
+            return self.databases[arch]
+
+        db_path = self.db_root / f"{arch}.json"
+        db = ArchitectureLatencyDB.load(str(db_path))
+        self.databases[arch] = db
+        return db
+
+    def save_architecture(self, arch: str, db: ArchitectureLatencyDB):
+        """Save database for a specific architecture."""
+        self.db_root.mkdir(parents=True, exist_ok=True)
+        db_path = self.db_root / f"{arch}.json"
+        db.save(str(db_path))
+        self.databases[arch] = db

--- a/wave_lang/kernel/wave/asm/latency_db/gfx942.json
+++ b/wave_lang/kernel/wave/asm/latency_db/gfx942.json
@@ -1,0 +1,456 @@
+{
+  "architecture": "gfx942",
+  "version": "1.0",
+  "timestamp": "2025-11-05T07:05:19.487897+00:00",
+  "instructions": {
+    "v_add_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer add, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_sub_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer subtract, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_lo_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer multiply low, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_hi_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer multiply high, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_add_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 add, 4-cycle latency, full-rate",
+      "stddev_latency": 0.0
+    },
+    "v_sub_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 subtract, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 multiply, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_fma_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 FMA, 4-cycle latency, full-rate",
+      "stddev_latency": 0.0
+    },
+    "v_and_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise AND, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_or_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise OR, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_xor_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise XOR, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_lshlrev_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Left shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_lshrrev_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Logical right shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_ashrrev_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Arithmetic right shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mov_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Move, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cndmask_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Conditional mask, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_eq_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare equal, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_lt_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare less than, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_gt_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare greater than, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_add_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar add, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_sub_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar subtract, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_mul_i32": {
+      "latency_cycles": 2.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Scalar multiply, 2-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_and_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar AND, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_or_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar OR, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_lshl_b32": {
+      "latency_cycles": 2.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Scalar left shift, 2-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_mov_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar move, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dword": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "4B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dwordx2": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "8B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dwordx4": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "16B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "4B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "8B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "16B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dword": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 4B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dwordx2": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 8B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dwordx4": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 16B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 4B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 8B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 16B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b32": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 4B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b64": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 8B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b128": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 16B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b32": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 4B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b64": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 8B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b128": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 16B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_16x16x16_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "16x16x16 MFMA f16->f32, 8-cycle latency, issue every 8 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_16x16x16_bf16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "16x16x16 MFMA bf16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_32x32x8_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "32x32x8 MFMA f16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_32x32x8_bf16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "32x32x8 MFMA bf16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_4x4x4_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "4x4x4 MFMA f16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_load_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 4B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_load_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 8B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_load_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 16B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_waitcnt": {
+      "latency_cycles": 0.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "estimated",
+      "notes": "Wait for counters, variable latency",
+      "stddev_latency": 0.0
+    },
+    "s_barrier": {
+      "latency_cycles": 100.0,
+      "throughput_ops_per_cycle": 0.01,
+      "measurement_source": "estimated",
+      "notes": "Workgroup barrier, ~100+ cycles",
+      "stddev_latency": 0.0
+    },
+    "s_nop": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "estimated",
+      "notes": "No operation, 1-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_memrealtime": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "Read memory realtime counter, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_accvgpr_read_b32": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "Read AGPR to VGPR, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_accvgpr_write_b32": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "Write VGPR to AGPR, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "mfma_to_agpr_read": {
+      "latency_cycles": 6.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Minimum wait between MFMA issue and v_accvgpr_read_b32. LLVM-validated value. AGPRs can be read ~2 cycles before full MFMA completion due to pipeline overlap.",
+      "stddev_latency": 0.0
+    },
+    "s_movk_i32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar move 16-bit constant, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_cmp_eq_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar compare equal, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_cmp_lt_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar compare less than, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_addc_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar add with carry, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_subb_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar subtract with borrow, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    }
+  },
+  "instruction_classes": {}
+}

--- a/wave_lang/kernel/wave/asm/latency_db/gfx950.json
+++ b/wave_lang/kernel/wave/asm/latency_db/gfx950.json
@@ -1,0 +1,456 @@
+{
+  "architecture": "gfx950",
+  "version": "1.0",
+  "timestamp": "2025-11-05T07:05:19.487897+00:00",
+  "instructions": {
+    "v_add_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer add, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_sub_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer subtract, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_lo_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer multiply low, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_hi_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer multiply high, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_add_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 add, 4-cycle latency, full-rate",
+      "stddev_latency": 0.0
+    },
+    "v_sub_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 subtract, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mul_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 multiply, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_fma_f32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Float32 FMA, 4-cycle latency, full-rate",
+      "stddev_latency": 0.0
+    },
+    "v_and_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise AND, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_or_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise OR, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_xor_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Bitwise XOR, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_lshlrev_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Left shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_lshrrev_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Logical right shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_ashrrev_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Arithmetic right shift, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mov_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Move, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cndmask_b32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Conditional mask, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_eq_u32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare equal, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_lt_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare less than, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_cmp_gt_i32": {
+      "latency_cycles": 4.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Integer compare greater than, 4-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_add_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar add, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_sub_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar subtract, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_mul_i32": {
+      "latency_cycles": 2.0,
+      "throughput_ops_per_cycle": 0.25,
+      "measurement_source": "isa_manual",
+      "notes": "Scalar multiply, 2-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_and_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar AND, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_or_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar OR, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_lshl_b32": {
+      "latency_cycles": 2.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "isa_manual",
+      "notes": "Scalar left shift, 2-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_mov_b32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar move, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dword": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "4B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dwordx2": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "8B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_load_dwordx4": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "16B load, ~80 cycles uncached",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "4B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "8B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "buffer_store_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "16B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dword": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 4B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dwordx2": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 8B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_load_dwordx4": {
+      "latency_cycles": 80.0,
+      "throughput_ops_per_cycle": 0.0125,
+      "measurement_source": "estimated",
+      "notes": "Global 16B load, ~80 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 4B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 8B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "global_store_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Global 16B store, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b32": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 4B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b64": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 8B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_read_b128": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 16B read, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b32": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 4B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b64": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 8B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "ds_write_b128": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "LDS 16B write, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_16x16x16_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "16x16x16 MFMA f16->f32, 8-cycle latency, issue every 8 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_16x16x16_bf16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "16x16x16 MFMA bf16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_32x32x8_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "32x32x8 MFMA f16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_32x32x8_bf16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "32x32x8 MFMA bf16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_mfma_f32_4x4x4_f16": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "4x4x4 MFMA f16->f32, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_load_dword": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 4B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_load_dwordx2": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 8B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_load_dwordx4": {
+      "latency_cycles": 40.0,
+      "throughput_ops_per_cycle": 0.025,
+      "measurement_source": "estimated",
+      "notes": "Scalar 16B load, ~40 cycles",
+      "stddev_latency": 0.0
+    },
+    "s_waitcnt": {
+      "latency_cycles": 0.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "estimated",
+      "notes": "Wait for counters, variable latency",
+      "stddev_latency": 0.0
+    },
+    "s_barrier": {
+      "latency_cycles": 100.0,
+      "throughput_ops_per_cycle": 0.01,
+      "measurement_source": "estimated",
+      "notes": "Workgroup barrier, ~100+ cycles",
+      "stddev_latency": 0.0
+    },
+    "s_nop": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "estimated",
+      "notes": "No operation, 1-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "s_memrealtime": {
+      "latency_cycles": 20.0,
+      "throughput_ops_per_cycle": 0.05,
+      "measurement_source": "estimated",
+      "notes": "Read memory realtime counter, ~20 cycles",
+      "stddev_latency": 0.0
+    },
+    "v_accvgpr_read_b32": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "Read AGPR to VGPR, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "v_accvgpr_write_b32": {
+      "latency_cycles": 8.0,
+      "throughput_ops_per_cycle": 0.125,
+      "measurement_source": "isa_manual",
+      "notes": "Write VGPR to AGPR, 8-cycle latency",
+      "stddev_latency": 0.0
+    },
+    "mfma_to_agpr_read": {
+      "latency_cycles": 6.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Minimum wait between MFMA issue and v_accvgpr_read_b32. LLVM-validated value. AGPRs can be read ~2 cycles before full MFMA completion due to pipeline overlap.",
+      "stddev_latency": 0.0
+    },
+    "s_movk_i32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar move 16-bit constant, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_cmp_eq_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar compare equal, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_cmp_lt_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar compare less than, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_addc_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar add with carry, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    },
+    "s_subb_u32": {
+      "latency_cycles": 1.0,
+      "throughput_ops_per_cycle": 1.0,
+      "measurement_source": "llvm_codegen",
+      "notes": "Scalar subtract with borrow, 1-cycle latency (LLVM codegen)",
+      "stddev_latency": 0.0
+    }
+  },
+  "instruction_classes": {}
+}

--- a/wave_lang/kernel/wave/asm/latency_provider.py
+++ b/wave_lang/kernel/wave/asm/latency_provider.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Latency Provider Interface.
+
+Provides instruction latency and throughput information to the ASM emitter
+for hazard detection and scheduling decisions.
+
+"""
+
+from typing import Optional
+from pathlib import Path
+
+from .latency_database import (
+    LatencyDatabaseManager,
+    InstructionTiming,
+)
+
+
+class LatencyProvider:
+    """Provides instruction latency and throughput information."""
+
+    def __init__(self, arch: str):
+        """Initialize latency provider."""
+        self.arch = arch
+        db_root = str(Path(__file__).parent / "latency_db")
+        self.db_manager = LatencyDatabaseManager(db_root=db_root)
+        self.db = self.db_manager.load_architecture(arch)
+
+    def get_timing(self, instruction: str) -> Optional[InstructionTiming]:
+        """Get timing for an instruction."""
+        return self.db.get_timing(instruction)
+
+    def get_latency(self, instruction: str) -> Optional[float]:
+        """Get latency in cycles for an instruction."""
+        timing = self.get_timing(instruction)
+        return timing.latency_cycles if timing else None
+
+    def get_throughput(self, instruction: str) -> Optional[float]:
+        """Get throughput in operations per cycle."""
+        timing = self.get_timing(instruction)
+        return timing.throughput_ops_per_cycle if timing else None

--- a/wave_lang/kernel/wave/asm/scoreboard.py
+++ b/wave_lang/kernel/wave/asm/scoreboard.py
@@ -1,0 +1,239 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Scoreboard-based Hazard Detection and Instruction Scheduling.
+
+Tracks outstanding operations and their readiness to detect:
+- RAW (Read-After-Write) hazards
+- WAW (Write-After-Write) hazards
+- Structural hazards (resource conflicts)
+
+Provides scheduling hints to:
+- Insert minimal waits (s_waitcnt, s_nop)
+- Reorder independent instructions to fill bubbles
+- Track VMEM, LGKM, MFMA, and VALU readiness
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+from .latency_provider import LatencyProvider
+from .instruction_categories import InstructionCategory, categorize_instruction
+
+
+@dataclass
+class PendingInstruction:
+    """Represents an instruction that has been issued but not completed."""
+
+    cycle: int  # Cycle when issued
+    instruction: str  # Instruction name (e.g., "buffer_load_dwordx4")
+    category: InstructionCategory
+    latency: float  # Expected latency in cycles
+    writes: Set[str] = field(
+        default_factory=set
+    )  # Resources written (e.g., "v0", "s4")
+    reads: Set[str] = field(default_factory=set)  # Resources read
+    ticket: Optional[int] = None  # VMEM/LGKM ticket for wait tracking
+
+    def ready_at_cycle(self) -> int:
+        """Cycle when this instruction's result will be ready."""
+        return self.cycle + int(self.latency)
+
+
+class Scoreboard:
+    """
+    Tracks outstanding instructions and detects hazards.
+
+    Maintains separate queues for different instruction categories
+    and provides scheduling decisions.
+    """
+
+    def __init__(self, latency_provider: LatencyProvider):
+        """Initialize scoreboard."""
+        self.latency_provider = latency_provider
+
+    def __init__(self, latency_provider: LatencyProvider):
+        """Initialize scoreboard."""
+        self.latency_provider = latency_provider
+        self.current_cycle = 0
+        self.pending: Dict[InstructionCategory, List[PendingInstruction]] = {
+            cat: [] for cat in InstructionCategory
+        }
+        self.last_write: Dict[str, int] = {}
+        self.last_read: Dict[str, int] = {}
+
+    def _categorize_instruction(self, instruction: str) -> InstructionCategory:
+        """
+        Categorize an instruction.
+
+        Args:
+            instruction: Instruction name
+
+        Returns:
+            InstructionCategory
+        """
+        return categorize_instruction(instruction)
+
+    def issue(
+        self,
+        instruction: str,
+        writes: Optional[Set[str]] = None,
+        reads: Optional[Set[str]] = None,
+        ticket: Optional[int] = None,
+    ) -> PendingInstruction:
+        """
+        Issue an instruction and add to scoreboard.
+
+        Args:
+            instruction: Instruction name
+            writes: Set of resources written (e.g., {"v0", "v1"})
+            reads: Set of resources read
+            ticket: Optional VMEM/LGKM ticket
+
+        Returns:
+            PendingInstruction object
+        """
+        category = self._categorize_instruction(instruction)
+        latency = self.latency_provider.get_latency(instruction)
+
+        pending_inst = PendingInstruction(
+            cycle=self.current_cycle,
+            instruction=instruction,
+            category=category,
+            latency=latency,
+            writes=writes or set(),
+            reads=reads or set(),
+            ticket=ticket,
+        )
+
+        self.pending[category].append(pending_inst)
+
+        # Update register state
+        for reg in pending_inst.writes:
+            self.last_write[reg] = self.current_cycle
+        for reg in pending_inst.reads:
+            self.last_read[reg] = self.current_cycle
+
+        return pending_inst
+
+    def advance(self, cycles: int = 1):
+        """
+        Advance the scoreboard by a number of cycles.
+
+        Retires completed instructions.
+
+        Args:
+            cycles: Number of cycles to advance
+        """
+        self.current_cycle += cycles
+
+        # Retire completed instructions
+        for category, pending_list in self.pending.items():
+            # Keep only instructions that are not ready yet
+            self.pending[category] = [
+                inst
+                for inst in pending_list
+                if inst.ready_at_cycle() > self.current_cycle
+            ]
+
+    def check_hazard(
+        self, reads: Optional[Set[str]] = None, writes: Optional[Set[str]] = None
+    ) -> Optional[Tuple[str, int]]:
+        """
+        Check for hazards with pending instructions.
+
+        Args:
+            reads: Resources to be read
+            writes: Resources to be written
+
+        Returns:
+            Tuple of (hazard_type, cycles_needed) or None if no hazard
+        """
+        reads = reads or set()
+        writes = writes or set()
+
+        max_cycles_needed = 0
+        hazard_type = None
+
+        # Check all pending instructions
+        for category, pending_list in self.pending.items():
+            for inst in pending_list:
+                # RAW hazard: We read what they write
+                if reads & inst.writes:
+                    cycles_needed = inst.ready_at_cycle() - self.current_cycle
+                    if cycles_needed > max_cycles_needed:
+                        max_cycles_needed = cycles_needed
+                        hazard_type = "RAW"
+
+                # WAW hazard: We write what they write
+                if writes & inst.writes:
+                    cycles_needed = inst.ready_at_cycle() - self.current_cycle
+                    if cycles_needed > max_cycles_needed:
+                        max_cycles_needed = cycles_needed
+                        hazard_type = "WAW"
+
+                # WAR hazard (less common in out-of-order execution)
+                # We write what they read - usually not a problem
+
+        if max_cycles_needed > 0:
+            return (hazard_type, max_cycles_needed)
+        return None
+
+    def get_vmem_wait_count(self, ticket: int) -> Optional[int]:
+        """
+        Get vmcnt value needed to wait for a specific VMEM ticket.
+
+        Args:
+            ticket: VMEM ticket to wait for
+
+        Returns:
+            vmcnt value or None if ticket already complete
+        """
+        # Find all pending VMEM instructions with tickets > ticket
+        pending_vmem = self.pending[InstructionCategory.VMEM]
+        newer_vmem = [
+            inst
+            for inst in pending_vmem
+            if inst.ticket is not None and inst.ticket > ticket
+        ]
+
+        if not newer_vmem:
+            # If ticket is in pending list, need to wait for all
+            has_ticket = any(inst.ticket == ticket for inst in pending_vmem)
+            if has_ticket:
+                return 0  # Wait for all pending VMEM
+            else:
+                return None  # Ticket already complete
+        else:
+            return len(newer_vmem)  # Wait allows newer ops to complete
+
+    def get_lgkm_wait_count(self, ticket: int) -> Optional[int]:
+        """
+        Get lgkmcnt value needed to wait for a specific LGKM ticket.
+
+        Similar to VMEM but for LDS/scalar memory.
+
+        Args:
+            ticket: LGKM ticket to wait for
+
+        Returns:
+            lgkmcnt value or None if ticket already complete
+        """
+        pending_lgkm = self.pending[InstructionCategory.LGKM]
+        newer_lgkm = [
+            inst
+            for inst in pending_lgkm
+            if inst.ticket is not None and inst.ticket > ticket
+        ]
+
+        if not newer_lgkm:
+            has_ticket = any(inst.ticket == ticket for inst in pending_lgkm)
+            if has_ticket:
+                return 0
+            else:
+                return None
+        else:
+            return len(newer_lgkm)

--- a/wave_lang/kernel/wave/asm/ticketing.py
+++ b/wave_lang/kernel/wave/asm/ticketing.py
@@ -1,0 +1,165 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Ticket-based tracking for VMEM and LGKM operations to enable optimal wait placement.
+"""
+
+from typing import Optional
+
+
+class Ticketing:
+    """
+    Tracks outstanding VMEM and LGKM operations via tickets for optimal s_waitcnt placement.
+
+    This class manages ticket issuance and wait coalescing for two types of memory operations:
+    - VMEM (Vector Memory): buffer_load/buffer_store operations
+    - LGKM (LDS/GDS/Konstant/Message): ds_read/ds_write, s_load, sendmsg operations
+
+    Ticket System:
+    - Each operation is assigned a monotonically increasing ticket number
+    - Tickets track the order of issued operations
+    - Wait coalescing ensures we emit minimal s_waitcnt instructions
+
+    Coalescing Rule:
+    - vmcnt(N) or lgkmcnt(N) waits for all operations with ticket <= (last_ticket - N)
+    - We only emit a wait if it's stricter than the previous wait
+    - This avoids redundant waits and maximizes latency hiding
+    """
+
+    def __init__(self):
+        # VMEM ticket tracking
+        self._vmem_last_ticket = -1  # Last issued VMEM ticket
+        self._vmem_last_wait_threshold = None  # Last vmcnt(N) emitted, for coalescing
+
+        # LGKM ticket tracking
+        self._lgkm_last_ticket = -1  # Last issued LGKM ticket
+        self._lgkm_last_wait_threshold = None  # Last lgkmcnt(N) emitted, for coalescing
+
+    # ========= VMEM Ticketing =========
+
+    def next_vmem_ticket(self) -> int:
+        """
+        Issue next VMEM ticket for a buffer load/store operation.
+
+        Returns:
+            New ticket number for this VMEM operation
+        """
+        self._vmem_last_ticket += 1
+        # Reset wait threshold since a new operation invalidates previous waits
+        self._vmem_last_wait_threshold = None
+        return self._vmem_last_ticket
+
+    def compute_vmem_wait(self, min_required_ticket: int) -> Optional[int]:
+        """
+        Compute minimal vmcnt(N) threshold to ensure ticket is ready.
+
+        The threshold allows (last_ticket - min_required_ticket) newer operations
+        to remain in-flight while guaranteeing min_required_ticket is complete.
+
+        Coalescing: Only returns a threshold if it's stricter than the last wait,
+        otherwise returns None (indicating no wait needed).
+
+        Args:
+            min_required_ticket: Ticket that must be ready before proceeding
+
+        Returns:
+            vmcnt threshold N to emit in s_waitcnt vmcnt(N), or None if no wait needed
+
+        Example:
+            If last_ticket=5 and min_required_ticket=3:
+            - threshold = max(0, 5-3) = 2
+            - This means: wait for ticket 3, allow tickets 4 and 5 to remain in-flight
+            - Emits: s_waitcnt vmcnt(2)
+        """
+        # Compute threshold: allow (last_ticket - min_required_ticket) newer operations
+        threshold = max(0, self._vmem_last_ticket - min_required_ticket)
+
+        # Coalesce: only return threshold if stricter than last wait (or first wait)
+        if (
+            self._vmem_last_wait_threshold is None
+            or threshold < self._vmem_last_wait_threshold
+        ):
+            self._vmem_last_wait_threshold = threshold
+            return threshold
+
+        return None
+
+    # ========= LGKM Ticketing =========
+
+    def next_lgkm_ticket(self) -> int:
+        """
+        Issue next LGKM ticket for an LDS/scalar memory operation.
+
+        Returns:
+            New ticket number for this LGKM operation
+        """
+        self._lgkm_last_ticket += 1
+        # Reset wait threshold since a new operation invalidates previous waits
+        self._lgkm_last_wait_threshold = None
+        return self._lgkm_last_ticket
+
+    def compute_lgkm_wait(self, min_required_ticket: int) -> Optional[int]:
+        """
+        Compute minimal lgkmcnt(N) threshold to ensure ticket is ready.
+
+        The threshold allows (last_ticket - min_required_ticket) newer operations
+        to remain in-flight while guaranteeing min_required_ticket is complete.
+
+        Coalescing: Only returns a threshold if it's stricter than the last wait,
+        otherwise returns None (indicating no wait needed).
+
+        Args:
+            min_required_ticket: Ticket that must be ready before proceeding
+
+        Returns:
+            lgkmcnt threshold N to emit in s_waitcnt lgkmcnt(N), or None if no wait needed
+
+        Example:
+            If last_ticket=3 and min_required_ticket=1:
+            - threshold = max(0, 3-1) = 2
+            - This means: wait for ticket 1, allow tickets 2 and 3 to remain in-flight
+            - Emits: s_waitcnt lgkmcnt(2)
+        """
+        # Compute threshold: allow (last_ticket - min_required_ticket) newer operations
+        threshold = max(0, self._lgkm_last_ticket - min_required_ticket)
+
+        # Coalesce: only return threshold if stricter than last wait (or first wait)
+        if (
+            self._lgkm_last_wait_threshold is None
+            or threshold < self._lgkm_last_wait_threshold
+        ):
+            self._lgkm_last_wait_threshold = threshold
+            return threshold
+
+        return None
+
+    def observe_lgkm_wait(self, threshold: int) -> None:
+        """
+        Record an externally emitted or implied LGKM wait.
+
+        This method updates the internal coalescing state to reflect that an
+        lgkmcnt(threshold) wait has been issued, either by external code
+        (e.g., user-specified barriers) or by the scheduler.
+
+        After observing a wait, subsequent compute_lgkm_wait() calls will
+        return None unless a new, stricter wait is required.
+
+        Args:
+            threshold: The lgkmcnt threshold that was waited on (0 for full drain)
+
+        Example:
+            For a shared memory barrier that drains all LGKM:
+            - emit s_waitcnt lgkmcnt(0)
+            - call observe_lgkm_wait(0)
+            - emit s_barrier
+            This prevents redundant lgkmcnt waits after the barrier until
+            new LGKM operations occur.
+        """
+        if (
+            self._lgkm_last_wait_threshold is None
+            or threshold < self._lgkm_last_wait_threshold
+        ):
+            self._lgkm_last_wait_threshold = threshold


### PR DESCRIPTION
Previously, the mma had a hardcoded set of noops that were inserted after the mma and before reading from agprs. This PR introduces facilities to load from a latency json file and use that for scheduling. Also for placement of vmcnt and lgkcmnt, a separate ticketing class is created and used.