### PR TITLE
[water] Fix missing return in `buildVectorWrite` causing duplicate operations

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
@@ -354,6 +354,7 @@ static void buildVectorWrite(Location loc, PatternRewriter &rewriter, Value mem,
     } else {
       vector::StoreOp::create(rewriter, loc, vecValue, mem, indices);
     }
+    return;
   }
 
   // vector.transfer_write (masked or unmasked)

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -481,7 +481,7 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
       N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
      : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
      // CHECK: vector.store {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
-
+     // CHECK-NOT: vector.transfer_write
   return
   }
 }


### PR DESCRIPTION
The `buildVectorWrite` function was missing a `return` statement after generating `vector.store` or `vector.masked_store` operations for contiguous memory access patterns. This caused the function to fall through and also execute the `vector.transfer_write` code path, resulting in duplicate operations being emitted during MLIR lowering.