### PR TITLE
[water] only allow 2d MMA operations

### DIFF
--- a/water/test/Dialect/Wave/infer-index-exprs.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs.mlir
@@ -515,19 +515,3 @@ module attributes { wave.normal_form = #wave.normal_form<full_types> } {
     return
   }
 }
-
-// -----
-
-module attributes { wave.normal_form = #wave.normal_form<full_types> } {
-  func.func @mma_3d(%a: !wave.tensor<[@M, @K, @B] of f16>,
-                    %b: !wave.tensor<[@N, @K, @B] of f16>,
-                    %c: !wave.tensor<[@M, @N, @B] of f32>) attributes {
-    wave.constraints = [
-      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
-    ]} {
-    // expected-error @below {{only 2 indexing symbols are currently supported for MMA result}}
-    wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x16_f16>}
-      : (!wave.tensor<[@M, @K, @B] of f16>, !wave.tensor<[@N, @K, @B] of f16>, !wave.tensor<[@M, @N, @B] of f32>) -> !wave.tensor<[@M, @N, @B] of f32>
-    return
-  }
-}

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -42,6 +42,19 @@ func.func @mismatch_dim_rhs_acc(%lhs: !wave.tensor<[@A, @B] of f16>, %rhs: !wave
 
 // -----
 
+module attributes { wave.normal_form = #wave.normal_form<full_types> } {
+  func.func @mma_3d(%a: !wave.tensor<[@M, @K, @B] of f16>,
+                    %b: !wave.tensor<[@N, @K, @B] of f16>,
+                    %c: !wave.tensor<[@M, @N, @B] of f32>) {
+    // expected-error @below {{only 2D MMA operations are supported}}
+    wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x16_f16>}
+      : (!wave.tensor<[@M, @K, @B] of f16>, !wave.tensor<[@N, @K, @B] of f16>, !wave.tensor<[@M, @N, @B] of f32>) -> !wave.tensor<[@M, @N, @B] of f32>
+    return
+  }
+}
+
+// -----
+
 func.func @invalid_register_type(%arg0: f32) {
   // expected-error @below {{expected wave tensor or vector type, got 'f32'}}
   wave.register %arg0 : f32


### PR DESCRIPTION
This is already expected implicitly by shape matchers, but not verified.