### PR TITLE
[water] Add lowerable ops as illegal

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -73,9 +73,10 @@ struct LowerWaveToMLIRPass
       vector::VectorDialect
         // clang-format on
         >();
-    target.addIllegalOp<wave::AllocateOp, wave::RegisterOp, wave::Exp2Op,
-                        wave::CastOp, wave::ExtractSliceOp, wave::IterateOp,
-                        wave::YieldOp>();
+    target.addIllegalOp<wave::AddOp, wave::AllocateOp, wave::CastOp,
+                        wave::DivOp, wave::Exp2Op, wave::ExtractSliceOp,
+                        wave::IterateOp, wave::MmaOp, wave::MulOp, wave::ReadOp,
+                        wave::RegisterOp, wave::WriteOp, wave::YieldOp>();
     ConversionConfig config;
     config.allowPatternRollback = false;
 

--- a/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
@@ -1,0 +1,42 @@
+// RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir --split-input-file --verify-diagnostics
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @binary_ops_pattern_failure() {
+    %cst = arith.constant 1.0 : f32
+    // expected-error @below {{wave dialect operation with no hyperparameters provided by any ancestor}}
+    %lhs = wave.register %cst : vector<4xf32>
+    return
+  }
+}
+
+// -----
+
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  // expected-error @+1 {{failed to convert starting at this operation}}
+  func.func @read_pattern_failure(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128}>} {
+
+    // ReadOpLoweringPattern requires 'index' attribute
+    // expected-error @+1 {{failed to legalize operation 'wave.read' that was explicitly marked illegal}}
+    %result = wave.read %mem : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  // expected-error @+1 {{failed to convert starting at this operation}}
+  func.func @write_pattern_failure(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128}>} {
+
+    %cst = arith.constant 0.0 : f16
+    %reg = wave.register %cst : vector<8xf16>
+
+    // WriteOpLoweringPattern requires 'index' attribute
+    // expected-error @+1 {{failed to legalize operation 'wave.write' that was explicitly marked illegal}}
+    wave.write %reg, %mem : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
+    return
+  }
+}


### PR DESCRIPTION
Some wave operations had lowering patterns but weren't marked illegal. If patterns failed, conversion could succeed with operations left unconverted.

This commit marks them as illegal, so pattern failures cause complete
conversion failure (preventing partial conversions).
