### PR TITLE
gitignore water artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ out
 
 # clangd
 water/.cache
+
+# Water artifacts
+water/llvm-install
+water/llvm-project
+water/build_tools/wheel/water_mlir/water_mlir


### PR DESCRIPTION
gitignore dirs generated by `WATER_BUILD_LLVM` and dirs for editable installs.