### PR TITLE
[water] Stop using Water C++ API in Python bindings

### DIFF
--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -40,6 +40,19 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirWaveSymbolAttrGetTypeID();
 // WaveIndexSymbolAttr
 //===---------------------------------------------------------------------===//
 
+enum WaveIndexSymbol {
+  WaveIndexSymbol_DEVICE_DIM_0 = 0,
+  WaveIndexSymbol_DEVICE_DIM_1 = 1,
+  WaveIndexSymbol_DEVICE_DIM_2 = 2,
+  WaveIndexSymbol_WORKGROUP_0 = 3,
+  WaveIndexSymbol_WORKGROUP_1 = 4,
+  WaveIndexSymbol_WORKGROUP_2 = 5,
+  WaveIndexSymbol_THREAD_0 = 6,
+  WaveIndexSymbol_THREAD_1 = 7,
+  WaveIndexSymbol_THREAD_2 = 8,
+  WaveIndexSymbol_GPR_NUMBER = 9,
+};
+
 /// Checks whether the given MLIR attribute is a WaveIndexSymbolAttr.
 MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveIndexSymbolAttr(MlirAttribute attr);
 
@@ -93,6 +106,12 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirWaveHyperparameterAttrGetTypeID();
 // WaveWorkgroupDimAttr
 //===---------------------------------------------------------------------===//
 
+enum WaveWorkgroupDim {
+  WaveWorkgroupDimX = 0,
+  WaveWorkgroupDimY = 1,
+  WaveWorkgroupDimZ = 2,
+};
+
 /// Checks whether the given MLIR attribute is a WaveWorkgroupDimAttr.
 MLIR_CAPI_EXPORTED bool
 mlirAttributeIsAWaveWorkgroupDimAttr(MlirAttribute attr);
@@ -112,6 +131,13 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirWaveWorkgroupDimAttrGetTypeID();
 // WaveAddressSpaceAttr
 //===---------------------------------------------------------------------===//
 
+enum WaveAddressSpace {
+  WaveAddressSpaceUnspecified = 0,
+  WaveAddressSpaceGlobal = 1,
+  WaveAddressSpaceShared = 2,
+  WaveAddressSpaceRegister = 3,
+};
+
 /// Checks whether the given MLIR attribute is a WaveAddressSpaceAttr.
 MLIR_CAPI_EXPORTED bool
 mlirAttributeIsAWaveAddressSpaceAttr(MlirAttribute attr);
@@ -130,6 +156,27 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirWaveAddressSpaceAttrGetTypeID();
 //===---------------------------------------------------------------------===//
 // WaveMmaKindAttr
 //===---------------------------------------------------------------------===//
+
+enum WaveMmaKind {
+  WaveMmaKind_F32_16x16x16_F16 = 4128,
+  WaveMmaKind_F32_32x32x8_F16 = 4129,
+  WaveMmaKind_F32_16x16x32_K8_F16 = 4130,
+  WaveMmaKind_F32_32x32x16_K8_F16 = 4131,
+  WaveMmaKind_I32_16x16x16_I8 = 4288,
+  WaveMmaKind_I32_32x32x8_I8 = 4289,
+  WaveMmaKind_F32_16x16x32_F8 = 4656,
+  WaveMmaKind_F32_32x32x16_F8 = 4657,
+  WaveMmaKind_F32_16x16x32_K4_F8 = 4658,
+  WaveMmaKind_F32_32x32x16_K4_F8 = 4659,
+  WaveMmaKind_I32_16x16x32_I8 = 4800,
+  WaveMmaKind_I32_32x32x16_I8 = 4801,
+  WaveMmaKind_F32_16x16x128_F8F6F4 = 4928,
+  WaveMmaKind_F32_32x32x64_F8F6F4 = 4929,
+  WaveMmaKind_F32_16x16x32_F16 = 4896,
+  WaveMmaKind_F32_32x32x16_F16 = 4897,
+  WaveMmaKind_F32_16x16x32_BF16 = 4898,
+  WaveMmaKind_F32_32x32x16_BF16 = 4899,
+};
 
 /// Checks whether the given MLIR attribute is a WaveMmaKindAttr.
 MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveMmaKindAttr(MlirAttribute attr);

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -10,7 +10,6 @@
 #include "mlir-c/IR.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
-#include "water/Dialect/Wave/IR/WaveAttrs.h"
 #include "water/c/Dialects.h"
 
 #include "nanobind/nanobind.h"
@@ -64,7 +63,7 @@ NB_MODULE(_waterDialects, m) {
       mlirWaveIndexSymbolAttrGetTypeID)
       .def_classmethod(
           "get",
-          [](const nb::object &cls, wave::WaveIndexSymbol value,
+          [](const nb::object &cls, WaveIndexSymbol value,
              MlirContext context) {
             return cls(mlirWaveIndexSymbolAttrGet(
                 context, static_cast<uint32_t>(value)));
@@ -74,22 +73,22 @@ NB_MODULE(_waterDialects, m) {
       .def(
           "value",
           [](MlirAttribute self) {
-            return static_cast<wave::WaveIndexSymbol>(
+            return static_cast<WaveIndexSymbol>(
                 mlirWaveIndexSymbolAttrGetValue(self));
           },
           "Returns the index symbol enum value.");
 
-  nb::enum_<wave::WaveIndexSymbol>(d, "WaveIndexSymbol")
-      .value("DEVICE_DIM_0", wave::WaveIndexSymbol::DEVICE_DIM_0)
-      .value("DEVICE_DIM_1", wave::WaveIndexSymbol::DEVICE_DIM_1)
-      .value("DEVICE_DIM_2", wave::WaveIndexSymbol::DEVICE_DIM_2)
-      .value("WORKGROUP_0", wave::WaveIndexSymbol::WORKGROUP_0)
-      .value("WORKGROUP_1", wave::WaveIndexSymbol::WORKGROUP_1)
-      .value("WORKGROUP_2", wave::WaveIndexSymbol::WORKGROUP_2)
-      .value("THREAD_0", wave::WaveIndexSymbol::THREAD_0)
-      .value("THREAD_1", wave::WaveIndexSymbol::THREAD_1)
-      .value("THREAD_2", wave::WaveIndexSymbol::THREAD_2)
-      .value("GPR_NUMBER", wave::WaveIndexSymbol::GPR_NUMBER);
+  nb::enum_<WaveIndexSymbol>(d, "WaveIndexSymbol")
+      .value("DEVICE_DIM_0", WaveIndexSymbol_DEVICE_DIM_0)
+      .value("DEVICE_DIM_1", WaveIndexSymbol_DEVICE_DIM_1)
+      .value("DEVICE_DIM_2", WaveIndexSymbol_DEVICE_DIM_2)
+      .value("WORKGROUP_0", WaveIndexSymbol_WORKGROUP_0)
+      .value("WORKGROUP_1", WaveIndexSymbol_WORKGROUP_1)
+      .value("WORKGROUP_2", WaveIndexSymbol_WORKGROUP_2)
+      .value("THREAD_0", WaveIndexSymbol_THREAD_0)
+      .value("THREAD_1", WaveIndexSymbol_THREAD_1)
+      .value("THREAD_2", WaveIndexSymbol_THREAD_2)
+      .value("GPR_NUMBER", WaveIndexSymbol_GPR_NUMBER);
 
   //===---------------------------------------------------------------------===//
   // WaveIndexMappingAttr
@@ -188,7 +187,7 @@ NB_MODULE(_waterDialects, m) {
       mlirWaveWorkgroupDimAttrGetTypeID)
       .def_classmethod(
           "get",
-          [](const nb::object &cls, wave::WaveWorkgroupDim value,
+          [](const nb::object &cls, WaveWorkgroupDim value,
              MlirContext context) {
             return cls(mlirWaveWorkgroupDimAttrGet(
                 context, static_cast<uint32_t>(value)));
@@ -198,15 +197,15 @@ NB_MODULE(_waterDialects, m) {
       .def(
           "value",
           [](MlirAttribute self) {
-            return static_cast<wave::WaveWorkgroupDim>(
+            return static_cast<WaveWorkgroupDim>(
                 mlirWaveWorkgroupDimAttrGetValue(self));
           },
           "Returns the workgroup dim enum value.");
 
-  nb::enum_<wave::WaveWorkgroupDim>(d, "WaveWorkgroupDim")
-      .value("X", wave::WaveWorkgroupDim::X)
-      .value("Y", wave::WaveWorkgroupDim::Y)
-      .value("Z", wave::WaveWorkgroupDim::Z);
+  nb::enum_<WaveWorkgroupDim>(d, "WaveWorkgroupDim")
+      .value("X", WaveWorkgroupDimX)
+      .value("Y", WaveWorkgroupDimY)
+      .value("Z", WaveWorkgroupDimZ);
 
   //===---------------------------------------------------------------------===//
   // WaveAddressSpaceAttr
@@ -217,7 +216,7 @@ NB_MODULE(_waterDialects, m) {
       mlirWaveAddressSpaceAttrGetTypeID)
       .def_classmethod(
           "get",
-          [](const nb::object &cls, wave::WaveAddressSpace value,
+          [](const nb::object &cls, WaveAddressSpace value,
              MlirContext context) {
             return cls(mlirWaveAddressSpaceAttrGet(
                 context, static_cast<uint32_t>(value)));
@@ -227,16 +226,16 @@ NB_MODULE(_waterDialects, m) {
       .def(
           "value",
           [](MlirAttribute self) {
-            return static_cast<wave::WaveAddressSpace>(
+            return static_cast<WaveAddressSpace>(
                 mlirWaveAddressSpaceAttrGetValue(self));
           },
           "Returns the address space enum value.");
 
-  nb::enum_<wave::WaveAddressSpace>(d, "WaveAddressSpace")
-      .value("Unspecified", wave::WaveAddressSpace::Unspecified)
-      .value("Global", wave::WaveAddressSpace::Global)
-      .value("Shared", wave::WaveAddressSpace::Shared)
-      .value("Register", wave::WaveAddressSpace::Register);
+  nb::enum_<WaveAddressSpace>(d, "WaveAddressSpace")
+      .value("Unspecified", WaveAddressSpaceUnspecified)
+      .value("Global", WaveAddressSpaceGlobal)
+      .value("Shared", WaveAddressSpaceShared)
+      .value("Register", WaveAddressSpaceRegister);
 
   //===---------------------------------------------------------------------===//
   // WaveMmaKindAttr
@@ -247,8 +246,7 @@ NB_MODULE(_waterDialects, m) {
       mlirWaveMmaKindAttrGetTypeID)
       .def_classmethod(
           "get",
-          [](const nb::object &cls, wave::WaveMmaKind value,
-             MlirContext context) {
+          [](const nb::object &cls, WaveMmaKind value, MlirContext context) {
             return cls(
                 mlirWaveMmaKindAttrGet(context, static_cast<uint32_t>(value)));
           },
@@ -257,33 +255,32 @@ NB_MODULE(_waterDialects, m) {
       .def(
           "value",
           [](MlirAttribute self) {
-            return static_cast<wave::WaveMmaKind>(
-                mlirWaveMmaKindAttrGetValue(self));
+            return static_cast<WaveMmaKind>(mlirWaveMmaKindAttrGetValue(self));
           },
           "Returns the MMA kind enum value.");
 
-  nb::enum_<wave::WaveMmaKind>(d, "WaveMmaKind")
+  nb::enum_<WaveMmaKind>(d, "WaveMmaKind")
       // CDNA1
-      .value("F32_16x16x16_F16", wave::WaveMmaKind::F32_16x16x16_F16)
-      .value("F32_32x32x8_F16", wave::WaveMmaKind::F32_32x32x8_F16)
-      .value("F32_16x16x32_K8_F16", wave::WaveMmaKind::F32_16x16x32_K8_F16)
-      .value("F32_32x32x16_K8_F16", wave::WaveMmaKind::F32_32x32x16_K8_F16)
-      .value("I32_16x16x16_I8", wave::WaveMmaKind::I32_16x16x16_I8)
-      .value("I32_32x32x8_I8", wave::WaveMmaKind::I32_32x32x8_I8)
+      .value("F32_16x16x16_F16", WaveMmaKind_F32_16x16x16_F16)
+      .value("F32_32x32x8_F16", WaveMmaKind_F32_32x32x8_F16)
+      .value("F32_16x16x32_K8_F16", WaveMmaKind_F32_16x16x32_K8_F16)
+      .value("F32_32x32x16_K8_F16", WaveMmaKind_F32_32x32x16_K8_F16)
+      .value("I32_16x16x16_I8", WaveMmaKind_I32_16x16x16_I8)
+      .value("I32_32x32x8_I8", WaveMmaKind_I32_32x32x8_I8)
       // CDNA3
-      .value("F32_16x16x32_F8", wave::WaveMmaKind::F32_16x16x32_F8)
-      .value("F32_32x32x16_F8", wave::WaveMmaKind::F32_32x32x16_F8)
-      .value("F32_16x16x32_K4_F8", wave::WaveMmaKind::F32_16x16x32_K4_F8)
-      .value("F32_32x32x16_K4_F8", wave::WaveMmaKind::F32_32x32x16_K4_F8)
-      .value("I32_16x16x32_I8", wave::WaveMmaKind::I32_16x16x32_I8)
-      .value("I32_32x32x16_I8", wave::WaveMmaKind::I32_32x32x16_I8)
+      .value("F32_16x16x32_F8", WaveMmaKind_F32_16x16x32_F8)
+      .value("F32_32x32x16_F8", WaveMmaKind_F32_32x32x16_F8)
+      .value("F32_16x16x32_K4_F8", WaveMmaKind_F32_16x16x32_K4_F8)
+      .value("F32_32x32x16_K4_F8", WaveMmaKind_F32_32x32x16_K4_F8)
+      .value("I32_16x16x32_I8", WaveMmaKind_I32_16x16x32_I8)
+      .value("I32_32x32x16_I8", WaveMmaKind_I32_32x32x16_I8)
       // CDNA4
-      .value("F32_16x16x128_F8F6F4", wave::WaveMmaKind::F32_16x16x128_F8F6F4)
-      .value("F32_32x32x64_F8F6F4", wave::WaveMmaKind::F32_32x32x64_F8F6F4)
-      .value("F32_32x32x16_BF16", wave::WaveMmaKind::F32_32x32x16_BF16)
-      .value("F32_16x16x32_BF16", wave::WaveMmaKind::F32_16x16x32_BF16)
-      .value("F32_32x32x16_F16", wave::WaveMmaKind::F32_32x32x16_F16)
-      .value("F32_16x16x32_F16", wave::WaveMmaKind::F32_16x16x32_F16);
+      .value("F32_16x16x128_F8F6F4", WaveMmaKind_F32_16x16x128_F8F6F4)
+      .value("F32_32x32x64_F8F6F4", WaveMmaKind_F32_32x32x64_F8F6F4)
+      .value("F32_32x32x16_BF16", WaveMmaKind_F32_32x32x16_BF16)
+      .value("F32_16x16x32_BF16", WaveMmaKind_F32_16x16x32_BF16)
+      .value("F32_32x32x16_F16", WaveMmaKind_F32_32x32x16_F16)
+      .value("F32_16x16x32_F16", WaveMmaKind_F32_16x16x32_F16);
 
   //===---------------------------------------------------------------------===//
   // WaveExprListAttr


### PR DESCRIPTION
Nanobind is built with RTTI and exceptions whereas LLVM is build without. Building the Water Python bindings on-top of the Water C Bindings only avoids future ABI issues.

Signed-off-by: Tim Gymnich <tim@gymni.ch>
