### PR TITLE
[CI] pip install remove --no-compile flag

### DIFF
--- a/.github/workflows/ci-gpu-35x.yaml
+++ b/.github/workflows/ci-gpu-35x.yaml
@@ -86,7 +86,7 @@ jobs:
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
           # Install wave deps
-          python -m pip install --no-compile --upgrade pip
+          python -m pip install --upgrade pip
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 

--- a/.github/workflows/ci-gpu-rdna.yaml
+++ b/.github/workflows/ci-gpu-rdna.yaml
@@ -84,7 +84,7 @@ jobs:
           sudo apt install -y libnuma1 numactl gfortran build-essential binutils dwarfdump
 
           # Install torch+rocm6.4
-          python -m pip install --no-compile --upgrade pip
+          python -m pip install --upgrade pip
           pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.4
 
           # Install wave deps

--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -197,8 +197,8 @@ jobs:
       - name: Install pip deps (mi250/mi325)
         if: ${{ env.HAS_GPU == 'true' && !cancelled() }}
         run: |
-          python -m pip install --no-compile --upgrade pip
-          pip install --no-compile -r pytorch-rocm-requirements.txt
+          python -m pip install --upgrade pip
+          pip install -r pytorch-rocm-requirements.txt
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 

--- a/.github/workflows/ci-happy.yml
+++ b/.github/workflows/ci-happy.yml
@@ -109,7 +109,7 @@ jobs:
               source "${USER_VENV}/bin/activate"
 
               echo "Install pip deps"
-              python3 -m pip install --no-compile --upgrade pip
+              python3 -m pip install --upgrade pip
 
               # Install wave deps
               pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install pip deps
         run: |
-          python -m pip install --no-compile --upgrade pip
+          python -m pip install --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Additionally, installing
           # cpu/rocm-specific pytorch wheels first avoids installing

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -55,11 +55,11 @@ jobs:
 
       - name: Install pip deps
         run: |
-          python -m pip install --no-compile --upgrade pip
+          python -m pip install --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
-          pip install --no-compile -r pytorch-rocm-requirements.txt
+          pip install -r pytorch-rocm-requirements.txt
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 


### PR DESCRIPTION
This should have no effect since it only delays byte code compilation until the first invocation, wich is in the next line in most cases. Remove flag to reduce noise and keep the setup inline with what actual users would use.