### PR TITLE
[wave2water] Fix elements_per_thread attribute syntax

### DIFF
--- a/lit_tests/kernel/wave/mlir_converter.py
+++ b/lit_tests/kernel/wave/mlir_converter.py
@@ -250,7 +250,7 @@ def mlir_converter_matrix_add():
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
-    # CHECK-SAME: wave.elements_per_thread = 32
+    # CHECK-SAME: elements_per_thread = 32 : i64
     # CHECK-SAME: (!wave.tensor<[@M, @N] of f16>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     # CHECK: %[[READ_B:.*]] = wave.read %[[ARG1]]
@@ -261,7 +261,7 @@ def mlir_converter_matrix_add():
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
-    # CHECK-SAME: wave.elements_per_thread = 32
+    # CHECK-SAME: elements_per_thread = 32 : i64
     # CHECK-SAME: (!wave.tensor<[@M, @N] of f16>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     # CHECK: %[[ADD:.*]] = wave.add %[[READ_A]], %[[READ_B]]
@@ -278,7 +278,7 @@ def mlir_converter_matrix_add():
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
-    # CHECK-SAME: wave.elements_per_thread = 32
+    # CHECK-SAME: elements_per_thread = 32 : i64
     # CHECK-SAME: !wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@M, @N] of f16>
 
     # CHECK: return

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -335,8 +335,8 @@ def _attach_attributes(node: CustomOp, op: ir.Operation):
         op.attributes["index"] = ir.ArrayAttr.get(dict_attrs)
 
     if getattr(node, "elements_per_thread", None):
-        op.attributes["wave.elements_per_thread"] = ir.IntegerAttr.get(
-            ir.IntegerType.get_signless(32), node.elements_per_thread
+        op.attributes["elements_per_thread"] = ir.IntegerAttr.get(
+            ir.IntegerType.get_signless(64), node.elements_per_thread
         )
 
     if getattr(node, "bounds", None):


### PR DESCRIPTION
The attribute should not be prefixed with `wave.` and is expected to be i64 and not i32.