### PR TITLE
[water] verify at most one hardware constraint

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -137,9 +137,9 @@ static llvm::LogicalResult verifyAttributeHyperparamUses(
 }
 
 /// Verify DeviceConstraints, WorkgroupConstraints, WaveConstraints, and
-/// TilingConstraints for a given set of hyperparameters. This verifcation
+/// TilingConstraints for a given set of hyperparameters. This verification
 /// assumes that all symbols used in the wave.constraints attributes have a
-/// coresponding entry in the hyperparameter attribute.
+/// corresponding entry in the hyperparameter attribute.
 static llvm::LogicalResult
 verifyConstraints(mlir::ArrayAttr constraints,
                   wave::WaveHyperparameterAttr hyperparams,
@@ -455,6 +455,11 @@ wave::WaveDialect::verifyOperationAttribute(mlir::Operation *op,
         diag.attachNote(parent->getLoc()) << "ancestor";
         return diag;
       }
+    }
+
+    if (llvm::count_if(attrs, llvm::IsaPred<wave::HardwareConstraintAttr>) >
+        1) {
+      return op->emitError() << "only one hardware constraint is allowed";
     }
 
     if (!needsHyperparams) {

--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -543,13 +543,9 @@ static wave::HardwareConstraintAttr parseWaveConstraints(
       symbolConstraints[tiling.getDim()].push_back(tiling);
     } else if (auto hardware =
                    llvm::dyn_cast<wave::HardwareConstraintAttr>(constraint)) {
-      if (!hardwareConstraint) {
-        hardwareConstraint = hardware;
-      } else {
-        // TODO: this should be checked by the verifier.
-        emitError(loc) << "multiple hardware constraints are not supported";
-        return nullptr;
-      }
+      assert(hardwareConstraint == nullptr &&
+             "multiple hardware constraints are not supported");
+      hardwareConstraint = hardware;
     } else {
       emitError(loc) << "unsupported constraint type: " << constraint;
       return nullptr;

--- a/water/test/Dialect/Wave/attr-constraint-invalid.mlir
+++ b/water/test/Dialect/Wave/attr-constraint-invalid.mlir
@@ -18,6 +18,13 @@ func.func private @test_num_dimensions_mismatch2() attributes { wave.constraints
 
 // -----
 
+#hw_constraint = #wave.hardware_constraint<threads_per_wave = 64>
+#hw_constraint2 = #wave.hardware_constraint<threads_per_wave = 32>
+// expected-error @below {{only one hardware constraint is allowed}}
+func.func private @test_repeated_hw_constraint() attributes { wave.constraints = [#hw_constraint, #hw_constraint2] }
+
+// -----
+
 #hyperparams = #wave.hyperparameters<{M = 1024, K = 1024, BLOCK_M = 128, BLOCK_K = 128}>
 #wg_constraint = #wave.workgroup_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>, workgroup_dim = <x>>
 #wv_constraint = #wave.wave_constraint<dim = <"M">, tile_size = <[#wave.symbol<"BLOCK_M">] -> (BLOCK_M floordiv 4)>>

--- a/water/test/Dialect/Wave/infer-index-exprs.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs.mlir
@@ -531,17 +531,3 @@ module attributes { wave.normal_form = #wave.normal_form<full_types> } {
     return
   }
 }
-
-// -----
-
-module attributes { wave.normal_form = #wave.normal_form<full_types> } {
-  // expected-error @below {{multiple hardware constraints are not supported}}
-  func.func @empty() attributes {
-    wave.constraints = [
-      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>,
-      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
-    ]
-  } {
-    return
-  }
-}


### PR DESCRIPTION
There should be at most one hardware constraint provided in the Wave
constraint attribute. Move the verification logic from the index
inference pass to the dialect attribute verifier.