### PR TITLE
[CI] Only fetch a single commit

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -70,7 +70,6 @@ jobs:
           repository: llvm/llvm-project
           ref: ${{ env.LLVM_SHA }}
           path: llvm-mlir/llvm-project
-          fetch-depth: 0
 
       - name: Build LLVM-MLIR
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
@@ -249,7 +248,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
From the checkout docs:
> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags.