### PR TITLE
[doc] add elementary wave kernels as examples

### DIFF
--- a/examples/python/0a_global_mem_buffer_copy.py
+++ b/examples/python/0a_global_mem_buffer_copy.py
@@ -1,0 +1,58 @@
+import torch
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+import wave_lang.kernel.wave.compile as compiler
+
+
+def main():
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            vector_shapes={
+                tkl.sym.M: tkl.sym.THREADS_PER_WAVE_M,
+                tkl.sym.N: tkl.sym.THREADS_PER_WAVE_N,
+            },
+        ),
+        tkw.WaveConstraint(tkl.sym.M, tkl.sym.THREADS_PER_WAVE_M),
+        tkw.WaveConstraint(tkl.sym.N, tkl.sym.THREADS_PER_WAVE_N),
+        tkw.WorkgroupConstraint(tkl.sym.M, tkl.sym.THREADS_PER_WORKGROUP_M, 0),
+        tkw.WorkgroupConstraint(tkl.sym.N, tkl.sym.THREADS_PER_WORKGROUP_N, 1),
+    ]
+
+    @tkw.wave(constraints)
+    def kernel_def(
+        inp: tkl.Memory[
+            tkl.sym.M, tkl.sym.N, tkl.global_symbols.GLOBAL_ADDRESS_SPACE, tkl.i8
+        ],
+        out: tkl.Memory[
+            tkl.sym.M, tkl.sym.N, tkl.global_symbols.GLOBAL_ADDRESS_SPACE, tkl.i8
+        ],
+    ):
+        reg = tkw.read(inp, elements_per_thread=tkl.sym.THREADS_PER_WAVE_N)
+        tkw.write(reg, out, elements_per_thread=tkl.sym.THREADS_PER_WAVE_N)
+
+    inp = torch.randint(high=32, size=(1024, 4096), dtype=torch.int8, device="cuda")
+    out = torch.randint(high=32, size=(1024, 4096), dtype=torch.int8, device="cuda")
+
+    hyper_params = {
+        tkl.sym.M: 1024,
+        tkl.sym.N: 4096,
+        tkl.sym.THREADS_PER_WAVE_M: 64,
+        tkl.sym.THREADS_PER_WAVE_N: 32,
+        tkl.sym.THREADS_PER_WORKGROUP_M: 64,
+        tkl.sym.THREADS_PER_WORKGROUP_N: 64,
+    }
+
+    default_params = tkw.utils.general_utils.get_default_scheduling_params()
+    hyper_params.update(default_params)
+    options = compiler.WaveCompileOptions(subs=hyper_params)
+    options = tkw.utils.run_utils.set_default_run_config(options)
+
+    kernel = compiler.wave_compile(options, kernel_def)
+    kernel(inp, out)
+    torch.testing.assert_close(inp, out)
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/0b_shared_mem_buffer_copy.py
+++ b/examples/python/0b_shared_mem_buffer_copy.py
@@ -1,0 +1,57 @@
+import torch
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+import wave_lang.kernel.wave.compile as compiler
+
+
+def main():
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            vector_shapes={
+                tkl.sym.M: tkl.sym.THREADS_PER_WAVE_M,
+                tkl.sym.N: tkl.sym.THREADS_PER_WAVE_N,
+            },
+        ),
+        tkw.WaveConstraint(tkl.sym.M, tkl.sym.THREADS_PER_WAVE_M),
+        tkw.WaveConstraint(tkl.sym.N, tkl.sym.THREADS_PER_WAVE_N),
+        tkw.WorkgroupConstraint(tkl.sym.M, tkl.sym.THREADS_PER_WORKGROUP_M, 0),
+        tkw.WorkgroupConstraint(tkl.sym.N, tkl.sym.THREADS_PER_WORKGROUP_N, 1),
+    ]
+
+    @tkw.wave(constraints)
+    def kernel_def(
+        inp: tkl.Memory[tkl.sym.M, tkl.sym.N, tkl.sym.ADDRESS_SPACE, tkl.i8],
+        out: tkl.Memory[
+            tkl.sym.M, tkl.sym.N, tkl.global_symbols.GLOBAL_ADDRESS_SPACE, tkl.i8
+        ],
+    ):
+        reg = tkw.read(inp, elements_per_thread=tkl.sym.THREADS_PER_WAVE_N)
+        tkw.write(reg, out, elements_per_thread=tkl.sym.THREADS_PER_WAVE_N)
+
+    inp = torch.randint(high=32, size=(1024, 4096), dtype=torch.int8, device="cuda")
+    out = torch.randint(high=32, size=(1024, 4096), dtype=torch.int8, device="cuda")
+
+    hyper_params = {
+        tkl.sym.M: 1024,
+        tkl.sym.N: 4096,
+        tkl.sym.THREADS_PER_WAVE_M: 64,
+        tkl.sym.THREADS_PER_WAVE_N: 32,
+        tkl.sym.THREADS_PER_WORKGROUP_M: 64,
+        tkl.sym.THREADS_PER_WORKGROUP_N: 64,
+        tkl.sym.ADDRESS_SPACE: tkl.global_symbols.SHARED_ADDRESS_SPACE,
+    }
+
+    default_params = tkw.utils.general_utils.get_default_scheduling_params()
+    hyper_params.update(default_params)
+    options = compiler.WaveCompileOptions(subs=hyper_params)
+    options = tkw.utils.run_utils.set_default_run_config(options)
+
+    kernel = compiler.wave_compile(options, kernel_def)
+    kernel(inp, out)
+    torch.testing.assert_close(inp, out)
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/0c_transpose_kernel.py
+++ b/examples/python/0c_transpose_kernel.py
@@ -1,0 +1,69 @@
+import torch
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+import wave_lang.kernel.wave.compile as compiler
+import wave_lang.kernel.wave.utils.torch_utils as torch_utils
+
+
+def main():
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,  # usually a constant for AMD GPUs
+            waves_per_block=(1, 1, 1),
+            # ratio of workgroup tile size (BLOCK_M) to the wave tile size (BLOCK_M)
+            # hence invariant: workgroup tile size >= wave tile size
+            # distribute rows among threads
+            # each thread reads entire row
+            vector_shapes={tkl.sym.M: 64, tkl.sym.N: 64},
+        ),
+        # workgroup tile size in the M dimension
+        tkw.WorkgroupConstraint(tkl.sym.M, tkl.sym.BLOCK_M, 0),
+        tkw.WorkgroupConstraint(tkl.sym.N, tkl.sym.BLOCK_N, 1),
+        # wave tile size in the M dimension
+        tkw.WaveConstraint(tkl.sym.M, tkl.sym.BLOCK_M),
+        tkw.WaveConstraint(tkl.sym.N, tkl.sym.BLOCK_N),
+    ]
+
+    mapping = tkw.IndexMapping(
+        num_iterators=2,
+        inputs={
+            tkl.sym.M: tkw.IndexMapping.iterator(0),
+            tkl.sym.N: tkw.IndexMapping.iterator(1),
+        },
+        outputs={
+            tkl.sym.M: tkw.IndexMapping.iterator(0),
+            tkl.sym.N: tkw.IndexMapping.iterator(1),
+        },
+    )
+
+    @tkw.wave(constraints)
+    def kernel_def(
+        inp: tkl.Memory[tkl.sym.M, tkl.sym.N, tkl.sym.GLOBAL_ADDRESS_SPACE, tkl.i8],
+        out: tkl.Memory[tkl.sym.N, tkl.sym.M, tkl.sym.GLOBAL_ADDRESS_SPACE, tkl.i8],
+    ):
+        inp_reg = tkw.read(inp, elements_per_thread=tkl.sym.BLOCK_N)
+        tkw.write(inp_reg, out, mapping=mapping, elements_per_thread=tkl.sym.BLOCK_N)
+
+    inp = torch_utils.device_randint(high=32, size=(256, 64), dtype=torch.int8)
+    out = torch_utils.device_randint(high=32, size=(64, 256), dtype=torch.int8)
+
+    hyper_params = {
+        tkl.sym.M: 256,
+        tkl.sym.N: 64,
+        tkl.sym.BLOCK_M: 64,
+        tkl.sym.BLOCK_N: 64,
+    }
+
+    default_params = tkw.utils.general_utils.get_default_scheduling_params()
+    hyper_params.update(default_params)
+    options = compiler.WaveCompileOptions(subs=hyper_params)
+    options = tkw.utils.run_utils.set_default_run_config(options)
+
+    kernel = compiler.wave_compile(options, kernel_def)
+    kernel(inp, out)
+    torch.testing.assert_close(out, inp.T)
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Specifically, this patch introduces kernels for:

- elementary copy from global memory to global memory
- elementary copy from shared memory to global memory
- transpose in global memory (to illustrate index mapping)