### PR TITLE
[water] override data flow along control edges of IterateOp

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -178,6 +178,7 @@ def IterateOp : Op<WaveDialect, "iterate", [
     "(`captures` `(` $captures^ `)`)?"
     "attr-dict-with-keyword regions `:` functional-type(operands, results)";
   let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 
   let extraClassDeclaration = [{
     // Get the body block.

--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -424,8 +424,8 @@ llvm::LogicalResult wave::detail::verifyTypesCompatible(
         lhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified &&
         rhs.getAddressSpaceValue() != wave::WaveAddressSpace::Unspecified) {
       if (errorLocation) {
-        emitError(*errorLocation) << "address space mismatch between" << lhsName
-                                  << " and " << rhsName;
+        emitError(*errorLocation) << "address space mismatch between "
+                                  << lhsName << " and " << rhsName;
       }
       return mlir::failure();
     }

--- a/water/test/Dialect/Wave/infer-types.mlir
+++ b/water/test/Dialect/Wave/infer-types.mlir
@@ -200,3 +200,17 @@ module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
 // expected-error @below {{water-wave-infer-types pass expects the root operation or its ancestor to guarantee the full_func_boundary normal form}}
 module {
 }
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_func_boundary>} {
+  func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<[@B] of f32>) {
+    %read = wave.read %arg1 : (!wave.tensor<[@B] of f32>) -> !wave.tensor<any of f32>
+    // expected-error @below {{type conflict was detected for result #0}}
+    wave.iterate @I iter_args(%arg0, %read) {
+    ^bb0(%arg2: !wave.tensor<[@B] of f32>, %arg3: !wave.tensor<any of f32>):
+      wave.yield %arg2, %arg3 : !wave.tensor<[@B] of f32>, !wave.tensor<any of f32>
+    } : (!wave.tensor<[@A] of f32>, !wave.tensor<any of f32>) -> (!wave.tensor<any of f32>, !wave.tensor<any of f32>)
+    return
+  }
+}

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -86,12 +86,162 @@ func.func @iterate_mismatching_results(%arg0: !wave.tensor<any of f32>, %arg1: !
 
 // -----
 
-func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<any of f32>) {
-  // expected-error @below {{along control flow edge from parent operands to Region #0: source type #0 '!wave.tensor<[@A] of f32>' should match input type #0 '!wave.tensor<[@B] of f32>'}}
+func.func @iterate_operands_block_args_mismatch(%arg0: !wave.tensor<any of f32>) {
+  // expected-error @below {{expects the same number of operands (1) and block arguments (2)}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<any of f32>, %arg2: !wave.tensor<any of f32>):
+    wave.yield %arg1 : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @iterate_iter_args_block_iter_args_mismatch(%arg0: !wave.tensor<any of f32>, %arg1: !wave.tensor<any of f32>) {
+  // expected-error @below {{expects the same number of operands (2) and block arguments (1)}}
   wave.iterate @I iter_args(%arg0, %arg1) {
-  ^bb0(%arg2: !wave.tensor<[@B] of f32>, %arg3: !wave.tensor<any of f32>):
-    wave.yield %arg2, %arg3 : !wave.tensor<[@B] of f32>, !wave.tensor<any of f32>
-  } : (!wave.tensor<[@A] of f32>, !wave.tensor<any of f32>) -> (!wave.tensor<any of f32>, !wave.tensor<any of f32>)
+  ^bb0(%arg2: !wave.tensor<any of f32>):
+    wave.yield %arg2 : !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @iterate_iter_arg_block_arg_element_type_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected operand iter_arg #0 and result #0 elemental types to match, got 'f32', 'bf16'}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of bf16>):
+    wave.yield %arg1 : !wave.tensor<[@A] of bf16>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of bf16>
+}
+
+// -----
+
+func.func @iterate_iter_arg_block_arg_rank_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{rank mismatch between operand iter_arg #0 and result #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A, @B] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A, @B] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A, @B] of f32>
+}
+
+// -----
+
+func.func @iterate_iter_arg_block_arg_shape_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected operand iter_arg #0 dimension #0 (#wave.symbol<"A">) to match result #0 dimension #0 (#wave.symbol<"B">)}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@B] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@B] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@B] of f32>
+}
+
+// -----
+
+func.func @iterate_iter_arg_block_arg_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <register>>) {
+  // expected-error @below {{address space mismatch between operand iter_arg #0 and result #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32, <shared>>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32, <shared>>
+  } : (!wave.tensor<[@A] of f32, <register>>) -> !wave.tensor<[@A] of f32, <shared>>
+}
+
+// -----
+
+func.func @iterate_iter_arg_result_element_type_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected operand iter_arg #0 and result #0 elemental types to match, got 'f32', 'bf16'}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A] of bf16>
+}
+
+// -----
+
+func.func @iterate_iter_arg_result_rank_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{rank mismatch between operand iter_arg #0 and result #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@A, @B] of f32>
+}
+
+// -----
+
+func.func @iterate_iter_arg_result_shape_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected operand iter_arg #0 dimension #0 (#wave.symbol<"A">) to match result #0 dimension #0 (#wave.symbol<"B">)}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>) -> !wave.tensor<[@B] of f32>
+}
+
+// -----
+
+func.func @iterate_iter_arg_result_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <register>>) {
+  // expected-error @below {{address space mismatch between operand iter_arg #0 and result #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32, <register>>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32, <register>>
+  } : (!wave.tensor<[@A] of f32, <register>>) -> !wave.tensor<[@A] of f32, <shared>>
+}
+
+// -----
+
+func.func @iterate_capture_type_mismatch(%arg0: !wave.tensor<[@A] of f32>, %capture: !wave.tensor<[@B] of f32>) {
+  // expected-error @below {{expects the same type for capture #0 and block argument #1}}
+  wave.iterate @I iter_args(%arg0) captures(%capture) {
+  ^bb0(%arg1: !wave.tensor<[@A] of f32>, %arg2: !wave.tensor<[@B] of bf16>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of f32>, !wave.tensor<[@B] of f32>) -> !wave.tensor<[@A] of f32>
+}
+
+// -----
+
+func.func @iterate_results_terminator_operands_mismatch(%arg0: !wave.tensor<any of f32>, %arg1: !wave.tensor<any of f32>) {
+  // expected-error @below {{expects the same number of results (1) and terminator operands (2)}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg2: !wave.tensor<any of f32>):
+    wave.yield %arg2, %arg1 : !wave.tensor<any of f32>, !wave.tensor<any of f32>
+  } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @iterate_result_terminator_element_type_mismatch(%arg0: !wave.tensor<[@A] of bf16>, %arg1: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected result #0 and terminator operand #0 elemental types to match, got 'bf16', 'f32'}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg2: !wave.tensor<[@A] of bf16>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A] of bf16>) -> !wave.tensor<[@A] of bf16>
+}
+
+// -----
+
+func.func @iterate_result_terminator_rank_mismatch(%arg0: !wave.tensor<[@A, @B] of f32>, %arg1: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{rank mismatch between result #0 and terminator operand #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg2: !wave.tensor<[@A, @B] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@A, @B] of f32>
+}
+
+// -----
+
+func.func @iterate_result_terminator_shape_mismatch(%arg0: !wave.tensor<[@B] of f32>, %arg1: !wave.tensor<[@A] of f32>) {
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match terminator operand #0 dimension #0 (#wave.symbol<"A">)}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg2: !wave.tensor<[@B] of f32>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32>
+  } : (!wave.tensor<[@B] of f32>) -> !wave.tensor<[@B] of f32>
+}
+
+// -----
+
+func.func @iterate_result_terminator_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <shared>>, %arg1: !wave.tensor<[@A] of f32, <register>>) {
+  // expected-error @below {{address space mismatch between result #0 and terminator operand #0}}
+  wave.iterate @I iter_args(%arg0) {
+  ^bb0(%arg2: !wave.tensor<[@A] of f32, <shared>>):
+    wave.yield %arg1 : !wave.tensor<[@A] of f32, <register>>
+  } : (!wave.tensor<[@A] of f32, <shared>>) -> !wave.tensor<[@A] of f32, <shared>>
 }
 
 // -----


### PR DESCRIPTION
Change the implementation of control flow interfaces on wave::IterateOp so that
data flow propagation becomes controllable manually instead of directly
forwarding/joining lattices along control flow edges. Concretely, indicate none
of the operands as being forwarded along the control flow edge.

This allows us to control how lattices are propagated along these edges in
dataflow analyses. Specifically, for index expression inference, the analysis
is now capable of removing the iterator symbol from the expression when
propagating it to operations outside the corresponding loop.