### PR TITLE
Add -Wno-macro-redefined to cmake

### DIFF
--- a/water/CMakeLists.txt
+++ b/water/CMakeLists.txt
@@ -13,7 +13,6 @@ if(HAS_WNO_MACRO_REDEFINED)
   add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-macro-redefined>")
 endif()
 
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   find_package(MLIR REQUIRED CONFIG)
 


### PR DESCRIPTION
This is a uselessly verbose warning that picks up changes in standard library we don't control.