### PR TITLE
[build] Add missing library dependency

### DIFF
--- a/wave_lang/kernel/wave/execution_engine/CMakeLists.txt
+++ b/wave_lang/kernel/wave/execution_engine/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(wave_execution_engine PRIVATE
   LLVM${LLVM_NATIVE_ARCH}AsmParser
   LLVM${LLVM_NATIVE_ARCH}CodeGen
   LLVM${LLVM_NATIVE_ARCH}Desc
+  LLVM${LLVM_NATIVE_ARCH}Info
   LLVMExecutionEngine
   LLVMOrcJIT
   LLVMTarget


### PR DESCRIPTION
Add `LLVM${LLVM_NATIVE_ARCH}Info` to `wave_execution_engine` `target_link_libraries` to resolve missing symbol/linking issues.