### PR TITLE
[water] register MLIR passes in python bindings

### DIFF
--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -15,6 +15,9 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Wave, wave);
 
+/// Register the Wave dialect passes.
+MLIR_CAPI_EXPORTED void mlirWaveDialectRegisterPasses();
+
 //===---------------------------------------------------------------------===//
 // Wave Dialect Constants
 //===---------------------------------------------------------------------===//

--- a/water/lib/CAPI/CMakeLists.txt
+++ b/water/lib/CAPI/CMakeLists.txt
@@ -4,4 +4,5 @@ add_mlir_public_c_api_library(WaterCAPI
   LINK_LIBS PUBLIC
     MLIRCAPIIR
     MLIRWaveDialect
+    MLIRWaveTransforms
 )

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -12,9 +12,16 @@
 
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
 #include "water/Dialect/Wave/IR/WaveDialect.h"
+#include "water/Dialect/Wave/Transforms/Passes.h"
 #include "water/c/Dialects.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Wave, wave, ::wave::WaveDialect)
+
+//===---------------------------------------------------------------------===//
+// Wave Dialect Passes
+//===---------------------------------------------------------------------===//
+
+void mlirWaveDialectRegisterPasses() { wave::registerPasses(); }
 
 //===---------------------------------------------------------------------===//
 // Wave Dialect Constants

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -29,6 +29,9 @@ NB_MODULE(_waterDialects, m) {
           mlirDialectHandleLoadDialect(h, context);
       },
       nb::arg("context").none() = nb::none(), nb::arg("load") = true);
+  d.def(
+      "register_passes", []() { mlirWaveDialectRegisterPasses(); },
+      "Registers the wave dialect passes.");
 
   // Export dialect constants
   d.attr("WAVE_CONSTRAINTS_ATTR_NAME") = mlirWaveDialectConstraintsAttrName;

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -4,6 +4,7 @@
 
 from water_mlir import ir
 from water_mlir.dialects import wave
+from water_mlir.dialects.transform import interpreter
 import water_mlir.ir as ir2
 from water_mlir.dialects import wave as wave2
 
@@ -14,6 +15,7 @@ if wave2.register_dialect is not wave.register_dialect:
     raise RuntimeError("module import path for wave differs")
 with ir.Context() as ctx:
     wave.register_dialect(ctx)
+    wave.register_passes()
 
     # CHECK: wave.constraints
     print(wave.WAVE_CONSTRAINTS_ATTR_NAME)
@@ -272,6 +274,32 @@ with ir.Context() as ctx:
         assert "incompatible function arguments" in str(e)
     else:
         assert False, "Expected to fail with TypeError."
+
+    # Invoke a pass using transform dialect. This should not fail.
+    transform_module = ir.Module.parse(
+        """
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    transform.apply_registered_pass "water-wave-detect-normal-forms" to %arg0
+      : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}"""
+    )
+    payload_module = ir.Module.parse("module {}")
+    ops = list(transform_module.body.operations)
+    entry_op = ops[0]
+    interpreter.apply_named_sequence(
+        payload_module,
+        entry_op,
+        transform_module,
+    )
+
+    # The pass must have applied and inferred normal forms. We don't care which
+    # ones here, this is tested separately, just checking the fact that the pass
+    # applied.
+    # CHECK: module attributes {wave.normal_form = #wave.normal_form<
+    print(payload_module)
 
 
 # CHECK: wave_ok


### PR DESCRIPTION
This will enable us to invoke passes programmatically via the pass manager or
transform dialect, without going through water-opt binary.

Signed-off-by: Alex Zinenko <git@ozinenko.com>