### PR TITLE
[water] Preserve normal forms when adding new forms in transformations

### DIFF
--- a/water/include/water/Dialect/Wave/Transforms/Utils.h
+++ b/water/include/water/Dialect/Wave/Transforms/Utils.h
@@ -12,8 +12,16 @@ namespace wave {
 // forms. The presence of the attribute, in turn, performs verification of the
 // normal form every time a verifier runs on the operation, including by default
 // after every pass.
+//
+// By default, preserves existing normal forms and adds the new form. Set
+// preserve=false to replace all existing forms with the provided form.
 llvm::LogicalResult setNormalFormPassPostcondition(wave::WaveNormalForm form,
-                                                   mlir::Operation *root);
+                                                   mlir::Operation *root,
+                                                   bool preserve = true);
+
+// Clears all normal form attributes from the operation, effectively setting
+// the normal form to None.
+llvm::LogicalResult clearNormalFormPassPostcondition(mlir::Operation *root);
 
 // Verifies if the operation, typically the root operation about to be processed
 // by a pass, satisfies the required normal form by checking the presence of the

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -837,18 +837,8 @@ public:
     if (llvm::failed(updateValueTypes(getOperation(), updateType)))
       return signalPassFailure();
 
-    // Get current normal form and add MemoryOnlyTypes to it
-    wave::WaveNormalForm currentForm = wave::WaveNormalForm::None;
-    if (auto attr = getOperation()->getAttrOfType<wave::WaveNormalFormAttr>(
-            wave::WaveDialect::kNormalFormAttrName)) {
-      currentForm = attr.getValue();
-    }
-    wave::WaveNormalForm newForm = static_cast<wave::WaveNormalForm>(
-        static_cast<uint32_t>(currentForm) |
-        static_cast<uint32_t>(wave::WaveNormalForm::MemoryOnlyTypes));
-
-    if (llvm::failed(
-            wave::setNormalFormPassPostcondition(newForm, getOperation())))
+    if (llvm::failed(wave::setNormalFormPassPostcondition(
+            wave::WaveNormalForm::MemoryOnlyTypes, getOperation())))
       return signalPassFailure();
   }
 };

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -119,8 +119,7 @@ struct LowerWaveToMLIRPass
     if (walkResult.wasInterrupted())
       return signalPassFailure();
 
-    if (failed(wave::setNormalFormPassPostcondition(wave::WaveNormalForm::None,
-                                                    op)))
+    if (failed(wave::clearNormalFormPassPostcondition(op)))
       return signalPassFailure();
   }
 };

--- a/water/lib/Dialect/Wave/Transforms/Utils.cpp
+++ b/water/lib/Dialect/Wave/Transforms/Utils.cpp
@@ -11,13 +11,30 @@
 
 llvm::LogicalResult
 wave::setNormalFormPassPostcondition(wave::WaveNormalForm form,
-                                     mlir::Operation *root) {
-  llvm::LogicalResult result =
-      wave::detail::verifyNormalFormAttr(root, form, /*emitDiagnostics=*/false);
+                                     mlir::Operation *root, bool preserve) {
+  wave::WaveNormalForm finalForm = form;
+
+  if (preserve) {
+    // Get current normal form and combine with new form.
+    if (auto attr = root->getAttrOfType<wave::WaveNormalFormAttr>(
+            wave::WaveDialect::kNormalFormAttrName)) {
+      wave::WaveNormalForm currentForm = attr.getValue();
+      finalForm = currentForm | form;
+    }
+  }
+
+  llvm::LogicalResult result = wave::detail::verifyNormalFormAttr(
+      root, finalForm, /*emitDiagnostics=*/false);
   if (llvm::succeeded(result))
     root->setAttr(wave::WaveDialect::kNormalFormAttrName,
-                  wave::WaveNormalFormAttr::get(root->getContext(), form));
+                  wave::WaveNormalFormAttr::get(root->getContext(), finalForm));
   return result;
+}
+
+llvm::LogicalResult
+wave::clearNormalFormPassPostcondition(mlir::Operation *root) {
+  return wave::setNormalFormPassPostcondition(wave::WaveNormalForm::None, root,
+                                              /*preserve=*/false);
 }
 
 llvm::LogicalResult

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -705,3 +705,13 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
     return
   }
 }
+
+// -----
+
+// CHECK: module attributes {wave.normal_form = #wave.normal_form<none>}
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  // CHECK-LABEL: func.func @test_normal_form_cleared
+  func.func @test_normal_form_cleared() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
+    return
+  }
+}

--- a/water/test/Dialect/Wave/normal-forms-invalid.mlir
+++ b/water/test/Dialect/Wave/normal-forms-invalid.mlir
@@ -1,0 +1,28 @@
+// RUN: water-opt %s --split-input-file --verify-diagnostics
+
+module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
+  // expected-error @below {{normal form requires tensor types to be fully specified at function boundaries}}
+  func.func private @foo(!wave.tensor<any of f32>)
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_op_types>} {
+  func.func @foo() {
+    %0 = arith.constant 0.0 : f32
+    // expected-error @below {{normal form requires tensor types to be fully specified}}
+    wave.register %0 : !wave.tensor<any of f32, <register>>
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<index_exprs>} {
+  func.func @bar() {
+    %0 = arith.constant 0.0 : f32
+    // expected-error @below {{normal form requires index expressions to be provided for all supported wave dialect operations}}
+    wave.register %0 : !wave.tensor<[@X] of f32, <register>>
+    return
+  }
+}

--- a/water/test/Dialect/Wave/normal-forms.mlir
+++ b/water/test/Dialect/Wave/normal-forms.mlir
@@ -1,28 +1,11 @@
-// RUN: water-opt %s --split-input-file --verify-diagnostics
+// RUN: water-opt %s --water-wave-infer-types --water-wave-propagate-elements-per-thread | FileCheck %s
 
+// CHECK: module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>}
 module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
-  // expected-error @below {{normal form requires tensor types to be fully specified at function boundaries}}
-  func.func private @foo(!wave.tensor<any of f32>)
-}
-
-// -----
-
-module attributes {wave.normal_form = #wave.normal_form<full_op_types>} {
-  func.func @foo() {
+  func.func @test_multiple_forms_in_sequence(%mem: !wave.tensor<[@M] of f32, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>} {
     %0 = arith.constant 0.0 : f32
-    // expected-error @below {{normal form requires tensor types to be fully specified}}
-    wave.register %0 : !wave.tensor<any of f32, <register>>
-    return
-  }
-}
-
-// -----
-
-module attributes {wave.normal_form = #wave.normal_form<index_exprs>} {
-  func.func @bar() {
-    %0 = arith.constant 0.0 : f32
-    // expected-error @below {{normal form requires index expressions to be provided for all supported wave dialect operations}}
-    wave.register %0 : !wave.tensor<[@X] of f32, <register>>
+    %reg = wave.register %0 : !wave.tensor<[@M] of f32, <register>>
+    wave.write %reg, %mem { elements_per_thread = 8 } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32, <global>>
     return
   }
 }

--- a/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -146,3 +146,15 @@ func.func @unsupported_op() attributes {wave.hyperparameters = #wave.hyperparame
   return
 }
 }
+
+// -----
+
+// CHECK: #wave.normal_form<memory_only_types>
+module {
+  func.func @test_no_existing_normal_form_attr(%mem: !wave.tensor<[@M] of f32, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>} {
+    %0 = arith.constant 0.0 : f32
+    %reg = wave.register %0 : !wave.tensor<[@M] of f32, <register>>
+    wave.write %reg, %mem { elements_per_thread = 8 } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32, <global>>
+    return
+  }
+}


### PR DESCRIPTION
PropagateElementsPerThread pass was overriding existing normal form flags instead of preserving them.
This caused the naturally-subsequent lower-wave-to-mlir pass to fail with normal form precondition errors.