### PR TITLE
[CI] remove summary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,23 +88,3 @@ jobs:
       - name: MyPy Type Checking
         run: |
           mypy
-
-  # Depends on all other jobs to provide an aggregate job status.
-  ci_summary:
-    if: always()
-    runs-on: ubuntu-24.04
-    needs:
-      - test
-    steps:
-      - name: Getting failed jobs
-        run: |
-          echo '${{ toJson(needs) }}'
-          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
-            | jq --raw-output \
-            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
-          )"
-          echo "failed-jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-          if [[ "${FAILED_JOBS}" != "" ]]; then
-            echo "The following jobs failed: ${FAILED_JOBS}"
-            exit 1
-          fi


### PR DESCRIPTION
- This extra workflow is just noise. Github is already able to summarize CI results