### PR TITLE
[asm] Add gather to LDS support and hazard mitigation

### DIFF
--- a/lit_tests/kernel/wave/asm.py
+++ b/lit_tests/kernel/wave/asm.py
@@ -435,3 +435,99 @@ def test_gemm_multi_wave_k_loop():
     # CHECK:          loop_0_exit:
     # CHECK:          buffer_store_dword
     # CHECK:          s_endpgm
+
+
+@run_test
+def test_gemm_gather_to_lds():
+    """
+    Test GEMM with gather_to_lds (global_to_shared) enabled.
+
+    When use_global_to_shared=True, the compiler generates buffer_load_dword...lds
+    instructions that load directly from global memory to LDS, bypassing VGPRs.
+
+    Verifies:
+    - buffer_load_dword ... lds instructions are emitted
+    - M0 register setup for LDS addressing
+    - Proper barrier synchronization (vmcnt + lgkmcnt + s_barrier)
+    """
+    constraints: list[tkw.Constraint] = [
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.TilingConstraint(K, BLOCK_K),
+        tkw.WaveConstraint(M, BLOCK_M),
+        tkw.WaveConstraint(N, BLOCK_N),
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        ),
+    ]
+
+    @tkw.wave(constraints)
+    def gemm_g2s(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    compile_options = WaveCompileOptions(
+        subs={
+            M: 32,
+            N: 32,
+            K: 32,
+            BLOCK_M: 16,
+            BLOCK_N: 16,
+            BLOCK_K: 16,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+        use_global_to_shared=True,  # Enable gather_to_lds
+    )
+    compile_options.compile_to_asm = True
+    gemm_g2s = wave_compile(compile_options, gemm_g2s)
+    print(gemm_g2s.asm)
+
+    # CHECK-LABEL:    test_gemm_gather_to_lds
+    # CHECK:          .protected gemm_g2s
+    # CHECK:          .amdhsa_kernel gemm_g2s
+    # CHECK:          gemm_g2s:
+
+    # Verify LDS SRD setup:
+    #   word2 = 2147483645 (0x7ffffffd) = max buffer size
+    #   word3 = 159744 (0x27000) = LDS addressing mode
+    # CHECK:          s_mov_b32 s{{[0-9]+}}, 2147483645
+    # CHECK:          s_mov_b32 s{{[0-9]+}}, 159744
+
+    # Verify M0 register setup for LDS destination address
+    # CHECK:          s_mov_b32 m0,
+
+    # Verify buffer_load_dword...lds instructions (gather from global to LDS)
+    # CHECK:          buffer_load_dword v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}], 0 offen lds
+
+    # Verify barrier synchronization after gather_to_lds:
+    #   vmcnt(0) waits for global memory loads to complete
+    #   lgkmcnt(0) waits for LDS writes to complete (from buffer_load...lds)
+    #   s_barrier synchronizes all threads
+    # CHECK:          s_waitcnt vmcnt(0)
+    # CHECK:          s_barrier
+
+    # Verify LDS reads after barrier (ds_read_b64 for MFMA inputs)
+    # CHECK:          ds_read_b64 v[{{[0-9]+}}:{{[0-9]+}}], v{{[0-9]+}}
+
+    # Verify MFMA instruction
+    # CHECK:          v_mfma_f32_16x16x16_f16
+
+    # CHECK:          s_endpgm

--- a/wave_lang/kernel/wave/asm/gather_to_shared.py
+++ b/wave_lang/kernel/wave/asm/gather_to_shared.py
@@ -1,0 +1,428 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Gather-to-Shared (G2S) handling for buffer_load...lds instructions.
+
+This module contains all functionality related to gather_to_lds operations:
+- Scheduling and M0 pre-computation
+- SRD tracing through memref cast chains
+- VGPR offset computation
+- The main gather_to_lds handler
+"""
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Any, Tuple, TYPE_CHECKING
+
+import sympy
+
+from wave_lang.support.ir_imports import amdgpu_d, MemRefType, VectorType
+
+from .instructions import (
+    BufferLoadDwordLds,
+    BufferLoadDwordx4Lds,
+    SMovB32,
+    SMovB32M0,
+    SAndB32,
+    SOrB32,
+    VMovB32,
+    VReadfirstlaneB32,
+)
+from .utils import parse_vector_type_from_obj, parse_memref_type_from_obj
+
+if TYPE_CHECKING:
+    from .kernel_model import KernelInfo
+    from .handlers import OperationHandlers
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# Default LDS column count for 2D memrefs
+_DEFAULT_LDS_COLS = 32
+
+# Default cache swizzle stride (LLVM uses 0x40400000 = stride 64)
+_DEFAULT_CACHE_SWIZZLE_STRIDE = 64
+
+# Cache swizzle enable bit (bit 30)
+_CACHE_SWIZZLE_ENABLE = 0x40000000
+
+# SRD word2: maximum buffer size
+_SRD_MAX_BUFFER_SIZE = 0x7FFFFFFD
+
+# SRD word3: data_format=4 (32-bit), num_format=7, add_tid_enable=1
+_SRD_WORD3_LDS = 0x27000
+
+# Element size scale for f16 (bytes per element)
+_F16_ELEM_BYTES = 2
+
+
+# =============================================================================
+# Scheduling functions
+# =============================================================================
+
+
+@dataclass
+class G2SSchedule:
+    """Scheduling info for g2s region."""
+
+    first_g2s_idx: int
+    g2s_ops: List[Any]
+
+
+def analyze_g2s_region(ops: List[Any]) -> Optional[G2SSchedule]:
+    """Find gather_to_lds operations and their scheduling info."""
+    g2s_ops = []
+    first_g2s_idx = None
+
+    for i, op in enumerate(ops):
+        if isinstance(op, amdgpu_d.GatherToLDSOp):
+            if first_g2s_idx is None:
+                first_g2s_idx = i
+            g2s_ops.append(op)
+
+    if not g2s_ops:
+        return None
+
+    return G2SSchedule(first_g2s_idx=first_g2s_idx, g2s_ops=g2s_ops)
+
+
+def precompute_m0_values(
+    schedule: G2SSchedule,
+    kernel_info: "KernelInfo",
+    handlers: "OperationHandlers",
+) -> None:
+    """Pre-compute M0 values for all g2s ops before any buffer_load...lds."""
+    for g2s_op in schedule.g2s_ops:
+        handlers.g2s.precompute_g2s_m0(g2s_op, kernel_info)
+
+
+# =============================================================================
+# G2SHandler
+# =============================================================================
+
+
+class G2SHandler:
+    """Handles gather_to_lds operations for the ASM backend."""
+
+    def __init__(self, handlers: "OperationHandlers"):
+        self.handlers = handlers
+        self.walker = handlers.walker
+
+    # -------------------------------------------------------------------------
+    # SRD tracing
+    # -------------------------------------------------------------------------
+
+    def _trace_memref_to_srd(
+        self, memref_ssa: str, kernel_info: "KernelInfo"
+    ) -> Tuple[Optional[tuple], Optional[str]]:
+        """Trace through cast chain to find the original memref with an SRD."""
+        srds = self.walker.emitter.srds
+        fat_sources = getattr(self.walker, "_fat_buffer_sources", {})
+        cast_sources = getattr(self.walker, "_memref_cast_sources", {})
+
+        current = memref_ssa
+        visited = set()
+
+        while current and current not in visited:
+            visited.add(current)
+
+            # Found SRD
+            if current in srds:
+                return srds[current], current
+
+            # Follow cast chain
+            if current in fat_sources:
+                info = fat_sources[current]
+                current = (
+                    info.get("source_ssa", current) if isinstance(info, dict) else info
+                )
+            elif current in cast_sources:
+                current = cast_sources[current]
+            else:
+                break
+
+        return None, None
+
+    # -------------------------------------------------------------------------
+    # SRD allocation and emission
+    # -------------------------------------------------------------------------
+
+    def _allocate_aligned_srd(self) -> Tuple[int, int, int, int]:
+        """Allocate 4-aligned SGPRs for an SRD."""
+        emitter = self.walker.emitter
+        temp_sgprs = []
+        while True:
+            s = emitter.sgpr_allocator.alloc_s()
+            if s % 4 == 0:
+                srd = (
+                    s,
+                    emitter.sgpr_allocator.alloc_s(),
+                    emitter.sgpr_allocator.alloc_s(),
+                    emitter.sgpr_allocator.alloc_s(),
+                )
+                break
+            temp_sgprs.append(s)
+        for s in temp_sgprs:
+            emitter.sgpr_allocator.free_s(s)
+        return srd
+
+    def _compute_cache_swizzle_bits(self, src_memref_ssa: str) -> int:
+        """Compute cache swizzle bits from fat_raw_buffer_cast info."""
+        fat_buffer_info = getattr(self.walker, "_fat_buffer_sources", {}).get(
+            src_memref_ssa
+        )
+        stride = _DEFAULT_CACHE_SWIZZLE_STRIDE
+        if fat_buffer_info and isinstance(fat_buffer_info, dict):
+            stride = fat_buffer_info.get(
+                "cache_swizzle_stride", _DEFAULT_CACHE_SWIZZLE_STRIDE
+            )
+
+        if stride > 0:
+            return _CACHE_SWIZZLE_ENABLE | (1 << (int(math.log2(stride)) + 16))
+        return 0
+
+    def _emit_srd_copy(
+        self,
+        srd_regs: Tuple[int, int, int, int],
+        orig_srd_regs: tuple,
+        cache_swizzle_bits: int,
+    ) -> None:
+        """Emit SRD copy with cache swizzle modifications."""
+        emitter = self.walker.emitter
+        s0, s1, s2, s3 = srd_regs
+
+        emitter.emit_instruction(SMovB32(s0, f"s{orig_srd_regs[0]}", "SRD word0"))
+
+        if cache_swizzle_bits == 0:
+            emitter.emit_instruction(SMovB32(s1, f"s{orig_srd_regs[1]}", "SRD word1"))
+        else:
+            emitter.emit_instruction(SAndB32(s1, f"s{orig_srd_regs[1]}", 0xFFFF))
+            emitter.emit_instruction(
+                SOrB32(s1, f"s{s1}", cache_swizzle_bits, "cache swizzle")
+            )
+
+        emitter.emit_instruction(SMovB32(s2, _SRD_MAX_BUFFER_SIZE, "SRD word2"))
+        emitter.emit_instruction(SMovB32(s3, _SRD_WORD3_LDS, "SRD word3"))
+
+    def _get_or_create_srd(
+        self, orig_srd_regs: tuple, src_memref_ssa: str
+    ) -> Tuple[int, int, int, int]:
+        """Get cached SRD or create a new one for gather_to_lds."""
+        cache_key = f"lds_srd_copy_{orig_srd_regs[0]}"
+        srd_copies = getattr(self.walker, "_lds_srd_copies", None)
+        if srd_copies is None:
+            self.walker._lds_srd_copies = {}
+            srd_copies = self.walker._lds_srd_copies
+
+        if cache_key in srd_copies:
+            return srd_copies[cache_key]
+
+        srd_regs = self._allocate_aligned_srd()
+        cache_swizzle_bits = self._compute_cache_swizzle_bits(src_memref_ssa)
+        self._emit_srd_copy(srd_regs, orig_srd_regs, cache_swizzle_bits)
+        srd_copies[cache_key] = srd_regs
+        return srd_regs
+
+    # -------------------------------------------------------------------------
+    # Offset computation
+    # -------------------------------------------------------------------------
+
+    def _compute_vgpr_offset(
+        self, index_ssa: str, kernel_info: "KernelInfo", scale_bytes: int
+    ) -> int:
+        """Compute a VGPR containing the offset value, scaled to bytes."""
+        value = kernel_info.index_env.get(index_ssa)
+
+        if isinstance(value, int):
+            voffset = self.walker.emitter.vgpr_allocator.alloc_v()
+            self.walker.emitter.emit_instruction(
+                VMovB32(voffset, value * scale_bytes, "offset")
+            )
+            return voffset
+
+        if isinstance(value, sympy.Expr):
+            scaled_expr = value * scale_bytes if scale_bytes != 1 else value
+            return int(
+                self.handlers._get_expr_emitter(kernel_info).get_or_emit(scaled_expr)[
+                    1:
+                ]
+            )
+
+        raise ValueError(f"Cannot compute offset for {index_ssa}: value={value}")
+
+    def _compute_vaddr(self, src_index_ssa: str, kernel_info: "KernelInfo") -> int:
+        """Compute vaddr VGPR for global memory offset."""
+        return self._compute_vgpr_offset(
+            src_index_ssa, kernel_info, scale_bytes=_F16_ELEM_BYTES
+        )
+
+    # -------------------------------------------------------------------------
+    # M0 computation
+    # -------------------------------------------------------------------------
+
+    def _get_lds_layout(self, dst_memref_type) -> Tuple[int, int]:
+        """Extract LDS columns and element bytes from destination memref type."""
+        if not isinstance(dst_memref_type, MemRefType):
+            raise ValueError(f"Unsupported destination memref type: {dst_memref_type}")
+        shape, _, elem_bytes = parse_memref_type_from_obj(dst_memref_type)
+        lds_cols = shape[1] if len(shape) >= 2 else _DEFAULT_LDS_COLS
+        return lds_cols, elem_bytes
+
+    def _emit_m0(
+        self,
+        operation,
+        kernel_info: "KernelInfo",
+        lds_base_bytes: int,
+        lds_cols: int,
+        elem_bytes: int,
+    ) -> None:
+        """Emit M0 register setup for LDS destination."""
+        emitter = self.walker.emitter
+
+        # Check for pre-computed M0
+        m0_sgprs = getattr(self.walker, "_m0_sgprs", None)
+        if m0_sgprs:
+            precomputed = m0_sgprs.get(id(operation))
+            if precomputed is not None:
+                emitter.emit_instruction(
+                    SMovB32M0(f"s{precomputed}", "Pre-computed M0")
+                )
+                return
+
+        # Compute M0 inline from row/col indices
+        dst_row = kernel_info.index_env.get(str(operation.operands[3]))
+        dst_col = kernel_info.index_env.get(str(operation.operands[4]))
+
+        # Build M0 expression: lds_base + (row * cols + col) * elem_bytes
+        row = (
+            dst_row if isinstance(dst_row, sympy.Expr) else sympy.Integer(dst_row or 0)
+        )
+        col = (
+            dst_col if isinstance(dst_col, sympy.Expr) else sympy.Integer(dst_col or 0)
+        )
+        m0_expr = sympy.simplify(lds_base_bytes + (row * lds_cols + col) * elem_bytes)
+
+        # Emit: either constant or expression -> readfirstlane -> M0
+        if m0_expr.is_number:
+            emitter.emit_instruction(SMovB32M0(int(m0_expr), "LDS offset"))
+        else:
+            m0_vreg = int(
+                self.handlers._get_expr_emitter(kernel_info).get_or_emit(m0_expr)[1:]
+            )
+            s_tmp = emitter.sgpr_allocator.alloc_s()
+            emitter.emit_instruction(VReadfirstlaneB32(s_tmp, m0_vreg))
+            emitter.emit_instruction(SMovB32M0(f"s{s_tmp}"))
+            emitter.sgpr_allocator.free_s(s_tmp)
+
+    def _emit_buffer_load(
+        self, transfer_bytes: int, voffset: int, srd_regs: tuple
+    ) -> None:
+        """Emit buffer_load...lds instruction."""
+        emitter = self.walker.emitter
+
+        if transfer_bytes == 4:
+            emitter.emit_instruction(
+                BufferLoadDwordLds(voffset, srd_regs, 0, 0, f"gather {transfer_bytes}B")
+            )
+        elif transfer_bytes == 16:
+            emitter.emit_instruction(
+                BufferLoadDwordx4Lds(
+                    voffset, srd_regs, 0, 0, f"gather {transfer_bytes}B"
+                )
+            )
+        else:
+            raise NotImplementedError(
+                f"gather_to_lds: transfer_bytes={transfer_bytes} not supported. "
+                f"Only 4B (buffer_load_dword) and 16B (buffer_load_dwordx4) are valid."
+            )
+
+    # -------------------------------------------------------------------------
+    # M0 pre-computation
+    # -------------------------------------------------------------------------
+
+    def precompute_g2s_m0(
+        self, operation: amdgpu_d.GatherToLDSOp, kernel_info: "KernelInfo"
+    ) -> Optional[int]:
+        """Pre-compute M0 value before barrier for LLVM-style optimization."""
+        lds_base = self.walker._lds_view_base_bytes.get(str(operation.operands[2]), 0)
+        lds_cols, elem_bytes = self._get_lds_layout(operation.operands[2].type)
+
+        dst_row = kernel_info.index_env.get(str(operation.operands[3]))
+        dst_col = kernel_info.index_env.get(str(operation.operands[4]))
+
+        if dst_row is None or dst_col is None:
+            return None  # Can't pre-compute without index values
+
+        # Build M0 expression
+        row = dst_row if isinstance(dst_row, sympy.Expr) else sympy.Integer(dst_row)
+        col = dst_col if isinstance(dst_col, sympy.Expr) else sympy.Integer(dst_col)
+        m0_expr = sympy.simplify(lds_base + (row * lds_cols + col) * elem_bytes)
+
+        emitter = self.walker.emitter
+        s_m0 = emitter.sgpr_allocator.alloc_s()
+
+        if m0_expr.is_number:
+            emitter.emit_instruction(SMovB32(s_m0, int(m0_expr), "Pre-compute M0"))
+        else:
+            m0_vreg = int(
+                self.handlers._get_expr_emitter(kernel_info).get_or_emit(m0_expr)[1:]
+            )
+            emitter.emit_instruction(VReadfirstlaneB32(s_m0, m0_vreg, "Pre-compute M0"))
+
+        return s_m0
+
+    # -------------------------------------------------------------------------
+    # Main handler
+    # -------------------------------------------------------------------------
+
+    def handle_gather_to_lds_op(
+        self, operation: amdgpu_d.GatherToLDSOp, kernel_info: "KernelInfo"
+    ):
+        """Handle amdgpu.gather_to_lds - gather from global memory directly to LDS."""
+        emitter = self.walker.emitter
+
+        # Parse transfer type
+        transfer_type = operation.attributes["transferType"].value
+        if not isinstance(transfer_type, VectorType):
+            raise ValueError(f"Unsupported transfer type: {transfer_type}")
+        elem_count, elem_bytes, _ = parse_vector_type_from_obj(transfer_type)
+        transfer_bytes = elem_count * elem_bytes
+
+        # Get operands
+        src_memref_ssa = str(operation.operands[0])
+        src_index_ssa = str(operation.operands[1])
+        dst_memref_ssa = str(operation.operands[2])
+
+        # Find/create SRD
+        orig_srd_regs, original_ssa = self._trace_memref_to_srd(
+            src_memref_ssa, kernel_info
+        )
+        if orig_srd_regs is None:
+            emitter.emit(f"    # ERROR: no SRD found for {src_memref_ssa}")
+            return
+
+        srd_regs = self._get_or_create_srd(orig_srd_regs, src_memref_ssa)
+        emitter.emit(
+            f"    # gather_to_lds: {transfer_bytes}B from {original_ssa} to LDS"
+        )
+
+        # Compute vaddr
+        voffset = self._compute_vaddr(src_index_ssa, kernel_info)
+
+        # Get LDS layout and emit M0
+        lds_base_bytes = self.walker._lds_view_base_bytes.get(dst_memref_ssa, 0)
+        lds_cols, elem_bytes = self._get_lds_layout(operation.operands[2].type)
+        self._emit_m0(operation, kernel_info, lds_base_bytes, lds_cols, elem_bytes)
+
+        # Emit buffer load
+        self._emit_buffer_load(transfer_bytes, voffset, srd_regs)
+
+        # Track g2s LDS views
+        g2s_views = getattr(self.walker, "_g2s_lds_views", None)
+        if g2s_views is None:
+            self.walker._g2s_lds_views = set()
+        self.walker._g2s_lds_views.add(dst_memref_ssa)

--- a/wave_lang/kernel/wave/asm/hazards.py
+++ b/wave_lang/kernel/wave/asm/hazards.py
@@ -1,0 +1,104 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Hardware Hazard Detection and Mitigation for AMDGCN.
+
+This module provides hazard detection and mitigation for AMD GPU architectures,
+particularly gfx940+ (CDNA 3) which has specific VALU hazards that require
+software workarounds.
+
+gfx940+ VALU Hazards (from LLVM's GCNHazardRecognizer.cpp):
+-----------------------------------------------------------
+The gfx940+ architectures (gfx940, gfx941, gfx942/MI300, gfx950) have
+hasVDecCoExecHazard=true and lack hardware interlocks for certain VALU
+instruction sequences:
+
+1. VALU writes VGPR, then v_readfirstlane reads it -> 1 wait state needed
+   (VALUWriteVGPRReadlaneRead = 1)
+
+2. VALU writes SGPR, then VALU reads it -> 2 wait states needed
+   (VALUWriteSGPRVALUReadSGPR = 2)
+
+Mitigation: Insert s_nop 0 after v_add instructions to provide the required
+wait state before v_readfirstlane can safely read the result.
+"""
+
+from typing import List, Optional
+
+from .instructions import Instruction, SNop
+
+
+class HazardDetector:
+    """
+    Detects and mitigates hardware hazards for AMDGCN code generation.
+
+    This class tracks instruction sequences and inserts s_nop instructions
+    to handle gfx940+ VALU hazards (applies to gfx940, gfx941, gfx942, gfx950).
+    """
+
+    # gfx940+ hazard constants from LLVM's GCNHazardRecognizer.cpp
+    VALU_WRITE_VGPR_READLANE_READ = 1  # Wait states for VALU->readfirstlane
+    VALU_WRITE_SGPR_VALU_READ_SGPR = 2  # Wait states for VALU->SGPR->VALU
+
+    # Instructions that trigger VALU hazards when followed by v_readfirstlane
+    # We apply s_nop mitigation to v_add instructions used in address
+    # computations before v_readfirstlane for M0.
+    HAZARDOUS_VALU_OPS = frozenset(
+        [
+            "v_add_u32",
+            "v_add_co_u32",
+            "v_add_nc_u32",
+        ]
+    )
+
+    def __init__(self):
+        """Initialize hazard detector."""
+        pass
+
+    def check_valu_hazard(self, mnemonic: str) -> bool:
+        """
+        Check if a mnemonic may cause a VALU hazard.
+
+        On gfx940+ (including gfx942/MI300 and gfx950), VALU instructions
+        that write VGPRs can cause hazards if followed by v_readfirstlane
+        reading those VGPRs.
+
+        Args:
+            mnemonic: The instruction mnemonic (e.g., "v_add_u32")
+
+        Returns:
+            True if this instruction may need hazard mitigation
+        """
+        return mnemonic.lower() in self.HAZARDOUS_VALU_OPS
+
+    def get_mitigation(self, mnemonic: str) -> Optional[Instruction]:
+        """
+        Get the hazard mitigation instruction for a given mnemonic.
+
+        Args:
+            mnemonic: The mnemonic of the instruction that was just emitted
+
+        Returns:
+            Mitigation instruction object, or None if no mitigation needed
+        """
+        if not mnemonic or not self.check_valu_hazard(mnemonic):
+            return None
+
+        # s_nop 0 provides 1 wait cycle for VALU->readfirstlane hazard
+        return SNop(0)
+
+    def get_mitigations(self, mnemonic: str) -> List[Instruction]:
+        """
+        Get list of mitigation instructions (for compatibility).
+
+        Args:
+            mnemonic: The mnemonic of the instruction that was just emitted
+
+        Returns:
+            List of mitigation instruction objects (may be empty)
+        """
+        mitigation = self.get_mitigation(mnemonic)
+        return [mitigation] if mitigation else []

--- a/wave_lang/kernel/wave/asm/mlir_walker.py
+++ b/wave_lang/kernel/wave/asm/mlir_walker.py
@@ -3,6 +3,12 @@
 # Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+MLIR IR Walker for ASM code generation.
+
+Implements LLVM-style vmcnt optimization by pre-computing M0 base values
+BEFORE barriers, then using scalar operations for M0 assignment.
+"""
 
 from wave_lang.support.ir_imports import (
     affine_d,
@@ -11,6 +17,7 @@ from wave_lang.support.ir_imports import (
     func_d,
     gpu_d,
     memref_d,
+    rocdl_d,
     scf_d,
     stream_d,
     vector_d,
@@ -23,6 +30,7 @@ from .utils import (
 
 from .kernel_model import KernelInfo
 from .handlers import OperationHandlers
+from .gather_to_shared import analyze_g2s_region, precompute_m0_values
 
 
 class IRWalker:
@@ -63,35 +71,78 @@ class IRWalker:
         return kernel_info
 
     def _walk_block(self, block, kernel_info: KernelInfo):
-        """Walk operations in a block and dispatch to appropriate handlers."""
-        for operation in block.operations:
-            if isinstance(operation, arith_d.ConstantOp):
-                self.handlers.handle_arith_constant_op(operation, kernel_info)
-            elif isinstance(operation, gpu_d.ThreadIdOp):
-                self.handlers.handle_gpu_thread_id_op(operation, kernel_info)
-            elif isinstance(operation, gpu_d.BlockIdOp):
-                self.handlers.handle_gpu_block_id_op(operation, kernel_info)
-            elif isinstance(operation, affine_d.AffineApplyOp):
-                self.handlers.handle_affine_apply_op(operation, kernel_info)
-            elif isinstance(operation, vector_d.LoadOp):
-                self.handlers.handle_vector_load_op(operation, kernel_info)
-            elif isinstance(operation, vector_d.StoreOp):
-                self.handlers.handle_vector_store_op(operation, kernel_info)
-            elif isinstance(operation, amdgpu_d.MFMAOp):
-                self.handlers.handle_mfma_op(operation, kernel_info)
-            elif isinstance(operation, amdgpu_d.LDSBarrierOp):
-                self.handlers.handle_lds_barrier_op(operation, kernel_info)
-            elif isinstance(operation, memref_d.ViewOp):
-                self.handlers.handle_view_op(operation, kernel_info)
-            elif isinstance(operation, memref_d.AllocOp):
-                self.handlers.handle_alloc_op(operation, kernel_info)
-            elif isinstance(operation, stream_d.BindingSubspanOp):
-                self.handlers.handle_stream_binding_subspan_op(operation, kernel_info)
-            elif isinstance(operation, scf_d.ForOp):
-                self.handlers.handle_scf_for_op(operation, kernel_info)
-            elif isinstance(operation, vector_d.ExtractStridedSliceOp):
-                self.handlers.handle_vector_extract_strided_slice_op(
-                    operation, kernel_info
-                )
-            else:
-                pass
+        """Walk operations in a block and dispatch to handlers.
+
+        For g2s regions: dispatches ops before first g2s, pre-computes M0,
+        then dispatches remaining ops.
+        """
+        ops = list(block.operations)
+
+        # Analyze for g2s scheduling
+        schedule = analyze_g2s_region(ops)
+
+        if schedule is None:
+            # No g2s ops - dispatch all ops sequentially
+            for op in ops:
+                self._dispatch_operation(op, kernel_info)
+        else:
+            # Dispatch ops before first g2s (populates index_env)
+            for i in range(schedule.first_g2s_idx):
+                self._dispatch_operation(ops[i], kernel_info)
+
+            # Pre-compute M0 values before any buffer_load...lds
+            precompute_m0_values(schedule, kernel_info, self.handlers)
+
+            # Dispatch remaining ops
+            for i in range(schedule.first_g2s_idx, len(ops)):
+                self._dispatch_operation(ops[i], kernel_info)
+
+    def _dispatch_operation(self, operation, kernel_info: KernelInfo):
+        """Dispatch a single operation to its appropriate handler."""
+        if isinstance(operation, arith_d.ConstantOp):
+            self.handlers.handle_arith_constant_op(operation, kernel_info)
+        elif isinstance(operation, arith_d.AddIOp):
+            self.handlers.handle_arith_addi_op(operation, kernel_info)
+        elif isinstance(operation, arith_d.MulIOp):
+            self.handlers.handle_arith_muli_op(operation, kernel_info)
+        elif isinstance(operation, arith_d.IndexCastOp):
+            self.handlers.handle_arith_index_cast_op(operation, kernel_info)
+        elif isinstance(operation, gpu_d.ThreadIdOp):
+            self.handlers.handle_gpu_thread_id_op(operation, kernel_info)
+        elif isinstance(operation, gpu_d.BlockIdOp):
+            self.handlers.handle_gpu_block_id_op(operation, kernel_info)
+        elif isinstance(operation, affine_d.AffineApplyOp):
+            self.handlers.handle_affine_apply_op(operation, kernel_info)
+        elif isinstance(operation, vector_d.LoadOp):
+            self.handlers.handle_vector_load_op(operation, kernel_info)
+        elif isinstance(operation, vector_d.StoreOp):
+            self.handlers.handle_vector_store_op(operation, kernel_info)
+        elif isinstance(operation, amdgpu_d.MFMAOp):
+            self.handlers.handle_mfma_op(operation, kernel_info)
+        elif isinstance(operation, amdgpu_d.LDSBarrierOp):
+            self.handlers.handle_lds_barrier_op(operation, kernel_info)
+        elif isinstance(operation, memref_d.ViewOp):
+            self.handlers.handle_view_op(operation, kernel_info)
+        elif isinstance(operation, memref_d.AllocOp):
+            self.handlers.handle_alloc_op(operation, kernel_info)
+        elif isinstance(operation, memref_d.CastOp):
+            self.handlers.handle_memref_cast_op(operation, kernel_info)
+        elif isinstance(operation, memref_d.ReinterpretCastOp):
+            self.handlers.handle_memref_reinterpret_cast_op(operation, kernel_info)
+        elif isinstance(operation, stream_d.BindingSubspanOp):
+            self.handlers.handle_stream_binding_subspan_op(operation, kernel_info)
+        elif isinstance(operation, scf_d.ForOp):
+            self.handlers.handle_scf_for_op(operation, kernel_info)
+        elif isinstance(operation, vector_d.ExtractStridedSliceOp):
+            self.handlers.handle_vector_extract_strided_slice_op(operation, kernel_info)
+        # Critical operations for gather_to_lds support
+        elif isinstance(operation, amdgpu_d.GatherToLDSOp):
+            self.handlers.g2s.handle_gather_to_lds_op(operation, kernel_info)
+        elif isinstance(operation, amdgpu_d.FatRawBufferCastOp):
+            self.handlers.handle_fat_raw_buffer_cast_op(operation, kernel_info)
+        elif isinstance(operation, rocdl_d.ReadfirstlaneOp):
+            self.handlers.handle_readfirstlane_op(operation, kernel_info)
+        elif isinstance(operation, rocdl_d.SWaitcntOp):
+            self.handlers.handle_s_waitcnt_op(operation, kernel_info)
+        else:
+            pass

--- a/wave_lang/kernel/wave/asm/utils.py
+++ b/wave_lang/kernel/wave/asm/utils.py
@@ -235,7 +235,8 @@ def _create_substitutions(values: List, prefix: str) -> Dict[sympy.Symbol, sympy
     Create substitutions for affine map parameters.
 
     Args:
-        values: List of values (integers or ID strings like "tid_x", "wgid_x", or "s4")
+        values: List of values (integers, ID strings like "tid_x", "wgid_x", "s4",
+                or SymPy expressions from previous affine.apply results)
         prefix: Prefix for the symbols ("d" for dimensions, "s" for symbols)
 
     Returns:
@@ -245,7 +246,10 @@ def _create_substitutions(values: List, prefix: str) -> Dict[sympy.Symbol, sympy
 
     for i, value in enumerate(values):
         param_symbol = sympy.Symbol(f"{prefix}{i}")
-        if isinstance(value, int):
+        if isinstance(value, sympy.Expr):
+            # SymPy expression from previous affine.apply - use directly
+            substitutions[param_symbol] = value
+        elif isinstance(value, int):
             substitutions[param_symbol] = sympy.Integer(value)
         elif value in ["tid_x", "tid_y", "tid_z", "wgid_x", "wgid_y", "wgid_z"]:
             # Thread IDs and workgroup IDs are symbolic runtime values


### PR DESCRIPTION
Summary
- This PR adds gather-to-LDS (buffer_load_dword...lds) support to the ASM backend, implements gfx950 VALU hazard mitigation, and simplifies several operation handlers.

Key Changes
New Modules:
- gather_to_shared.py: G2SHandler class for buffer_load_dword...lds emission with M0 pre-computation, SRD tracing, and cache swizzle support
- hazards.py: HazardDetector class for gfx950 VALU hazard detection with automatic s_nop 0 insertion

Testing:
Added test_gemm_gather_to_lds lit test verifying buffer_load...lds emission

Documentation:
Updated asm_backend.rst with Gather-to-LDS and Hardware Hazard Mitigation sections