### PR TITLE
[asm] Add loop support (scf.for) with unified SSA tracking and regist…

### DIFF
--- a/lit_tests/kernel/wave/asm.py
+++ b/lit_tests/kernel/wave/asm.py
@@ -88,7 +88,6 @@ def test_read_write():
     print(read_write.asm)
 
     # CHECK-LABEL:    test_read_write
-    # CHECK:          .amdgcn_target "amdgcn-amd-amdhsa--gfx942"
     # CHECK:          .text
     # CHECK:          .protected read_write
     # CHECK:          .globl read_write
@@ -188,7 +187,6 @@ def test_mma():
     print(mma.asm)
 
     # CHECK-LABEL:    test_mma
-    # CHECK:          .amdgcn_target "amdgcn-amd-amdhsa--gfx942"
     # CHECK:          .text
     # CHECK:          .protected mma
     # CHECK:          .globl mma
@@ -323,7 +321,6 @@ def test_mma_multi_workgroup_multi_wave():
     print(mma_multi.asm)
 
     # CHECK-LABEL:    test_mma_multi_workgroup_multi_wave
-    # CHECK:          .amdgcn_target "amdgcn-amd-amdhsa--gfx942"
     # CHECK:          .protected mma_multi
     # CHECK:          .amdhsa_kernel mma_multi
     # CHECK:          .amdhsa_user_sgpr_kernarg_segment_ptr 1
@@ -333,5 +330,108 @@ def test_mma_multi_workgroup_multi_wave():
     # CHECK:          v_mfma_f32_16x16x16_f16
     # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
     # Note: s_nop may or may not be emitted depending on latency tracking
+    # CHECK:          buffer_store_dword
+    # CHECK:          s_endpgm
+
+
+@run_test
+def test_gemm_multi_wave_k_loop():
+    """
+    Test multi-wave GEMM with K-loop (BLOCK_K=64).
+
+    Uses 4 waves per workgroup (BLOCK_M=32, BLOCK_N=32, WAVE_M=16, WAVE_N=16)
+    with BLOCK_K=64 to test loop generation with chained MFMA accumulators.
+
+    Verifies:
+    - Loop induction variable initialization
+    - Multiple MFMA instructions with accumulator chaining
+    - Loop increment and branch back
+    """
+    constraints: list[tkw.Constraint] = [
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.TilingConstraint(K, BLOCK_K),
+        tkw.WaveConstraint(M, BLOCK_M // 2),  # 2 waves in M dimension
+        tkw.WaveConstraint(N, BLOCK_N // 2),  # 2 waves in N dimension
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        ),
+    ]
+
+    @tkw.wave(constraints)
+    def gemm_multi_wave(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    compile_options = WaveCompileOptions(
+        subs={
+            M: 64,
+            N: 64,
+            K: 128,
+            BLOCK_M: 32,
+            BLOCK_N: 32,
+            BLOCK_K: 64,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    compile_options.compile_to_asm = True
+    gemm_multi_wave = wave_compile(compile_options, gemm_multi_wave)
+    print(gemm_multi_wave.asm)
+
+    # CHECK-LABEL:    test_gemm_multi_wave_k_loop
+    # CHECK:          .protected gemm_multi_wave
+    # CHECK:          .amdhsa_kernel gemm_multi_wave
+    # CHECK:          .amdhsa_system_vgpr_workitem_id 1
+    # CHECK:          gemm_multi_wave:
+
+    # Verify loop initialization - induction variable and accumulator setup
+    # CHECK:          # Initialize loop 0 counter and bounds
+    # CHECK:          s_mov_b32 s{{[0-9]+}}, 0
+    # CHECK:          # Initialize accumulator 0 to 0.0
+    # CHECK-COUNT-4:  v_mov_b32 v{{[0-9]+}}, 0
+
+    # Verify loop header - comparison and conditional branch
+    # CHECK:          loop_0_header:
+    # CHECK:          s_cmp_lt_u32 s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:          s_cbranch_scc1 loop_0_body
+
+    # Verify loop body starts
+    # CHECK:          loop_0_body:
+
+    # Verify 4 MFMAs with chained accumulators (all using same accumulator v[4:7])
+    # CHECK:          v_mfma_f32_16x16x16_f16 v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}]
+    # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
+    # CHECK:          v_mfma_f32_16x16x16_f16 v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}]
+    # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
+    # CHECK:          v_mfma_f32_16x16x16_f16 v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}]
+    # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
+    # CHECK:          v_mfma_f32_16x16x16_f16 v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}], v[{{[0-9]+}}:{{[0-9]+}}]
+    # CHECK:          # MFMA issued, latency ~{{[0-9]+}} cycles
+
+    # Verify loop latch - increment and branch back
+    # CHECK:          loop_0_latch:
+    # CHECK:          s_add_u32 s{{[0-9]+}}, s{{[0-9]+}}, s{{[0-9]+}}
+    # CHECK:          s_branch loop_0_header
+
+    # Verify loop exit and result stores
+    # CHECK:          loop_0_exit:
     # CHECK:          buffer_store_dword
     # CHECK:          s_endpgm

--- a/wave_lang/kernel/wave/asm/handlers.py
+++ b/wave_lang/kernel/wave/asm/handlers.py
@@ -17,6 +17,7 @@ from wave_lang.support.ir_imports import (
     arith_d,
     gpu_d,
     memref_d,
+    scf_d,
     stream_d,
     vector_d,
 )
@@ -211,6 +212,13 @@ class OperationHandlers:
                 ]:
                     # Thread IDs and workgroup IDs can be used as symbol values
                     symbol_values.append(operand_value)
+                elif (
+                    isinstance(operand_value, str)
+                    and operand_value.startswith("s")
+                    and operand_value[1:].isdigit()
+                ):
+                    # SGPR references (e.g., "s4" for loop counter) can be used as symbol values
+                    symbol_values.append(operand_value)
                 else:
                     # If we can't resolve the symbol value, we can't simplify
                     return None
@@ -323,6 +331,38 @@ class OperationHandlers:
         # Emit load instruction
         self._emit_load_instruction(operation, kernel_info, memref_ssa, indices)
 
+    def handle_vector_extract_strided_slice_op(
+        self, operation: vector_d.ExtractStridedSliceOp, kernel_info: KernelInfo
+    ):
+        """Handle vector.extract_strided_slice operations - extract subset of source registers."""
+        # Get source SSA value and its registers
+        source_ssa = str(operation.operands[0])
+        source_regs = self.walker.ssa_to_vgpr.get(source_ssa)
+
+        if not source_regs:
+            # Source not tracked - skip silently
+            return
+
+        # Extract offset and size from operation attributes
+        offsets = operation.attributes["offsets"]
+        sizes = operation.attributes["sizes"]
+
+        # Parse the offset value (should be a single integer for 1D extract)
+        offset_val = int(str(offsets).split("[")[1].split("]")[0])
+        size_val = int(str(sizes).split("[")[1].split("]")[0])
+
+        # Extract the appropriate subset of registers
+        if size_val == 1:
+            # Single scalar extract - return just the one register as a tuple
+            extracted_reg = source_regs[offset_val]
+            result_regs = (extracted_reg,)
+        else:
+            # Multi-element extract - return a slice
+            result_regs = source_regs[offset_val : offset_val + size_val]
+
+        result_ssa = str(operation.result)
+        self.walker.ssa_to_vgpr[result_ssa] = result_regs
+
     def handle_vector_store_op(
         self, operation: vector_d.StoreOp, kernel_info: KernelInfo
     ):
@@ -421,40 +461,61 @@ class OperationHandlers:
 
     def handle_mfma_op(self, operation: amdgpu_d.MFMAOp, kernel_info: KernelInfo):
         """Handle amdgpu.mfma operations - emit MFMA instruction with proper input sourcing."""
-        # Skip if MFMA has already been emitted
-        if self.walker._mfma_emitted:
-            return
-
         # Get the operand SSA values from the MFMA operation
         # MFMA format: %result = amdgpu.mfma %lhs * %rhs + %acc
-        if len(operation.operands) >= 2:
+        if len(operation.operands) >= 3:
             lhs_ssa = str(operation.operands[0])  # First operand (LHS of multiply)
             rhs_ssa = str(operation.operands[1])  # Second operand (RHS of multiply)
+            acc_ssa = str(operation.operands[2])  # Third operand (accumulator)
 
-            # Map the SSA values to their corresponding LDS-loaded register pairs
-            lhs_pair = self.walker._lds_last_pair.get(lhs_ssa)
-            rhs_pair = self.walker._lds_last_pair.get(rhs_ssa)
+            # Map the SSA values to their corresponding register pairs using unified tracking
+            lhs_pair = self.walker.ssa_to_vgpr.get(lhs_ssa)
+            rhs_pair = self.walker.ssa_to_vgpr.get(rhs_ssa)
 
             if lhs_pair and rhs_pair:
-                self.walker.emitter.emit_mfma_16x16x16_f16(lhs_pair, rhs_pair)
+                # Determine which accumulator to use
+                acc_quad = None
+
+                # Check if accumulator is from a previous MFMA result or vector
+                acc_regs = self.walker.ssa_to_vgpr.get(acc_ssa)
+                if acc_regs:
+                    # Accumulator from a previous operation
+                    if len(acc_regs) == 2:
+                        # Pair - extend to quad
+                        acc_quad = (
+                            acc_regs[0],
+                            acc_regs[0] + 1,
+                            acc_regs[0] + 2,
+                            acc_regs[0] + 3,
+                        )
+                    elif len(acc_regs) == 4:
+                        # Already a quad
+                        acc_quad = acc_regs
+
+                self.walker.emitter.emit_mfma_16x16x16_f16(lhs_pair, rhs_pair, acc_quad)
 
                 # MFMA now writes directly to VGPRs (not AGPRs), so result is already in VGPRs
                 result_quad = self.walker.emitter.current_vgpr_quad
 
-                # Free input pairs
-                self.walker.emitter.vgpr_allocator.free_v_pair(lhs_pair)
-                self.walker.emitter.vgpr_allocator.free_v_pair(rhs_pair)
+                # Track this MFMA result in unified SSA→VGPR map
+                result_ssa = str(operation.result)
+                self.walker.ssa_to_vgpr[result_ssa] = result_quad
 
-                self.walker.last_regs = list(result_quad)
+                # Free input pairs (unless they're from a previous MFMA or loop accumulator)
+                # Check if lhs/rhs are from loop accumulator or MFMA results (v4-v7 range)
+                if lhs_pair[0] < 4 or lhs_pair[0] > 7:
+                    self.walker.emitter.vgpr_allocator.free_v_pair(lhs_pair)
+                if rhs_pair[0] < 4 or rhs_pair[0] > 7:
+                    self.walker.emitter.vgpr_allocator.free_v_pair(rhs_pair)
+
                 self.walker.last_vmem_ticket = None  # Data now from MFMA, not VMEM
-                self.walker._mfma_emitted = True
                 return
 
         # If we reach here, MFMA inputs weren't properly set up
         raise RuntimeError(
             f"MFMA operation encountered but inputs not available. "
             f"Operands: {[str(op) for op in operation.operands]}, "
-            f"LDS pairs: {list(self.walker._lds_last_pair.keys())}"
+            f"Available SSA→VGPR mappings: {list(self.walker.ssa_to_vgpr.keys())}"
         )
 
     def handle_barrier_op(self, operation: gpu_d.BarrierOp, kernel_info: KernelInfo):
@@ -519,29 +580,24 @@ class OperationHandlers:
         Uses the byte_offset_expr computed from MLIR's actual indices rather than
         forcing lane-linear addressing.
         """
+        import sympy
 
-        # If LDS address wasn't established by a prior store, compute it from the passed-in expression
-        if memref_ssa not in self.walker._lds_addr_vreg:
-            # Add view base offset if present
-            vbase_val = self.walker._lds_view_base_bytes.get(memref_ssa, 0)
-            if vbase_val:
-                byte_offset_expr = byte_offset_expr + sympy.Integer(vbase_val)
+        # Add view base offset if present
+        vbase_val = self.walker._lds_view_base_bytes.get(memref_ssa, 0)
+        if vbase_val:
+            byte_offset_expr = byte_offset_expr + sympy.Integer(vbase_val)
 
-            # Materialize the byte offset expression into a VGPR for LDS addressing (with CSE)
-            addr_reg = self._get_expr_emitter(kernel_info).get_or_emit(byte_offset_expr)
-            addr_v = int(addr_reg[1:])
-            self.walker._lds_addr_vreg[memref_ssa] = addr_v
+        # Materialize the byte offset expression into a VGPR for LDS addressing (with CSE)
+        addr_reg = self._get_expr_emitter(kernel_info).get_or_emit(byte_offset_expr)
+        addr_v = int(addr_reg[1:])
 
         # Emit LDS read into allocated VGPR pairs
-        addr_v = self.walker._lds_addr_vreg[memref_ssa]
         pair = self.walker.emitter.vgpr_allocator.alloc_v_pair()
         self.walker.emitter.emit_lds_read_b64(pair, addr_v)
 
-        # Track the loaded data by result SSA value (for MFMA operand matching)
+        # Track the loaded data in unified SSA→VGPR map
         result_ssa = str(operation.results[0])
-        self.walker._lds_last_pair[result_ssa] = pair
-        self.walker._lds_read_order.append(result_ssa)
-        self.walker.last_regs = [pair]
+        self.walker.ssa_to_vgpr[result_ssa] = pair
 
     def _ensure_global_load_srd(self, kernel_info, memref_ssa):
         """Ensure SRD is set up for a global load."""
@@ -570,15 +626,29 @@ class OperationHandlers:
             raise ValueError(f"Cannot parse vector type for global load: {e}")
 
     def _emit_buffer_load_and_track(
-        self, kernel_info, memref_ssa, vector_bytes, voffset_v, instoffset
+        self, operation, kernel_info, memref_ssa, vector_bytes, voffset_v, instoffset
     ):
         """Emit buffer load instruction and track loaded registers and ticket."""
-        self.walker.last_regs, self.walker.last_vmem_ticket = (
-            self.walker.emitter.emit_load(
-                memref_ssa, vector_bytes, voffset_v, instoffset
-            )
+        loaded_regs, vmem_ticket = self.walker.emitter.emit_load(
+            memref_ssa, vector_bytes, voffset_v, instoffset
         )
-        self.walker.last_vec_bytes = vector_bytes
+
+        # emit_load returns a list of register tuples
+        # For single load (8/16 bytes), extract the tuple from the list
+        if isinstance(loaded_regs, list) and len(loaded_regs) == 1:
+            regs_tuple = loaded_regs[0]
+        elif isinstance(loaded_regs, list):
+            # Multiple loads - keep as list for now
+            regs_tuple = loaded_regs
+        else:
+            regs_tuple = loaded_regs
+
+        # Store in unified SSA→VGPR tracking
+        result_ssa = str(operation.results[0])
+        self.walker.ssa_to_vgpr[result_ssa] = regs_tuple
+
+        # Keep vmem_ticket for wait count computation
+        self.walker.last_vmem_ticket = vmem_ticket
 
     def _emit_global_load(self, operation, kernel_info, memref_ssa, byte_offset_expr):
         """Emit a global buffer load operation."""
@@ -606,7 +676,7 @@ class OperationHandlers:
         vector_bytes = self._parse_vector_load_type(operation)
 
         self._emit_buffer_load_and_track(
-            kernel_info, memref_ssa, vector_bytes, voffset_v, instoffset
+            operation, kernel_info, memref_ssa, vector_bytes, voffset_v, instoffset
         )
 
         # Free voffset only if it was a temporary (not from cache)
@@ -692,52 +762,50 @@ class OperationHandlers:
         return int(addr_reg[1:])
 
     def _extract_source_registers(self, vector_bytes):
-        """Extract source registers from last_regs based on vector size."""
-        first = (
-            self.walker.last_regs[0]
-            if isinstance(self.walker.last_regs, list)
-            else self.walker.last_regs
-        )
+        """Extract source registers from current store value based on vector size."""
+        regs = self._current_store_regs
+
+        # regs should already be a tuple of register indices from ssa_to_vgpr
+        # e.g., (8, 9) for a pair, (4, 5, 6, 7) for a quad
 
         if vector_bytes == 4:
-            # Single register (scalar)
-            return first[0] if isinstance(first, tuple) else first
+            # Single register (4 bytes) - extract first element
+            if isinstance(regs, (tuple, list)) and len(regs) > 0:
+                return regs[0]
+            elif isinstance(regs, int):
+                return regs
+            else:
+                raise ValueError(f"Expected register(s) for 4-byte store, got: {regs}")
         elif vector_bytes == 8:
-            # Register pair
-            return first if isinstance(first, tuple) else (first[0], first[1])
+            # Register pair (8 bytes)
+            if isinstance(regs, (tuple, list)) and len(regs) == 2:
+                return regs  # Already a pair
+            else:
+                raise ValueError(
+                    f"Expected 2-element tuple for 8-byte store, got {len(regs) if isinstance(regs, (tuple, list)) else 'non-tuple'}: {regs}"
+                )
         elif vector_bytes == 16:
-            # Register quad
-            return (
-                first
-                if isinstance(first, tuple)
-                else (first[0], first[1], first[2], first[3])
-            )
+            # Register quad (16 bytes)
+            if isinstance(regs, (tuple, list)) and len(regs) == 4:
+                return regs  # Already a quad
+            else:
+                raise ValueError(
+                    f"Expected 4-element tuple for 16-byte store, got {len(regs) if isinstance(regs, (tuple, list)) else 'non-tuple'}: {regs}"
+                )
         else:
             raise NotImplementedError(
                 f"LDS stores of {vector_bytes} bytes not yet supported. "
                 f"Supported sizes: 4 (ds_write_b32), 8 (ds_write_b64), 16 (ds_write_b128)"
             )
 
-    def _emit_ds_write_and_track(self, memref_ssa, addr_v, src_regs, vector_bytes):
-        """Emit ds_write instruction and track state for later reads."""
+    def _emit_ds_write(self, memref_ssa, addr_v, src_regs, vector_bytes):
+        """Emit ds_write instruction for LDS stores."""
         if vector_bytes == 4:
             self.walker.emitter.emit_lds_write_b32(addr_v, src_regs)
-            self.walker._lds_addr_vreg[memref_ssa] = addr_v
-            self.walker._lds_last_pair[memref_ssa] = (
-                src_regs,
-                src_regs,
-            )  # Store as pair for consistency
         elif vector_bytes == 8:
             self.walker.emitter.emit_lds_write_b64(addr_v, src_regs)
-            self.walker._lds_addr_vreg[memref_ssa] = addr_v
-            self.walker._lds_last_pair[memref_ssa] = src_regs
         elif vector_bytes == 16:
             self.walker.emitter.emit_lds_write_b128(addr_v, src_regs)
-            self.walker._lds_addr_vreg[memref_ssa] = addr_v
-            self.walker._lds_last_pair[memref_ssa] = (
-                src_regs[0],
-                src_regs[1],
-            )  # Store first pair
 
     def _emit_lds_store(
         self,
@@ -762,7 +830,7 @@ class OperationHandlers:
 
                 self.walker.emitter.emit_instruction(SWaitcnt(f"vmcnt({threshold})"))
         src_regs = self._extract_source_registers(vector_bytes)
-        self._emit_ds_write_and_track(memref_ssa, addr_v, src_regs, vector_bytes)
+        self._emit_ds_write(memref_ssa, addr_v, src_regs, vector_bytes)
 
     def _ensure_global_store_srd(self, kernel_info, memref_ssa):
         """Ensure SRD is set up for a global store."""
@@ -778,29 +846,14 @@ class OperationHandlers:
             arg_idx = binding_use.arg_index if binding_use.arg_index >= 0 else 0
             self.walker.emitter.ensure_srd_for_subspan(memref_ssa, arg_idx, limit_bytes)
 
-    def _pop_next_scalar_register(self):
-        """Pop and return the next scalar register from the queue, updating state."""
-        # Normalize to list
-        src_regs = (
-            self.walker.last_regs
-            if isinstance(self.walker.last_regs, list)
-            else [self.walker.last_regs]
-        )
-        is_multi_element = len(src_regs) > 1
+    def _get_scalar_register_for_store(self):
+        """Get the scalar register to store (first element of current store value)."""
+        src_regs = self._current_store_regs
 
-        # Pop first element
+        # Get first element
         src_v = src_regs[0]
         if not isinstance(src_v, int):
             src_v = src_v[0] if isinstance(src_v, tuple) else src_v
-
-        # Update queue
-        remaining = src_regs[1:]
-        if remaining:
-            self.walker.last_regs = remaining
-        else:
-            self.walker.last_regs = None
-            if is_multi_element:
-                self.walker._mfma_stores_emitted = True
 
         return src_v
 
@@ -857,8 +910,8 @@ class OperationHandlers:
                 self.walker.emitter.emit_instruction(SWaitcnt(f"vmcnt({threshold})"))
 
         if num_elements == 1:
-            # Scalar store: pop register from queue, emit, free
-            src_v = self._pop_next_scalar_register()
+            # Scalar store: get first register, emit, free
+            src_v = self._get_scalar_register_for_store()
             self.walker.emitter.emit_store_scalar_with_vindex(
                 memref_ssa, src_v, voffset_v, instoffset
             )
@@ -869,7 +922,11 @@ class OperationHandlers:
         else:
             # Vectorized store: emit all elements at once
             self.walker.emitter.emit_store_with_regs(
-                memref_ssa, self.walker.last_regs, vector_bytes, voffset_v, instoffset
+                memref_ssa,
+                self._current_store_regs,
+                vector_bytes,
+                voffset_v,
+                instoffset,
             )
             if voffset_is_temp:
                 self.walker.emitter.vgpr_allocator.free_v(voffset_v)
@@ -894,11 +951,19 @@ class OperationHandlers:
             self._parse_store_type_info(operation)
         )
 
-        # Check if we have data to store
-        if not self.walker.last_regs:
+        # Get the SSA value being stored (first operand)
+        value_ssa = str(operation.operands[0])
+
+        # Look up the registers containing the value to store
+        value_regs = self.walker.ssa_to_vgpr.get(value_ssa)
+        if not value_regs:
             raise RuntimeError(
-                "Store encountered without a preceding load to provide data regs."
+                f"Store operation references SSA value {value_ssa} but it's not in ssa_to_vgpr. "
+                f"Available: {list(self.walker.ssa_to_vgpr.keys())}"
             )
+
+        # Store value_regs for extraction in subsequent methods
+        self._current_store_regs = value_regs
 
         # Check address space to determine LDS vs global
         if self._is_lds_store_memref(operation):
@@ -924,3 +989,87 @@ class OperationHandlers:
             num_elements,
             vector_bytes,
         )
+
+    def handle_scf_for_op(self, operation: scf_d.ForOp, kernel_info: KernelInfo):
+        """
+        Handle scf.for operations - emit loop assembly code.
+
+        Args:
+            operation: The scf.for operation
+            kernel_info: Kernel information for context
+        """
+        emitter = self.walker.emitter
+
+        # Extract loop bounds
+        lower_bound_ssa = str(operation.lowerBound)
+        upper_bound_ssa = str(operation.upperBound)
+        step_ssa = str(operation.step)
+
+        # Get bounds from index_env (should be constants)
+        if lower_bound_ssa not in kernel_info.index_env:
+            raise ValueError(
+                f"Loop lower bound {lower_bound_ssa} not found in index_env"
+            )
+        if upper_bound_ssa not in kernel_info.index_env:
+            raise ValueError(
+                f"Loop upper bound {upper_bound_ssa} not found in index_env"
+            )
+        if step_ssa not in kernel_info.index_env:
+            raise ValueError(f"Loop step {step_ssa} not found in index_env")
+        lower_bound = kernel_info.index_env[lower_bound_ssa]
+        upper_bound = kernel_info.index_env[upper_bound_ssa]
+        step = kernel_info.index_env[step_ssa]
+
+        # Begin loop structure
+        loop_ctx = emitter.begin_loop(lower_bound, upper_bound, step)
+
+        # Get induction variable and map it to the loop counter SGPR
+        loop_body = operation.body
+        induction_var = loop_body.arguments[0]
+        induction_var_ssa = str(induction_var)
+        loop_counter_sgpr = loop_ctx["counter_sgpr"]
+
+        # Store mapping from SSA induction variable to SGPR counter for use in expressions
+        # This will be used when affine.apply operations reference the induction variable
+        kernel_info.index_env[induction_var_ssa] = f"s{loop_counter_sgpr}"
+        loop_ctx["induction_var_ssa"] = induction_var_ssa
+
+        # Allocate and initialize VGPRs for iter_args (accumulators)
+        from .instructions import VMovB32
+
+        iter_arg_vgprs = []
+
+        for i, arg in enumerate(loop_body.arguments[1:]):  # Skip induction variable
+            # Allocate quad for accumulator (MFMA result)
+            quad = emitter.vgpr_allocator.alloc_v_quad()
+            iter_arg_vgprs.append(quad)
+
+            # Track in unified SSA→VGPR map
+            arg_ssa = str(arg)
+            self.walker.ssa_to_vgpr[arg_ssa] = quad
+
+            # Initialize accumulator to 0.0 before loop
+            emitter.emit(f"    # Initialize accumulator {i} to 0.0")
+            for vreg in quad:
+                emitter.emit_instruction(VMovB32(vreg, 0))
+
+        loop_ctx["iter_arg_vgprs"] = iter_arg_vgprs
+
+        # Emit loop header and conditional branch
+        emitter.emit_loop_header(loop_ctx)
+
+        # Walk loop body
+        self.walker._walk_block(loop_body, kernel_info)
+
+        # Emit loop latch (increment and branch back)
+        emitter.emit_loop_latch(loop_ctx)
+
+        # End loop
+        emitter.end_loop()
+
+        # Map scf.for results to the final values of iter_args
+        # The results of scf.for are the final values after the loop completes
+        for i, result in enumerate(operation.results):
+            result_ssa = str(result)
+            if i < len(iter_arg_vgprs):
+                self.walker.ssa_to_vgpr[result_ssa] = iter_arg_vgprs[i]

--- a/wave_lang/kernel/wave/asm/mlir_walker.py
+++ b/wave_lang/kernel/wave/asm/mlir_walker.py
@@ -11,6 +11,7 @@ from wave_lang.support.ir_imports import (
     func_d,
     gpu_d,
     memref_d,
+    scf_d,
     stream_d,
     vector_d,
     OpAttributeMap,
@@ -26,20 +27,16 @@ from .handlers import OperationHandlers
 
 class IRWalker:
     def __init__(self, emitter=None):
-        """Initialize IRWalker with optional emitter for single-pass traversal."""
+        """Initialize IRWalker with optional emitter."""
         self.emitter = emitter
-        self.last_regs = None
-        self.last_vec_bytes = 0
-        self.last_vmem_ticket = None  # Track VMEM ticket for last load
-        # Track LDS addresses and last regs per memref for shared memory paths
-        self._lds_addr_vreg: dict[str, int] = {}
-        self._lds_last_pair: dict[str, tuple[int, int]] = {}
-        self._lds_read_order: list[str] = []
-        self._mfma_emitted: bool = False
-        self._lds_view_base_bytes: dict[str, int] = {}
-        # Track global memory load register pairs for MFMA
-        self._global_load_pairs: list[tuple[int, int]] = []
-        self._mfma_stores_emitted: bool = False  # Track if MFMA result stores are done
+
+        # Unified SSA-to-VGPR mapping for all vector operations
+        # Maps SSA value strings to register allocations (tuples of register indices)
+        self.ssa_to_vgpr: dict[str, tuple[int, ...]] = {}
+
+        # Supporting fields
+        self.last_vmem_ticket = None  # Used for wait count computation
+        self._lds_view_base_bytes: dict[str, int] = {}  # LDS view offsets
         # Initialize operation handlers
         self.handlers = OperationHandlers(self)
 
@@ -61,31 +58,40 @@ class IRWalker:
                 kernel_info.subgroup_size = subgroup_size
 
         # Walk operations and fill environment + accesses
-        for block in fn.body.blocks:
-            for operation in block.operations:
-                if isinstance(operation, arith_d.ConstantOp):
-                    self.handlers.handle_arith_constant_op(operation, kernel_info)
-                elif isinstance(operation, gpu_d.ThreadIdOp):
-                    self.handlers.handle_gpu_thread_id_op(operation, kernel_info)
-                elif isinstance(operation, gpu_d.BlockIdOp):
-                    self.handlers.handle_gpu_block_id_op(operation, kernel_info)
-                elif isinstance(operation, affine_d.AffineApplyOp):
-                    self.handlers.handle_affine_apply_op(operation, kernel_info)
-                elif isinstance(operation, vector_d.LoadOp):
-                    self.handlers.handle_vector_load_op(operation, kernel_info)
-                elif isinstance(operation, vector_d.StoreOp):
-                    self.handlers.handle_vector_store_op(operation, kernel_info)
-                elif isinstance(operation, amdgpu_d.MFMAOp):
-                    self.handlers.handle_mfma_op(operation, kernel_info)
-                elif isinstance(operation, amdgpu_d.LDSBarrierOp):
-                    self.handlers.handle_lds_barrier_op(operation, kernel_info)
-                elif isinstance(operation, memref_d.ViewOp):
-                    self.handlers.handle_view_op(operation, kernel_info)
-                elif isinstance(operation, memref_d.AllocOp):
-                    self.handlers.handle_alloc_op(operation, kernel_info)
-                elif isinstance(operation, stream_d.BindingSubspanOp):
-                    self.handlers.handle_stream_binding_subspan_op(
-                        operation, kernel_info
-                    )
+        self._walk_block(fn.entry_block, kernel_info)
 
         return kernel_info
+
+    def _walk_block(self, block, kernel_info: KernelInfo):
+        """Walk operations in a block and dispatch to appropriate handlers."""
+        for operation in block.operations:
+            if isinstance(operation, arith_d.ConstantOp):
+                self.handlers.handle_arith_constant_op(operation, kernel_info)
+            elif isinstance(operation, gpu_d.ThreadIdOp):
+                self.handlers.handle_gpu_thread_id_op(operation, kernel_info)
+            elif isinstance(operation, gpu_d.BlockIdOp):
+                self.handlers.handle_gpu_block_id_op(operation, kernel_info)
+            elif isinstance(operation, affine_d.AffineApplyOp):
+                self.handlers.handle_affine_apply_op(operation, kernel_info)
+            elif isinstance(operation, vector_d.LoadOp):
+                self.handlers.handle_vector_load_op(operation, kernel_info)
+            elif isinstance(operation, vector_d.StoreOp):
+                self.handlers.handle_vector_store_op(operation, kernel_info)
+            elif isinstance(operation, amdgpu_d.MFMAOp):
+                self.handlers.handle_mfma_op(operation, kernel_info)
+            elif isinstance(operation, amdgpu_d.LDSBarrierOp):
+                self.handlers.handle_lds_barrier_op(operation, kernel_info)
+            elif isinstance(operation, memref_d.ViewOp):
+                self.handlers.handle_view_op(operation, kernel_info)
+            elif isinstance(operation, memref_d.AllocOp):
+                self.handlers.handle_alloc_op(operation, kernel_info)
+            elif isinstance(operation, stream_d.BindingSubspanOp):
+                self.handlers.handle_stream_binding_subspan_op(operation, kernel_info)
+            elif isinstance(operation, scf_d.ForOp):
+                self.handlers.handle_scf_for_op(operation, kernel_info)
+            elif isinstance(operation, vector_d.ExtractStridedSliceOp):
+                self.handlers.handle_vector_extract_strided_slice_op(
+                    operation, kernel_info
+                )
+            else:
+                pass

--- a/wave_lang/kernel/wave/asm/register_allocator.py
+++ b/wave_lang/kernel/wave/asm/register_allocator.py
@@ -7,7 +7,35 @@
 Register file and allocators for AMDGCN assembly generation.
 """
 
-from typing import Tuple
+from typing import Tuple, List, Union, Optional
+from enum import Enum
+import os
+
+
+# Global debug flag for allocator logging (set DEBUG_ASM_ALLOCATOR=1 to enable)
+DEBUG_ALLOCATOR = os.environ.get("DEBUG_ASM_ALLOCATOR", "0") == "1"
+
+
+class RegisterOp(Enum):
+    """Register operation types for logging."""
+
+    ALLOC_V = "alloc_v"
+    ALLOC_V_PAIR = "alloc_v_pair"
+    ALLOC_V_QUAD = "alloc_v_quad"
+    FREE_V = "free_v"
+    FREE_V_PAIR = "free_v_pair"
+    FREE_V_QUAD = "free_v_quad"
+    RESERVE = "reserve"
+    ALLOC_S = "alloc_s"
+    FREE_S = "free_s"
+
+
+def _log_alloc(msg: str):
+    """Log allocator operations if debug flag is enabled."""
+    if DEBUG_ALLOCATOR:
+        import sys
+
+        print(f"[ALLOCATOR] {msg}", file=sys.stderr)
 
 
 class RegFile:
@@ -17,11 +45,45 @@ class RegFile:
         self.a_used = set()  # Track AGPR usage
         self.a_max = -1  # Track maximum AGPR index used
 
+        # Track allocation history for debugging (enabled via DEBUG_ALLOCATOR)
+        self.allocation_history: List[str] = (
+            []
+        )  # Human-readable log of alloc/free events
+
 
 class SGPRAllocator:
     def __init__(self, register_file: RegFile):
         self.register_file = register_file
         self.next_sgpr = 2
+        self.allocated_sgprs: set = set()  # Track allocated SGPRs for validation
+
+    def alloc_s(self) -> int:
+        """Allocate a single SGPR."""
+        register = self.next_sgpr
+        self.next_sgpr += 1
+        self.register_file.s_max = max(self.register_file.s_max, register)
+        self.allocated_sgprs.add(register)
+        _log_alloc(f"{RegisterOp.ALLOC_S.value}: s{register}")
+        self.register_file.allocation_history.append(
+            f"{RegisterOp.ALLOC_S.value}: s{register}"
+        )
+        return register
+
+    def free_s(self, register: int):
+        """Free a single SGPR (for future optimization - currently a no-op)."""
+        # Validation: Check for double-free
+        if register not in self.allocated_sgprs:
+            _log_alloc(
+                f"WARNING: Attempted to free unallocated/already-freed SGPR s{register}"
+            )
+        else:
+            self.allocated_sgprs.discard(register)
+            _log_alloc(f"{RegisterOp.FREE_S.value}: s{register}")
+            self.register_file.allocation_history.append(
+                f"{RegisterOp.FREE_S.value}: s{register}"
+            )
+        # Simple allocator doesn't reuse SGPRs yet
+        pass
 
     def pair(self) -> Tuple[int, int]:
         first_register, second_register = self.next_sgpr, self.next_sgpr + 1
@@ -49,62 +111,180 @@ class VGPRAllocator:
         self.base = base
         self.reserved = set()  # Reserved registers that should never be allocated
 
+        # Free lists for LIFO reuse per size class
+        self.free_list_singles = []  # List of freed single VGPRs
+        self.free_list_pairs = []  # List of freed VGPR pairs (tuples)
+        self.free_list_quads = []  # List of freed VGPR quads (tuples)
+
+        # Track peak VGPR usage for metadata
+        self.v_peak = -1
+
     def reserve(self, reg: int):
         """Mark a register as reserved (e.g., for special purposes)."""
+        if reg in self.reserved:
+            _log_alloc(f"WARNING: v{reg} already reserved, skipping duplicate reserve")
+            return
         self.reserved.add(reg)
         self.register_file.v_used.add(reg)
+        self.v_peak = max(self.v_peak, reg)
+        _log_alloc(f"{RegisterOp.RESERVE.value}: v{reg}")
+        self.register_file.allocation_history.append(
+            f"{RegisterOp.RESERVE.value}: v{reg}"
+        )
+
+    def _try_reuse(
+        self, free_list: List, op: RegisterOp
+    ) -> Optional[Union[int, Tuple]]:
+        """Try to reuse registers from a free list."""
+        while free_list:
+            regs = free_list.pop()
+            # Convert to tuple for uniform handling
+            regs_tuple = (regs,) if isinstance(regs, int) else regs
+
+            # Check if any register is reserved or in use
+            if not any(
+                r in self.reserved or r in self.register_file.v_used for r in regs_tuple
+            ):
+                # Mark as used
+                self.register_file.v_used.update(regs_tuple)
+
+                # Log the reuse
+                if isinstance(regs, int):
+                    _log_alloc(f"{op.value}: v{regs} (reused)")
+                    self.register_file.allocation_history.append(
+                        f"{op.value}: v{regs} (reused)"
+                    )
+                else:
+                    _log_alloc(f"{op.value}: v[{regs[0]}:{regs[-1]}] (reused)")
+                    self.register_file.allocation_history.append(
+                        f"{op.value}: v[{regs[0]}:{regs[-1]}] (reused)"
+                    )
+
+                return regs
+        return None
+
+    def _allocate_new(
+        self, count: int, alignment: int, op: RegisterOp
+    ) -> Union[int, Tuple]:
+        """Allocate new register(s) with given count and alignment."""
+        # Align base register
+        base_reg = (self.base + alignment - 1) & ~(alignment - 1)
+
+        # Find free aligned block
+        while any(
+            (base_reg + i) in self.register_file.v_used
+            or (base_reg + i) in self.reserved
+            for i in range(count)
+        ):
+            base_reg += alignment
+
+        # Create register tuple
+        if count == 1:
+            regs = base_reg
+            regs_tuple = (base_reg,)
+        elif count == 2:
+            regs = (base_reg, base_reg + 1)
+            regs_tuple = regs
+        else:  # count == 4
+            regs = (base_reg, base_reg + 1, base_reg + 2, base_reg + 3)
+            regs_tuple = regs
+
+        # Mark as used and update peak
+        self.register_file.v_used.update(regs_tuple)
+        self.v_peak = max(self.v_peak, base_reg + count - 1)
+
+        # Log allocation
+        if count == 1:
+            _log_alloc(f"{op.value}: v{regs} (new, v_peak={self.v_peak})")
+            self.register_file.allocation_history.append(f"{op.value}: v{regs} (new)")
+        else:
+            _log_alloc(
+                f"{op.value}: v[{regs[0]}:{regs[-1]}] (new, v_peak={self.v_peak})"
+            )
+            self.register_file.allocation_history.append(
+                f"{op.value}: v[{regs[0]}:{regs[-1]}] (new)"
+            )
+
+        return regs
 
     def alloc_v(self) -> int:
-        """Allocate a single VGPR."""
-        reg = self.base
-        while reg in self.register_file.v_used or reg in self.reserved:
-            reg += 1
-        self.register_file.v_used.add(reg)
-        return reg
+        """Allocate a single VGPR with reuse from free list."""
+        result = self._try_reuse(self.free_list_singles, RegisterOp.ALLOC_V)
+        if result is not None:
+            return result
+        return self._allocate_new(count=1, alignment=1, op=RegisterOp.ALLOC_V)
 
     def alloc_v_pair(self) -> Tuple[int, int]:
-        """Allocate a pair of VGPRs (aligned to 2)."""
-        base_reg = (self.base + 1) & ~1  # Align to 2
-        while any(
-            (base_reg + i) in self.register_file.v_used
-            or (base_reg + i) in self.reserved
-            for i in range(2)
-        ):
-            base_reg += 2
-        regs = (base_reg, base_reg + 1)
-        self.register_file.v_used.update(regs)
-        return regs
+        """Allocate a pair of VGPRs (aligned to 2) with reuse."""
+        result = self._try_reuse(self.free_list_pairs, RegisterOp.ALLOC_V_PAIR)
+        if result is not None:
+            return result
+        return self._allocate_new(count=2, alignment=2, op=RegisterOp.ALLOC_V_PAIR)
 
     def alloc_v_quad(self) -> Tuple[int, int, int, int]:
-        """Allocate a quad of VGPRs (aligned to 4)."""
-        base_reg = (self.base + 3) & ~3  # Align to 4
-        while any(
-            (base_reg + i) in self.register_file.v_used
-            or (base_reg + i) in self.reserved
-            for i in range(4)
-        ):
-            base_reg += 4
-        regs = (base_reg, base_reg + 1, base_reg + 2, base_reg + 3)
-        self.register_file.v_used.update(regs)
-        return regs
+        """Allocate a quad of VGPRs (aligned to 4) with reuse."""
+        result = self._try_reuse(self.free_list_quads, RegisterOp.ALLOC_V_QUAD)
+        if result is not None:
+            return result
+        return self._allocate_new(count=4, alignment=4, op=RegisterOp.ALLOC_V_QUAD)
+
+    def _free_registers(
+        self, regs: Union[int, Tuple], free_list: List, op: RegisterOp
+    ) -> None:
+        """Generic register freeing with validation."""
+        # Normalize to tuple for uniform handling
+        regs_tuple = (regs,) if isinstance(regs, int) else regs
+
+        # Validate: check if any register is reserved
+        if any(r in self.reserved for r in regs_tuple):
+            if isinstance(regs, int):
+                _log_alloc(f"WARNING: Attempted to free reserved VGPR v{regs}")
+            else:
+                _log_alloc(
+                    f"WARNING: Attempted to free reserved VGPRs v[{regs[0]}:{regs[-1]}]"
+                )
+            return
+
+        # Validate: check if all registers are actually in use
+        if not all(r in self.register_file.v_used for r in regs_tuple):
+            if isinstance(regs, int):
+                _log_alloc(
+                    f"WARNING: Attempted to free unallocated/already-freed VGPR v{regs}"
+                )
+            else:
+                _log_alloc(
+                    f"WARNING: Attempted to free unallocated/already-freed VGPRs v[{regs[0]}:{regs[-1]}]"
+                )
+            return
+
+        # Free all registers atomically
+        for reg in regs_tuple:
+            self.register_file.v_used.discard(reg)
+
+        # Add to free list for reuse
+        free_list.append(regs)
+
+        # Log the operation
+        if isinstance(regs, int):
+            _log_alloc(f"{op.value}: v{regs}")
+            self.register_file.allocation_history.append(f"{op.value}: v{regs}")
+        else:
+            _log_alloc(f"{op.value}: v[{regs[0]}:{regs[-1]}]")
+            self.register_file.allocation_history.append(
+                f"{op.value}: v[{regs[0]}:{regs[-1]}]"
+            )
 
     def free_v(self, reg: int):
         """Free a single VGPR."""
-        if reg in self.reserved:
-            return  # Don't free reserved registers
-        self.register_file.v_used.discard(reg)
+        self._free_registers(reg, self.free_list_singles, RegisterOp.FREE_V)
 
     def free_v_pair(self, regs: Tuple[int, int]):
         """Free a pair of VGPRs."""
-        for reg in regs:
-            if reg not in self.reserved:
-                self.register_file.v_used.discard(reg)
+        self._free_registers(regs, self.free_list_pairs, RegisterOp.FREE_V_PAIR)
 
     def free_v_quad(self, regs: Tuple[int, int, int, int]):
         """Free a quad of VGPRs."""
-        for reg in regs:
-            if reg not in self.reserved:
-                self.register_file.v_used.discard(reg)
+        self._free_registers(regs, self.free_list_quads, RegisterOp.FREE_V_QUAD)
 
     # Legacy method for compatibility
     def quad(self) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
…er reuse

This PR adds native support for MLIR structured control flow loops (scf.for) to the ASM backend, enabling efficient K-loop tiling for GEMM with MFMA accumulator chaining. It introduces unified SSA-to-VGPR tracking (ssa_to_vgpr dictionary) to replace fragmented tracking variables, simplifying data flow and improving correctness.