### PR TITLE
[asm] Add support for running MMA on multiple workgroups and waves

### DIFF
--- a/lit_tests/kernel/wave/asm.py
+++ b/lit_tests/kernel/wave/asm.py
@@ -103,10 +103,10 @@ def test_read_write():
     # CHECK:          .amdhsa_next_free_sgpr {{[0-9]+}}
     # CHECK:          .amdhsa_group_segment_fixed_size 0
     # CHECK:          .amdhsa_private_segment_fixed_size 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_x 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_y 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_z 0
-    # CHECK:          .amdhsa_system_vgpr_workitem_id 1
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_x {{[01]}}
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_y {{[01]}}
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_z {{[01]}}
+    # CHECK:          .amdhsa_system_vgpr_workitem_id {{[0-9]+}}
     # CHECK:          .amdhsa_float_denorm_mode_32 3
     # CHECK:          .amdhsa_float_denorm_mode_16_64 3
     # CHECK:          .end_amdhsa_kernel
@@ -114,30 +114,30 @@ def test_read_write():
     # CHECK:          # SRD upper word (gfx9xx): data_format=4 => 0x20000
     # CHECK:          .set Srd127_96, 0x20000
     # CHECK:          read_write:
-    # CHECK:              s_load_dwordx2 s[2:3], s[0:1], 0x0
-    # CHECK:              s_load_dwordx2 s[4:5], s[0:1], 0x8
+    # CHECK:              s_load_dwordx2 s[{{[0-9]+}}:{{[0-9]+}}], s[0:1], 0x0
+    # CHECK:              s_load_dwordx2 s[{{[0-9]+}}:{{[0-9]+}}], s[0:1], 0x8
     # CHECK:              s_waitcnt lgkmcnt(0)
     # CHECK:              # SRD for Value(%reinterpret_cast = memref.reinterpret_cast %0 to offset: [0], sizes: [16, 16], strides: [16, 1] : memref<f16> to memref<16x16xf16, strided<[16, 1]>>) (arg0)
-    # CHECK:              s_mov_b32 s8, s2
-    # CHECK:              s_mov_b32 s9, s3
-    # CHECK:              s_mov_b32 s10, {{[0-9]+}}
-    # CHECK:              s_mov_b32 s11, Srd127_96
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, {{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, Srd127_96
     # CHECK:              # SRD for Value(%reinterpret_cast_0 = memref.reinterpret_cast %1 to offset: [0], sizes: [16, 16], strides: [16, 1] : memref<f16> to memref<16x16xf16, strided<[16, 1]>>) (arg1)
-    # CHECK:              s_mov_b32 s12, s4
-    # CHECK:              s_mov_b32 s13, s5
-    # CHECK:              s_mov_b32 s14, {{[0-9]+}}
-    # CHECK:              s_mov_b32 s15, Srd127_96
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, {{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, Srd127_96
     # CHECK:              # lane id (0..63)
     # CHECK:              v_mbcnt_lo_u32_b32 v{{[0-9]+}}, -1
     # CHECK:              v_mbcnt_hi_u32_b32 v{{[0-9]+}}, -1, v{{[0-9]+}}
     # CHECK:              v_lshlrev_b32 v{{[0-9]+}}, 5, v{{[0-9]+}}
     # CHECK:              # load 32B from {{.*}}
-    # CHECK:              buffer_load_dwordx4  v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[8:11], 0 offen offset:0
-    # CHECK:              buffer_load_dwordx4  v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[8:11], 0 offen offset:16
+    # CHECK:              buffer_load_dwordx4  v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:0
+    # CHECK:              buffer_load_dwordx4  v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:16
     # CHECK:              s_waitcnt vmcnt(0)
     # CHECK:              # store 32B to {{.*}}
-    # CHECK:              buffer_store_dwordx4 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[12:15], 0 offen offset:0
-    # CHECK:              buffer_store_dwordx4 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[12:15], 0 offen offset:16
+    # CHECK:              buffer_store_dwordx4 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:0
+    # CHECK:              buffer_store_dwordx4 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:16
     # CHECK:              s_endpgm
 
 
@@ -203,10 +203,10 @@ def test_mma():
     # CHECK:          .amdhsa_next_free_sgpr {{[0-9]+}}
     # CHECK:          .amdhsa_group_segment_fixed_size {{[0-9]+}}
     # CHECK:          .amdhsa_private_segment_fixed_size 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_x 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_y 0
-    # CHECK:          .amdhsa_system_sgpr_workgroup_id_z 0
-    # CHECK:          .amdhsa_system_vgpr_workitem_id 1
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_x {{[01]}}
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_y {{[01]}}
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_z {{[01]}}
+    # CHECK:          .amdhsa_system_vgpr_workitem_id {{[0-9]+}}
     # CHECK:          .amdhsa_float_denorm_mode_32 3
     # CHECK:          .amdhsa_float_denorm_mode_16_64 3
     # CHECK:          .end_amdhsa_kernel
@@ -214,56 +214,124 @@ def test_mma():
     # CHECK:          # SRD upper word (gfx9xx): data_format=4 => 0x20000
     # CHECK:          .set Srd127_96, 0x20000
     # CHECK:          mma:
-    # CHECK:              s_load_dwordx2 s[2:3], s[0:1], 0x0
-    # CHECK:              s_load_dwordx2 s[4:5], s[0:1], 0x8
-    # CHECK:              s_load_dwordx2 s[6:7], s[0:1], 0x10
+    # CHECK:              s_load_dwordx2 s[{{[0-9]+}}:{{[0-9]+}}], s[0:1], 0x0
+    # CHECK:              s_load_dwordx2 s[{{[0-9]+}}:{{[0-9]+}}], s[0:1], 0x8
+    # CHECK:              s_load_dwordx2 s[{{[0-9]+}}:{{[0-9]+}}], s[0:1], 0x10
     # CHECK:              s_waitcnt lgkmcnt(0)
     # CHECK:              # SRD for {{.*}} (arg0)
-    # CHECK:              s_mov_b32 s8, s2
-    # CHECK:              s_mov_b32 s9, s3
-    # CHECK:              s_mov_b32 s10, {{[0-9]+}}
-    # CHECK:              s_mov_b32 s11, Srd127_96
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, {{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, Srd127_96
     # CHECK:              # SRD for {{.*}} (arg1)
-    # CHECK:              s_mov_b32 s12, s4
-    # CHECK:              s_mov_b32 s13, s5
-    # CHECK:              s_mov_b32 s14, {{[0-9]+}}
-    # CHECK:              s_mov_b32 s15, Srd127_96
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, {{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, Srd127_96
     # CHECK:              # SRD for {{.*}} (arg2)
-    # CHECK:              s_mov_b32 s16, s6
-    # CHECK:              s_mov_b32 s17, s7
-    # CHECK:              s_mov_b32 s18, {{[0-9]+}}
-    # CHECK:              s_mov_b32 s19, Srd127_96
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, {{[0-9]+}}
+    # CHECK:              s_mov_b32 s{{[0-9]+}}, Srd127_96
     # CHECK:              # lane id (0..63)
     # CHECK:              v_mbcnt_lo_u32_b32 v{{[0-9]+}}, -1
     # CHECK:              v_mbcnt_hi_u32_b32 v{{[0-9]+}}, -1, v{{[0-9]+}}
     # CHECK:              # load 8B from {{.*}}
-    # CHECK:              buffer_load_dwordx2 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[8:11], 0 offen offset:0
+    # CHECK:              buffer_load_dwordx2 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:0
     # CHECK:              s_waitcnt vmcnt(0)
     # CHECK:              ds_write_b64 v{{[0-9]+}}, v[{{[0-9]+}}:{{[0-9]+}}]
     # CHECK:              # load 8B from {{.*}}
-    # CHECK:              buffer_load_dwordx2 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[12:15], 0 offen offset:0
+    # CHECK:              buffer_load_dwordx2 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:0
     # CHECK:              s_waitcnt vmcnt(0)
     # CHECK:              ds_write_b64 v{{[0-9]+}}, v[{{[0-9]+}}:{{[0-9]+}}]
     # CHECK:              s_barrier
     # CHECK:              ds_read_b64 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}
     # CHECK:              ds_read_b64 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}
-    # CHECK:              v_mfma_f32_16x16x16_f16 a[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], 0
+    # CHECK:              v_mfma_f32_16x16x16_f16 v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], 0
     # CHECK:              # MFMA issued, latency ~{{[0-9]+}} cycles
-    # CHECK:              s_nop {{[0-9]+}}
-    # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
-    # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
-    # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
-    # CHECK:              v_accvgpr_read_b32 v{{[0-9]+}}, a{{[0-9]+}}
+    # Note: VGPR-variant MFMA writes directly to VGPRs, no accvgpr_read or s_nop needed
     # CHECK-DAG:          v_lshrrev_b32 v{{[0-9]+}}, 4, v{{[0-9]+}}
     # CHECK-DAG:          v_and_b32 v{{[0-9]+}}, 15, v{{[0-9]+}}
     # CHECK-DAG:          v_lshlrev_b32 v{{[0-9]+}}, {{[0-9]+}}, v{{[0-9]+}}
     # CHECK-DAG:          v_add_u32 v{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
     # CHECK:              # store 4B to {{.*}}
-    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[16:19], 0 offen offset:{{[0-9]+}}
+    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:{{[0-9]+}}
     # CHECK:              # store 4B to {{.*}}
-    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[16:19], 0 offen offset:{{[0-9]+}}
+    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:{{[0-9]+}}
     # CHECK:              # store 4B to {{.*}}
-    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[16:19], 0 offen offset:{{[0-9]+}}
+    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:{{[0-9]+}}
     # CHECK:              # store 4B to {{.*}}
-    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[16:19], 0 offen offset:{{[0-9]+}}
+    # CHECK:              buffer_store_dword v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen offset:{{[0-9]+}}
     # CHECK:              s_endpgm
+
+
+@run_test
+def test_mma_multi_workgroup_multi_wave():
+    """
+    Test MMA with multi-workgroup, multi-wave constraint structure.
+
+    Uses 1024x1024x16 shape to test multi-workgroup code generation.
+    With BLOCK_M=16, BLOCK_N=16, this creates a 64x64 grid of workgroups.
+
+    Note: This test verifies that the constraint structure and assembly
+    generation work correctly for the multi-workgroup case. The centralized
+    ticketing system ensures uniform VMEM/LGKM ticket issuance across all
+    workgroups and waves.
+    """
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def mma_multi(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        acc = tkw.mma(a_reg, b_reg, c_reg)
+        tkw.write(acc, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    compile_options = WaveCompileOptions(
+        subs={
+            M: 1024,
+            N: 1024,
+            K: 16,
+            BLOCK_M: 16,
+            BLOCK_N: 16,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    # Compile to AMDGCN assembly (for lit tests, no amdclang++)
+    compile_options.compile_to_asm = True
+    mma_multi = wave_compile(compile_options, mma_multi)
+    print(mma_multi.asm)
+
+    # CHECK-LABEL:    test_mma_multi_workgroup_multi_wave
+    # CHECK:          .amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+    # CHECK:          .protected mma_multi
+    # CHECK:          .amdhsa_kernel mma_multi
+    # CHECK:          .amdhsa_user_sgpr_kernarg_segment_ptr 1
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_x 1
+    # CHECK:          .amdhsa_system_sgpr_workgroup_id_y 1
+    # CHECK:          mma_multi:
+    # CHECK:          v_mfma_f32_16x16x16_f16
+    # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
+    # Note: s_nop may or may not be emitted depending on latency tracking
+    # CHECK:          buffer_store_dword
+    # CHECK:          s_endpgm

--- a/tests/kernel/wave/asm_backend_test.py
+++ b/tests/kernel/wave/asm_backend_test.py
@@ -163,3 +163,218 @@ def test_mma_kernel_asm_backend(shape, run_bench):
     expected = torch.matmul(a.float(), b.float().T)
 
     assert_close(c, expected)
+
+
+@require_e2e
+@require_cdna_3_or_4
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (32, 32, 16),  # 2x2 = 4 workgroups
+        (64, 64, 16),  # 4x4 = 16 workgroups
+        (128, 128, 16),  # 8x8 = 64 workgroups
+        (256, 256, 16),  # 16x16 = 256 workgroups
+    ],
+)
+def test_mma_multi_workgroup_single_wave_asm_backend(shape, run_bench):
+    """End-to-end test for multi-workgroup MMA using ASM backend.
+
+    Tests multi-workgroup scenarios with 1 wave per workgroup, where each wave
+    operates on a 16x16 tile (required by the F32_16x16x16_F16 MMA instruction).
+    """
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    ADDRESS_SPACE_0 = tkl.sym.ADDRESS_SPACE_0
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Configuration: 1 wave per workgroup, each handling 16x16 tile
+    BLOCK_M = 16
+    BLOCK_N = 16
+    WAVE_M = 16
+    WAVE_N = 16
+    wave_size = 64
+
+    constraints: list[tkw.Constraint] = [
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.WaveConstraint(M, WAVE_M),
+        tkw.WaveConstraint(N, WAVE_N),
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        ),
+    ]
+
+    @tkw.wave(constraints)
+    def mma_multi_kernel(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        """MMA kernel that computes C = A @ B^T with multi-workgroup, multi-wave."""
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        acc = tkw.mma(a_reg, b_reg, c_reg)
+        tkw.write(acc, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    # Create test tensors with larger dimensions
+    # A is M x K, B is N x K (for B^T in MMA), C is M x N
+    m, n, k = shape
+    a = device_randn((m, k), dtype=torch.float16)
+    b = device_randn((n, k), dtype=torch.float16)
+    c = device_zeros((m, n), dtype=torch.float32)
+
+    options = WaveCompileOptions(
+        subs={
+            M: m,
+            N: n,
+            K: k,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+        backend="asm",
+        wave_runtime=True,
+        compile_to_mlir=False,
+        location_capture_config=LocationCaptureConfig(level=LocationCaptureLevel.NONE),
+        enforce_locations=False,
+    )
+    options = set_default_run_config(options)
+
+    compiled_kernel = wave_compile(options, mma_multi_kernel)
+
+    compiled_kernel(a, b, c)
+
+    # Compute expected result: C = A @ B^T
+    expected = torch.matmul(a.float(), b.float().T)
+
+    assert_close(c, expected)
+
+
+@require_e2e
+@require_cdna_3_or_4
+@pytest.mark.parametrize(
+    "shape,config",
+    [
+        # (M, N, K), (BLOCK_M, BLOCK_N, WAVE_M, WAVE_N)
+        # Config ensures each wave handles 16x16 tile for F32_16x16x16_F16 MMA
+        # Max 16 waves per workgroup constraint (16 * 64 = 1024 threads max)
+        (
+            (256, 256, 16),
+            (64, 64, 16, 16),
+        ),  # 4x4 WGs, 4x4 waves per WG (16 waves = max, test both multi-wg and multi-wave)
+        (
+            (64, 64, 16),
+            (64, 64, 16, 16),
+        ),  # 1 WG with 4x4 waves (16 waves = max, pure multi-wave)
+        (
+            (64, 32, 16),
+            (64, 32, 16, 16),
+        ),  # 1 WG with 4x2 waves (8 waves, smaller multi-wave)
+        (
+            (128, 64, 16),
+            (32, 32, 16, 16),
+        ),  # 4x2 WGs, 2x2 waves per WG (4 waves per WG, multi-wg + multi-wave)
+        (
+            (8192, 8192, 16),
+            (32, 32, 16, 16),
+        ),  # 256x256 WGs, 2x2 waves per WG (large scale test)
+    ],
+)
+def test_mma_multi_wave_asm_backend(shape, config, run_bench):
+    """End-to-end test for multi-wave MMA using ASM backend.
+
+    Tests scenarios with multiple waves per workgroup, where each wave operates
+    on a 16x16 tile (required by the F32_16x16x16_F16 MMA instruction).
+
+    The ASM backend now fully supports multi-wave execution by properly extracting
+    tid_x and tid_y from the flat thread ID in v0, matching LLVM's behavior.
+    """
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    ADDRESS_SPACE_0 = tkl.sym.ADDRESS_SPACE_0
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Extract configuration
+    BLOCK_M, BLOCK_N, WAVE_M, WAVE_N = config
+    wave_size = 64
+
+    # Verify configuration: each wave must handle 16x16 tile for MMA
+    assert (
+        BLOCK_M % WAVE_M == 0
+    ), f"BLOCK_M ({BLOCK_M}) must be divisible by WAVE_M ({WAVE_M})"
+    assert (
+        BLOCK_N % WAVE_N == 0
+    ), f"BLOCK_N ({BLOCK_N}) must be divisible by WAVE_N ({WAVE_N})"
+    assert (
+        WAVE_M == 16 and WAVE_N == 16
+    ), f"Wave tile must be 16x16 for F32_16x16x16_F16 MMA"
+
+    constraints: list[tkw.Constraint] = [
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.WaveConstraint(M, WAVE_M),
+        tkw.WaveConstraint(N, WAVE_N),
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        ),
+    ]
+
+    @tkw.wave(constraints)
+    def mma_multi_wave_kernel(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        """MMA kernel that computes C = A @ B^T with multi-wave support."""
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        acc = tkw.mma(a_reg, b_reg, c_reg)
+        tkw.write(acc, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    # Create test tensors
+    m, n, k = shape
+    a = device_randn((m, k), dtype=torch.float16)
+    b = device_randn((n, k), dtype=torch.float16)
+    c = device_zeros((m, n), dtype=torch.float32)
+
+    options = WaveCompileOptions(
+        subs={
+            M: m,
+            N: n,
+            K: k,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+        backend="asm",
+        wave_runtime=True,
+        compile_to_mlir=False,
+        location_capture_config=LocationCaptureConfig(level=LocationCaptureLevel.NONE),
+        enforce_locations=False,
+    )
+    options = set_default_run_config(options)
+
+    compiled_kernel = wave_compile(options, mma_multi_wave_kernel)
+
+    compiled_kernel(a, b, c)
+
+    # Compute expected result: C = A @ B^T
+    expected = torch.matmul(a.float(), b.float().T)
+
+    assert_close(c, expected)

--- a/wave_lang/kernel/wave/asm/kernel_model.py
+++ b/wave_lang/kernel/wave/asm/kernel_model.py
@@ -18,7 +18,7 @@ class MemRefInfo:
     elem_bytes: int
 
 
-IndexVal = Union[int, str]  # int for constants, "tid.x" marker for per-lane
+IndexVal = Union[int, str]  # int for constants, "tid_x" marker for per-lane
 
 
 @dataclass
@@ -49,7 +49,7 @@ class KernelInfo:
     # SSA env for simple indices
     index_env: Dict[str, IndexVal] = field(
         default_factory=dict
-    )  # e.g., {"%thread_id_x": "tid.x", "%c0": 0, "%1": "tid.x"}
+    )  # e.g., {"%thread_id_x": "tid_x", "%c0": 0, "%1": "tid_x"}
     subspans: Dict[str, BindingUse] = field(
         default_factory=dict
     )  # memref_ssa -> BindingUse
@@ -57,6 +57,7 @@ class KernelInfo:
     wg_size: Tuple[int, int, int] = (64, 1, 1)
     subgroup_size: int = 64
     tid_ub_x: int = 64
+    tid_ub_y: int = 1  # Upper bound for thread ID in Y dimension
     # optional: remember last affine map for comments
     affine_map_attr: Optional[object] = None
     lds_size_bytes: int = 0

--- a/wave_lang/kernel/wave/asm/mlir_walker.py
+++ b/wave_lang/kernel/wave/asm/mlir_walker.py
@@ -67,6 +67,8 @@ class IRWalker:
                     self.handlers.handle_arith_constant_op(operation, kernel_info)
                 elif isinstance(operation, gpu_d.ThreadIdOp):
                     self.handlers.handle_gpu_thread_id_op(operation, kernel_info)
+                elif isinstance(operation, gpu_d.BlockIdOp):
+                    self.handlers.handle_gpu_block_id_op(operation, kernel_info)
                 elif isinstance(operation, affine_d.AffineApplyOp):
                     self.handlers.handle_affine_apply_op(operation, kernel_info)
                 elif isinstance(operation, vector_d.LoadOp):

--- a/wave_lang/kernel/wave/cache.py
+++ b/wave_lang/kernel/wave/cache.py
@@ -177,6 +177,7 @@ class WaveCacheManager(object):
         # Add subfunctions invariant property to hash.
         arg_dtypes = extract_arg_types(kernel_fn)
         processed_constraints = anonymize_constraints(constraints)
+
         key = [
             arg_dtypes,
             processed_constraints,
@@ -193,6 +194,7 @@ class WaveCacheManager(object):
             options.dynamic_symbols,
             options.schedule,
             options.use_scheduling_barriers,
+            options.backend,  # Include backend to differentiate llvm vs asm
             options.device,
             options.num_devices,
             options.target,


### PR DESCRIPTION
This PR adds support for running a single 16x16x16 MMA across multiple waves and workgroups. Lit and end to end tests are added.

Manually tested on MI350. MI25x not supported.