### PR TITLE
[wave2water] Fix Water tests failing on machines without ROCm

### DIFF
--- a/water/test/Transforms/gpu-module-to-binary-dump.mlir
+++ b/water/test/Transforms/gpu-module-to-binary-dump.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: rocdl
 // RUN: rm -rf %t
 // RUN: water-opt %s --water-gpu-module-to-binary="dump-intermediates=%t" | FileCheck %s
 // RUN: test -f %t/kernel_module_original.ll

--- a/water/test/Transforms/gpu-module-to-binary-override.mlir
+++ b/water/test/Transforms/gpu-module-to-binary-override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: rocdl
 // RUN: rm -rf %t && mkdir -p %t/dump1 %t/dump2 %t/override
 // RUN: water-opt %s --water-gpu-module-to-binary="dump-intermediates=%t/dump1" | FileCheck %s
 // RUN: cp %t/dump1/kernel_module_linked.ll %t/override/kernel_module_linked.ll

--- a/water/test/Transforms/gpu-module-to-binary.mlir
+++ b/water/test/Transforms/gpu-module-to-binary.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: rocdl
 // RUN: water-opt %s --water-gpu-module-to-binary | FileCheck %s
 
 // Test that the pass converts a gpu.module with ROCDL target to a gpu.binary

--- a/water/test/lit.cfg.py
+++ b/water/test/lit.cfg.py
@@ -76,3 +76,33 @@ tools = [
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+# Check for ROCm availability
+import shutil
+
+
+def check_rocm_available():
+    """Check if ROCm is available by looking for lld or checking environment variables."""
+    # Check for ROCM environment variables
+    rocm_env_vars = ["ROCM_PATH", "ROCM_ROOT", "ROCM_HOME"]
+    for var in rocm_env_vars:
+        if os.environ.get(var):
+            return True
+
+    # Check for lld in PATH (needed for ROCm compilation)
+    if shutil.which("lld") or shutil.which("ld.lld"):
+        return True
+
+    # Check for common ROCm installation paths
+    rocm_paths = ["/opt/rocm", "/usr/lib/rocm"]
+    for path in rocm_paths:
+        if os.path.isdir(path):
+            return True
+
+    return False
+
+
+# TODO:  alternatively, just build LLD as part of our llvm build and put it
+# into water/bin
+if check_rocm_available():
+    config.available_features.add("rocdl")


### PR DESCRIPTION
These tests attempt to compile GPU kernels to binary using ROCm tools but fail with `ld.lld invocation failed` errors on systems where ROCm is not available.