### PR TITLE
[wave] use rocdl operations instead of calls to llvm intrinsics

### DIFF
--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -447,7 +447,7 @@ def test_bshd_attention_pipelined_prefetch_pingpong():
     # CHECK: rocdl.s.setprio 0
     # Softmax
     # CHECK: gpu.shuffle
-    # CHECK: llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK: rocdl.sched.barrier
 
     # Global load, shared write, shared read
     # CHECK-COUNT-2: vector.load
@@ -455,7 +455,7 @@ def test_bshd_attention_pipelined_prefetch_pingpong():
     # CHECK-COUNT-2: vector.store
     # CHECK-COUNT-4: memref.load
     # CHECK-COUNT-1: vector.from_elements
-    # CHECK-DAG: llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK-DAG: rocdl.sched.barrier
 
     # MMA
     # CHECK: rocdl.s.setprio 1
@@ -463,14 +463,14 @@ def test_bshd_attention_pipelined_prefetch_pingpong():
     # CHECK: rocdl.s.setprio 0
     # Softmax
     # CHECK: gpu.shuffle
-    # CHECK: llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK: rocdl.sched.barrier
 
     # Global load, shared write, shared read
     # CHECK-COUNT: vector.load
     # CHECK: amdgpu.lds_barrier
     # CHECK-COUNT: vector.store
     # CHECK-COUNT-32: vector.load
-    # CHECK: llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK: rocdl.sched.barrier
 
     # CHECK: scf.if
     # CHECK-NEXT: rocdl.s.barrier

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1120,7 +1120,7 @@ def test_tensor_waitcnt():
     print(schedule_ops.asm)
 
     # CHECK-LABEL:    func.func @schedule_ops
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
+    # CHECK:            rocdl.s.wait.tensorcnt 0
     # CHECK:            rocdl.s.wait.dscnt 0
     # CHECK:            rocdl.s.barrier.signal -1
     # CHECK:            rocdl.s.barrier.wait -1

--- a/lit_tests/kernel/wave/gather_to_shared.py
+++ b/lit_tests/kernel/wave/gather_to_shared.py
@@ -77,13 +77,13 @@ def test_gather_to_shared():
     # CHECK-LABEL:    test_gather_to_shared
     # CHECK:          func.func @gemm
     # CHECK-COUNT-1:    memref.alloc()
-    # CHECK:            %[[idx0:.*]] = llvm.call_intrinsic "llvm.amdgcn.readfirstlane"(%{{.*}}) : (i32) -> i32
+    # CHECK:            %[[idx0:.*]] = rocdl.readfirstlane %{{.*}} : i32
     # CHECK:            %[[idx1:.*]] = arith.index_cast %[[idx0]] : i32 to index
-    # CHECK:            %[[idx2:.*]] = llvm.call_intrinsic "llvm.amdgcn.readfirstlane"(%{{.*}}) : (i32) -> i32
+    # CHECK:            %[[idx2:.*]] = rocdl.readfirstlane %{{.*}} : i32
     # CHECK:            %[[idx3:.*]] = arith.index_cast %[[idx2]] : i32 to index
-    # CHECK:            %[[idx4:.*]] = llvm.call_intrinsic "llvm.amdgcn.readfirstlane"(%{{.*}}) : (i32) -> i32
+    # CHECK:            %[[idx4:.*]] = rocdl.readfirstlane %{{.*}} : i32
     # CHECK:            %[[idx5:.*]] = arith.index_cast %[[idx4]] : i32 to index
-    # CHECK:            %[[idx6:.*]] = llvm.call_intrinsic "llvm.amdgcn.readfirstlane"(%{{.*}}) : (i32) -> i32
+    # CHECK:            %[[idx6:.*]] = rocdl.readfirstlane %{{.*}} : i32
     # CHECK:            %[[idx7:.*]] = arith.index_cast %[[idx6]] : i32 to index
     # CHECK:            scf.for
     # CHECK:              amdgpu.lds_barrier

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1171,13 +1171,13 @@ def test_gemm_pipelined():
     # CHECK-COUNT-4:    amdgpu.mfma
     # CHECK-COUNT-1:    amdgpu.lds_barrier
     # CHECK-COUNT-6:    vector.load
-    # CHECK-COUNT-3:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-3:    rocdl.sched.group.barrier
     # CHECK-COUNT-4:    vector.load
-    # CHECK-COUNT-1:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-1:    rocdl.sched.group.barrier
     # CHECK-COUNT-4:    amdgpu.mfma
     # CHECK-COUNT-1:    amdgpu.lds_barrier
     # CHECK-COUNT-2:    vector.store
-    # CHECK-COUNT-2:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-2:    rocdl.sched.group.barrier
     # CHECK-COUNT-1:    scf.yield
     # CHECK-COUNT-4:    amdgpu.mfma
     # CHECK-COUNT-1:    amdgpu.lds_barrier
@@ -1266,7 +1266,7 @@ def test_gemm_prefetch():
 
     # Steady State Global Read
     # CHECK-COUNT-2:    vector.load {{.*}} : memref<128x128xf16, strided<[128, 1]>>, vector<8xf16>
-    # CHECK-COUNT-2:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-2:    rocdl.sched.group.barrier
 
     # Compute
     # CHECK-COUNT-8:    amdgpu.mfma
@@ -1274,7 +1274,7 @@ def test_gemm_prefetch():
 
     # Steady State Local Write
     # CHECK-COUNT-2:    vector.store
-    # CHECK-COUNT-2:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-2:    rocdl.sched.group.barrier
     # CHECK:          scf.yield
 
     # Prologue
@@ -1459,13 +1459,13 @@ def test_dynamic_gemm_pipelined():
     # CHECK-COUNT-1:    amdgpu.lds_barrier
     # CHECK-COUNT-4:    vector.load
     # CHECK-COUNT-2:    vector.maskedload
-    # CHECK-COUNT-3:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-3:    rocdl.sched.group.barrier
     # CHECK-COUNT-4:    vector.load
-    # CHECK-COUNT-1:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-1:    rocdl.sched.group.barrier
     # CHECK-COUNT-4:    amdgpu.mfma
     # CHECK-COUNT-1:    amdgpu.lds_barrier
     # CHECK-COUNT-2:    vector.store
-    # CHECK-COUNT-2:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+    # CHECK-COUNT-2:    rocdl.sched.group.barrier
     # CHECK-COUNT-1:    scf.yield
     # CHECK-COUNT-4:    amdgpu.mfma
     # CHECK-COUNT-1:    amdgpu.lds_barrier
@@ -1566,41 +1566,41 @@ def test_gemm_two_cluster_pingpong():
     # CHECK-COUNT-2:    vector.load %[[VIEW_1]][{{.*}}, %[[K1:.+]]] : memref<128x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-8:    vector.load %[[VIEW_0]][{{.*}}, %[[K0]]] : memref<256x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-8:    vector.load %[[VIEW_0]][{{.*}}, %[[K1]]] : memref<256x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # 1st Cluster: Global load LHS
     # CHECK-COUNT-2:    vector.load {{.*}} : memref<4096x4096xf16, strided<[4096, 1]>>, vector<8xf16>
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # 1st Cluster: Second slice of Local read lhs and rhs
     # CHECK-COUNT-2:    vector.load %[[VIEW_1]][{{.*}}, %[[K2:.+]]] : memref<128x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-2:    vector.load %[[VIEW_1]][{{.*}}, %[[K3:.+]]] : memref<128x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-8:    vector.load %[[VIEW_0]][{{.*}}, %[[K2]]] : memref<256x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-8:    vector.load %[[VIEW_0]][{{.*}}, %[[K3]]] : memref<256x68xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # 1st Cluster: Global load RHS
     # CHECK-COUNT-4:    vector.load {{.*}} : memref<4096x4096xf16, strided<[4096, 1]>>, vector<8xf16>
     # CHECK:            rocdl.s.barrier
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # First dot slice
     # CHECK:            rocdl.s.setprio 1
     # CHECK-COUNT-32:   amdgpu.mfma
     # CHECK:            rocdl.s.setprio 0
     # CHECK:            amdgpu.lds_barrier
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
 
     # 2nd cluster local writes.
     # CHECK-COUNT-6:    vector.store
     # CHECK:            rocdl.s.barrier
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
 
     # Second dot slice:
     # CHECK:            rocdl.s.setprio 1
     # CHECK-COUNT-32:   amdgpu.mfma
     # CHECK:            rocdl.s.setprio 0
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
 
     # Final LDS barrier to synchronize shared writes.
     # CHECK:            amdgpu.lds_barrier
@@ -1669,17 +1669,17 @@ def test_gemm_two_async_cluster_pingpong():
     # CHECK-COUNT-2:    vector.load %[[LHS_BUFFER]][{{.*}}, %[[K1:.+]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-4:    vector.load %[[RHS_BUFFER:.+]][{{.*}}, %[[K0]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-4:    vector.load %[[RHS_BUFFER]][{{.*}}, %[[K1]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # 1st Cluster: Global load to shared
     # CHECK-COUNT-4:    amdgpu.gather_to_lds
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier
+    # CHECK:            rocdl.sched.barrier
 
     # First dot slice
     # CHECK:            rocdl.s.setprio 1
     # CHECK-COUNT-16:   amdgpu.mfma
     # CHECK:            rocdl.s.setprio 0
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
     # CHECK-NEXT:       amdgpu.memory_counter_wait load(4)
     # CHECK-NEXT:       rocdl.s.barrier
 
@@ -1688,7 +1688,7 @@ def test_gemm_two_async_cluster_pingpong():
     # CHECK-COUNT-2:    vector.load %[[LHS_BUFFER]][{{.*}}, %[[K3:.+]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-4:    vector.load %[[RHS_BUFFER]][{{.*}}, %[[K2]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
     # CHECK-COUNT-4:    vector.load %[[RHS_BUFFER]][{{.*}}, %[[K3]]] : memref<128x64xf16, #gpu.address_space<workgroup>>, vector<4xf16>
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
     # CHECK-NEXT:       amdgpu.memory_counter_wait load(0)
     # CHECK-NEXT:       rocdl.s.barrier
 
@@ -1696,7 +1696,7 @@ def test_gemm_two_async_cluster_pingpong():
     # CHECK:            rocdl.s.setprio 1
     # CHECK-COUNT-16:   amdgpu.mfma
     # CHECK:            rocdl.s.setprio 0
-    # CHECK:            llvm.call_intrinsic "llvm.amdgcn.sched.barrier"
+    # CHECK:            rocdl.sched.barrier
 
     # Final LDS barrier to synchronize shared writes.
     # CHECK:            amdgpu.lds_barrier

--- a/lit_tests/kernel/wave/mma.py
+++ b/lit_tests/kernel/wave/mma.py
@@ -680,8 +680,8 @@ def test_wmma_with_tensor_load():
     ### pack descriptors and invoke tensor load
 
     # CHECK:        %[[TENSOR_DESC_0:.*]] = vector.from_elements
-    # CHECK-NOT:    llvm.call_intrinsic "llvm.amdgcn.tensor.load.to.lds"
-    # CHECK-NOT:    llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
+    # CHECK-NOT:    rocdl.tensor.load.to.lds
+    # CHECK-NOT:    rocdl.s.wait.tensorcnt
     # CHECK-NOT:    amdgpu.lds_barrier
 
     ### get shared buffer pointer
@@ -700,8 +700,8 @@ def test_wmma_with_tensor_load():
     # CHECK:        %[[DESC_FUSED:.*]] = arith.select %[[SELECTED]], %[[TENSOR_DESC_0]], %[[TENSOR_DESC_1]] : vector<8xi32>
 
     ### resource provider
-    # CHECK:        llvm.call_intrinsic "llvm.amdgcn.tensor.load.to.lds"(%[[D_FUSED]], %[[DESC_FUSED]], {{.*}}, {{.*}}, {{.*}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, i32) -> ()
-    # CHECK:        llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
+    # CHECK:        rocdl.tensor.load.to.lds %[[D_FUSED]], %[[DESC_FUSED]], {{.*}}, {{.*}} cachepolicy {{.*}} : vector<4xi32>, vector<8xi32>
+    # CHECK:        rocdl.s.wait.tensorcnt 0
     # CHECK:        rocdl.s.wait.dscnt 0
     # CHECK:        rocdl.s.barrier.signal -1
 


### PR DESCRIPTION
- use rocdl operations instead of calls to llvm intrinsics to improve general ergonomics of working with these intrinsics
