### PR TITLE
[water] Remove normal form attributes after applying water pipeline

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/Utils.cpp
+++ b/water/lib/Dialect/Wave/Transforms/Utils.cpp
@@ -33,8 +33,9 @@ wave::setNormalFormPassPostcondition(wave::WaveNormalForm form,
 
 llvm::LogicalResult
 wave::clearNormalFormPassPostcondition(mlir::Operation *root) {
-  return wave::setNormalFormPassPostcondition(wave::WaveNormalForm::None, root,
-                                              /*preserve=*/false);
+  // Actually remove the normal form attribute instead of setting it to None
+  root->removeAttr(wave::WaveDialect::kNormalFormAttrName);
+  return llvm::success();
 }
 
 llvm::LogicalResult

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -708,7 +708,8 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-// CHECK: module attributes {wave.normal_form = #wave.normal_form<none>}
+// CHECK: module {
+// CHECK-NOT: wave.normal_form
 module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
   // CHECK-LABEL: func.func @test_normal_form_cleared
   func.func @test_normal_form_cleared() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {

--- a/wave_lang/kernel/wave/water.py
+++ b/wave_lang/kernel/wave/water.py
@@ -12,7 +12,6 @@ import os
 import subprocess
 import sys
 import math
-import re
 from typing import Any, Sequence
 from functools import lru_cache
 
@@ -539,19 +538,6 @@ def apply_water_middle_end_passes(mlir_text: str) -> str:
             ],
             input=mlir_text,
             text=True,
-        )
-
-        # Clean Wave-specific attributes that cause issues in later pipelines
-        # TODO(#595): do this in the very last pass of water pipeline instead
-        result = re.sub(
-            r",\s*wave\.normal_form\s*=\s*#wave\.normal_form<[^>]*>",
-            "",
-            result,
-        )
-        result = re.sub(
-            r"wave\.normal_form\s*=\s*#wave\.normal_form<[^>]*>,?\s*",
-            "",
-            result,
         )
 
         return result


### PR DESCRIPTION
Remove normal form attributes after applying water middle-end pipeline.

Fixes #595.