### PR TITLE
Exclude broken nanobind release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake", "ninja", "pybind11", "nanobind", "setuptools-rust"]
+requires = ["setuptools", "wheel", "cmake", "ninja", "pybind11", "nanobind < 2.10", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [pytest]

--- a/water/requirements-dev.txt
+++ b/water/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Development requirements for building Python bindings
-nanobind>=2.9, <3.0
+nanobind~=2.9.2
 pybind11>=2.10.0, <=2.13.6
 numpy
 lit


### PR DESCRIPTION
Then recently release version 2.10 of nanobind has a broken dependency on `tsl-robin-map`.

https://github.com/wjakob/nanobind/issues/1237

```
Could not find a package configuration file provided by "tsl-robin-map"
        with any of the following names:
      
          tsl-robin-mapConfig.cmake
          tsl-robin-map-config.cmake
      
        Add the installation prefix of "tsl-robin-map" to CMAKE_PREFIX_PATH or set
```

Signed-off-by: Tim Gymnich <tim@gymni.ch>
