### PR TITLE
[water] make step and stride constant

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -382,22 +382,34 @@ def WaveIterSymbolAttr : AttrDef<WaveDialect, "WaveIterSymbol"> {
 def WaveIndexMappingAttr : AttrDef<WaveDialect, "WaveIndexMapping"> {
   let mnemonic = "index_mapping";
   let description = [{
-    An affine map with named symbols for Wave indexing expressions.
+    An attribute capturing how symbols indexing a tensor are distributed
+    across concurrent threads, workgroups, devices, and loop tiles.
 
-    This attribute preserves meaningful symbol names (e.g., WG0, BLOCK_M, T0)
-    while storing affine maps internally for start, step, and stride. The
-    symbol_names array corresponds 1:1 to the symbols in the affine
-    expressions, where s0 maps to symbol_names[0], s1 to symbol_names[1], etc.
+    In this attribute, the start expression corresponds to the offset from
+    the start of the tensor dimension, the step corresponds to the number
+    of consecutive elements taken (i.e., corresponding to the `vector.step`
+    operation to index into them) and the stride corresponds to the number
+    of elements to step over in this dimension to get to the next block
+    of consecutive elements that are accessed by the current thread. The
+    start expression is an affine expression where positional affine symbols
+    are mapped to specific wave symbols. It will typically include thread and
+    workgroup index symbols (the absence thereof indicates that all threads or
+    all workgroups access the same element, i.e., a broadcast), as well as
+    loop iteration symbols for operations nested in loops. Start and stride
+    are constant values.
 
-    Custom syntax: [symbol_name attributes] -> (start_expr, step_expr, stride_expr)
-    Example: [wave.index_symbol<WG0>, wave.symbol<"BLOCK_M">] -> (WG0 * BLOCK_M + 42, 1, BLOCK_M)
+    The symbols array corresponds 1:1 to the symbols in the affine map, where
+    s0 maps to symbols[0], s1 to symbols[1], etc.
+
+    Custom syntax: `[symbol_name attributes] -> (start_expr, step, stride)`
+    Example: `[wave.index_symbol<WG0>, wave.symbol<"BLOCK_M">] -> (WG0 * BLOCK_M + 42, 1, 4)`
   }];
 
   let parameters = (ins
     ArrayRefParameter<"::mlir::Attribute">:$symbols,
     "::mlir::AffineMap":$start,
-    "::mlir::AffineMap":$step,
-    "::mlir::AffineMap":$stride
+    "uint64_t":$step,
+    "uint64_t":$stride
   );
 
   let hasCustomAssemblyFormat = 1;

--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -100,13 +100,11 @@ MLIR_CAPI_EXPORTED bool
 mlirAttributeIsAWaveIndexMappingAttr(MlirAttribute attr);
 
 /// Creates a new WaveIndexMappingAttr with the given start, step and stride
-/// maps that are interpreted as accepting the symbols provided in the
-/// `symbolNames` list. The list must have as many entries as maps have symbols,
-/// and all maps must have the same number of symbols and zero dimensions. The
-/// list is expected to only contain WaveSymbolAttr instances.
+/// values that are interpreted as constant offsets. The `symbolNames` list
+/// is expected to only contain WaveSymbolAttr instances.
 MLIR_CAPI_EXPORTED MlirAttribute mlirWaveIndexMappingAttrGet(
-    MlirContext mlirCtx, MlirAttribute *symbolNames, MlirAffineMap start,
-    MlirAffineMap step, MlirAffineMap stride);
+    MlirContext mlirCtx, MlirAttribute *symbolNames, intptr_t numSymbols,
+    MlirAffineMap start, uint64_t step, uint64_t stride);
 
 /// Returns the typeID of a WaveIndexMappingAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveIndexMappingAttrGetTypeID();
@@ -116,11 +114,10 @@ MLIR_CAPI_EXPORTED MlirAffineMap
 mlirWaveIndexMappingAttrGetStart(MlirAttribute attr);
 
 /// Get the step from a WaveIndexMappingAttr.
-MLIR_CAPI_EXPORTED MlirAffineMap
-mlirWaveIndexMappingAttrGetStep(MlirAttribute attr);
+MLIR_CAPI_EXPORTED uint64_t mlirWaveIndexMappingAttrGetStep(MlirAttribute attr);
 
 /// Get the stride from a WaveIndexMappingAttr.
-MLIR_CAPI_EXPORTED MlirAffineMap
+MLIR_CAPI_EXPORTED uint64_t
 mlirWaveIndexMappingAttrGetStride(MlirAttribute attr);
 
 /// Get the number of (input) symbols.

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -108,17 +108,12 @@ bool mlirAttributeIsAWaveIndexMappingAttr(MlirAttribute attr) {
 
 MlirAttribute mlirWaveIndexMappingAttrGet(MlirContext mlirCtx,
                                           MlirAttribute *symbolNames,
-                                          MlirAffineMap start,
-                                          MlirAffineMap step,
-                                          MlirAffineMap stride) {
+                                          intptr_t numSymbols,
+                                          MlirAffineMap start, uint64_t step,
+                                          uint64_t stride) {
   mlir::MLIRContext *ctx = unwrap(mlirCtx);
 
   // Convert C array of MlirAttribute to vector of WaveSymbolAttr.
-  unsigned numSymbols = mlirAffineMapGetNumSymbols(start);
-  assert(mlirAffineMapGetNumSymbols(step) == numSymbols &&
-         "expected start and step to have the same number of dimensions");
-  assert(mlirAffineMapGetNumSymbols(stride) == numSymbols &&
-         "expected start and stride to have the same number of dimensions");
   llvm::SmallVector<mlir::Attribute> symbolAttrs = llvm::map_to_vector(
       llvm::make_range(symbolNames, symbolNames + numSymbols),
       [](MlirAttribute attr) { return unwrap(attr); });
@@ -131,7 +126,7 @@ MlirAttribute mlirWaveIndexMappingAttrGet(MlirContext mlirCtx,
          "WaveIndexSymbolAttr attributes");
 
   return wrap(wave::WaveIndexMappingAttr::get(ctx, symbolAttrs, unwrap(start),
-                                              unwrap(step), unwrap(stride)));
+                                              step, stride));
 }
 
 MlirTypeID mlirWaveIndexMappingAttrGetTypeID() {
@@ -142,12 +137,12 @@ MlirAffineMap mlirWaveIndexMappingAttrGetStart(MlirAttribute attr) {
   return wrap(llvm::cast<wave::WaveIndexMappingAttr>(unwrap(attr)).getStart());
 }
 
-MlirAffineMap mlirWaveIndexMappingAttrGetStep(MlirAttribute attr) {
-  return wrap(llvm::cast<wave::WaveIndexMappingAttr>(unwrap(attr)).getStep());
+uint64_t mlirWaveIndexMappingAttrGetStep(MlirAttribute attr) {
+  return llvm::cast<wave::WaveIndexMappingAttr>(unwrap(attr)).getStep();
 }
 
-MlirAffineMap mlirWaveIndexMappingAttrGetStride(MlirAttribute attr) {
-  return wrap(llvm::cast<wave::WaveIndexMappingAttr>(unwrap(attr)).getStride());
+uint64_t mlirWaveIndexMappingAttrGetStride(MlirAttribute attr) {
+  return llvm::cast<wave::WaveIndexMappingAttr>(unwrap(attr)).getStride();
 }
 
 intptr_t mlirWaveIndexMappingAttrGetNumSymbols(MlirAttribute attr) {

--- a/water/lib/Dialect/Wave/IR/WaveUtils.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveUtils.cpp
@@ -28,13 +28,7 @@ wave::getUncollapsedVectorShape(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
     Attribute entry = indexDict.get(symbol.getName());
     assert(entry && "expected dictionary to contain indices for the shape");
     auto mapAttr = cast<wave::WaveIndexMappingAttr>(entry);
-    std::optional<SmallVector<int64_t>> folded =
-        wave::evaluateMapWithHyperparams(mapAttr.getStep(),
-                                         mapAttr.getSymbols(), hyper);
-    if (!folded)
-      return ShapedType::kDynamic;
-    assert(folded->size() == 1 && "expected single-result map");
-    return (*folded)[0];
+    return static_cast<int64_t>(mapAttr.getStep());
   });
 }
 

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -128,27 +128,20 @@ NB_MODULE(_waterDialects, m) {
       .def_classmethod(
           "get",
           [](const nb::object &cls, std::vector<MlirAttribute> &symbols,
-             MlirAffineMap start, MlirAffineMap step, MlirAffineMap stride,
+             MlirAffineMap start, uint64_t step, uint64_t stride,
              // MlirContext should always come last to allow for being
              // automatically deduced from context.
              MlirContext context) {
             intptr_t numSymbols = symbols.size();
-            intptr_t numResults = mlirAffineMapGetNumResults(start);
-            for (MlirAffineMap map : {start, step, stride}) {
-              if (numSymbols != mlirAffineMapGetNumSymbols(map)) {
-                throw nb::value_error("Expected symbols, start, step and "
-                                      "stride to be co-indexed.");
-              }
-              if (mlirAffineMapGetNumDims(map) != 0) {
-                throw nb::value_error("Maps should not involve dimensions.");
-              }
-              if (numResults != mlirAffineMapGetNumResults(map)) {
-                throw nb::value_error(
-                    "Maps should have the same number of results.");
-              }
+            if (numSymbols != mlirAffineMapGetNumSymbols(start)) {
+              throw nb::value_error(
+                  "Expected symbols and start to be co-indexed.");
             }
-            return cls(mlirWaveIndexMappingAttrGet(context, symbols.data(),
-                                                   start, step, stride));
+            if (mlirAffineMapGetNumDims(start) != 0) {
+              throw nb::value_error("Start map should not involve dimensions.");
+            }
+            return cls(mlirWaveIndexMappingAttrGet(
+                context, symbols.data(), numSymbols, start, step, stride));
           },
           nb::arg("cls"), nb::arg("symbols"), nb::arg("start"), nb::arg("step"),
           nb::arg("stride"), nb::arg("context") = nb::none(),

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -370,7 +370,7 @@ func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes 
       // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
       // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
+      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 8, 1)}]
      : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
      // CHECK: %[[VEC:.+]] = vector.load {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
 
@@ -478,7 +478,7 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
       // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
       // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
+      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 8, 1)}]
      : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
      // CHECK: vector.store {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
      // CHECK-NOT: vector.transfer_write

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -107,8 +107,7 @@ func.func @index_attr_wrong_attr_type(%arg0: f32) {
 
 // must provide the full triple (start, step, stride)
 func.func @index_attr_missing_step_stride(%arg0: f32) {
-  // expected-error @+2 {{expected ','}}
-  // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
+  // expected-error @below {{expected ','}}
   wave.register %arg0 index [{X : [#wave.index_symbol<WG0>] -> (WG0)}] : !wave.tensor<[@M] of f32, <register>>
   return
 }
@@ -117,8 +116,7 @@ func.func @index_attr_missing_step_stride(%arg0: f32) {
 
 // must provide the full triple (start, step, stride)
 func.func @index_attr_missing_stride(%arg0: f32) {
-  // expected-error @+2 {{expected ','}}
-  // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
+  // expected-error @below {{expected ','}}
   wave.register %arg0 index [{X : [#wave.index_symbol<WG0>] -> (WG0, 1)}] : !wave.tensor<[@M] of f32, <register>>
   return
 }
@@ -256,7 +254,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
     // expected-note @below {{BLOCK_M, BLOCK_N, M}}
     %0 = wave.read %mem index [{
         M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, 1, 1)}]
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
@@ -271,7 +269,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
     // expected-note @below {{available symbols: M, N}}
     %0 = wave.read %mem index [{
         M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, 1, 1)}]
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
@@ -357,8 +355,8 @@ func.func @read_index_multi_step_eval(%mem: !wave.tensor<[@M, @N] of f32>) attri
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}
   wave.read %mem index [{
-    M : [#wave.index_symbol<T0>, #wave.symbol<"X">] -> (T0, 2 * X, 1),
-    N : [#wave.index_symbol<T1>, #wave.symbol<"X">, #wave.symbol<"Y">] -> (T1, X + Y, 1)
+    M : [#wave.index_symbol<T0>, #wave.symbol<"X">] -> (T0, 2, 1),
+    N : [#wave.index_symbol<T1>, #wave.symbol<"X">, #wave.symbol<"Y">] -> (T1, 2, 1)
   }] : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
   return
 }

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -108,7 +108,7 @@ func.func @register_with_symbols_complex_index() {
   // CHECK: wave.register
   %register = wave.register %0
     index [{
-      B : [#wave.index_symbol<WG2>, #wave.symbol<"BLOCK_B">] -> (WG2 * (BLOCK_B+BLOCK_B), BLOCK_B * (WG2+WG2), WG2 * BLOCK_B),
+      B : [#wave.index_symbol<WG2>, #wave.symbol<"BLOCK_B">] -> (WG2 * (BLOCK_B+BLOCK_B), 1, 1),
       M : [#wave.index_symbol<WG0>, #wave.symbol<"BLOCK_M">, #wave.index_symbol<T0>] -> (WG0 * BLOCK_M + BLOCK_M * ((T0 floordiv 64) floordiv 2) + T0 mod 32, 1, 1),
       N : [#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">, #wave.index_symbol<WG1>, #wave.index_symbol<GPR_NUM>, #wave.index_symbol<T0>] -> (T1 * (BLOCK_N floordiv 2) + BLOCK_N * WG1 + GPR_NUM mod 4 + ((GPR_NUM floordiv 4) mod 4) * 8 + ((T0 mod 64) floordiv 32) * 4, 1, 1)
     }]
@@ -157,7 +157,7 @@ attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 32, BLOCK_N 
   // CHECK: #wave.index_symbol<T0>
   %0 = wave.read %mem index [{
       M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, 1, 1)}]
     : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
   return
 }


### PR DESCRIPTION
In practice, symbolic expressions only appear in the start part of the mapping
tuple whereas its step and stride are always constant. Remove the unnecessary
complexity of using full affine expressions there and use constants instead.