### PR TITLE
Disable CI on mi250

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [3.11]
-        os: [ubuntu-22.04, linux-mi325-1gpu-ossci-iree-org, nodai-amdgpu-mi250-x86-64]
+        os: [ubuntu-22.04, linux-mi325-1gpu-ossci-iree-org] # nodai-amdgpu-mi250-x86-64
     runs-on: ${{matrix.os}}
     timeout-minutes: 60
     needs: build_llvm_linux


### PR DESCRIPTION
This has been systematically broken for O(weeks). There is no point in having CI if it is constantly red and ignored, only distraction. When/if this is fixed, it can be turned back on.