### PR TITLE
Fix scalar constant generation for float types

### DIFF
--- a/wave_lang/kernel/wave/codegen/handlers.py
+++ b/wave_lang/kernel/wave/codegen/handlers.py
@@ -187,6 +187,10 @@ def handle_scalar(emitter: WaveEmitter, node: fx.Node):
         )
         scalar = conversion_op(target_type, scalar_i32)
     elif isinstance(value, (int, float)):
+        # If target type is a float type and value is an int, convert
+        # to float to avoid canonicalization issues
+        if is_float_type(target_type) and isinstance(value, int):
+            value = float(value)
         scalar = arith_d.constant(target_type, value)
     emitter.bind_node_proxy(node, IRProxyValue(scalar))
 


### PR DESCRIPTION
This fix converts integer values to float when the target type is a float type before passing to arith_d.constant.

When creating scalar constants with integer values but float types, MLIR requires the literal to be a float (2.0) not an integer (2). If an integer is passed, sometimes you get the error "unexpected decimal integer literal for a floating point value", and sometimes you get a segfault during MLIR canonicalization. In particular, for the included test it segfaults without the conversion that this patch applies.