### PR TITLE
[water] make MMA kind optional

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -119,7 +119,7 @@ def MmaOp : WaveOp<"mma",
     Arg<WaveTensorInRegister, "Left-hand side of the multiplication">:$lhs,
     Arg<WaveTensorInRegister, "Right-hand side of the multiplication">:$rhs,
     Arg<WaveTensorInRegister, "Accumulator for addition">:$accumulator,
-    Arg<WaveMmaKindAttr, "Kind of the MMA intrinsic to target">:$kind
+    Arg<OptionalAttr<WaveMmaKindAttr>, "Kind of the MMA intrinsic to target">:$kind
   ), commonArguments);
 
   let results = (outs

--- a/water/include/water/Dialect/Wave/Transforms/Passes.td
+++ b/water/include/water/Dialect/Wave/Transforms/Passes.td
@@ -137,4 +137,14 @@ def WaterWavePropagateElementsPerThreadPass
   }];
 }
 
+def WaterWavePropagateDefaultsFromConstraintsPass
+    : Pass<"water-wave-propagate-defaults-from-constraints"> {
+  let summary = "Propagate default values from constraints to operations where "
+                "they are not set.";
+  let description = [{
+    Propagates the following values:
+     - `mma_type` is propagate to mma operations that have no `mma_kind` set.
+  }];
+}
+
 #endif // WATER_DIALECT_WAVE_TRANSFORMS_PASSES

--- a/water/include/water/Dialect/Wave/Transforms/Utils.h
+++ b/water/include/water/Dialect/Wave/Transforms/Utils.h
@@ -8,6 +8,12 @@
 
 namespace wave {
 
+// Populates `constraints` with a mapping from an operation with a Wave
+// constraints attribute attached to that attribute.
+llvm::LogicalResult collectWaveConstraints(
+    mlir::Operation *top,
+    llvm::DenseMap<mlir::Operation *, mlir::Attribute> &constraints);
+
 // Sets the attribute indicating that the operation satisfies provided normal
 // forms. The presence of the attribute, in turn, performs verification of the
 // normal form every time a verifier runs on the operation, including by default

--- a/water/lib/Dialect/Wave/Transforms/CMakeLists.txt
+++ b/water/lib/Dialect/Wave/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRWaveTransforms
   LowerReadWriteOps.cpp
   LowerWaveToMLIR.cpp
   TypeConverter.cpp
+  PropagateDefaultsFromConstraints.cpp
   Utils.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -540,9 +540,13 @@ public:
            accType.getRank() == 1 &&
            "only 1-D vectors supported for mma lowering");
 
-    wave::WaveMmaKind kind = op.getKind();
+    std::optional<wave::WaveMmaKind> kind = op.getKind();
+    if (!kind)
+      return rewriter.notifyMatchFailure(
+          op, "mma operation without kind attribute");
+
     auto [M, N, K] =
-        wave::WaveMmaKindAttr::getShape(rewriter.getContext(), kind);
+        wave::WaveMmaKindAttr::getShape(rewriter.getContext(), *kind);
 
     // TODO: Extend lowering for ops beyond MFMA, e.g. WMMA
     auto mfma = mlir::amdgpu::MFMAOp::create(rewriter, loc, acc.getType(),

--- a/water/lib/Dialect/Wave/Transforms/PropagateDefaultsFromConstraints.cpp
+++ b/water/lib/Dialect/Wave/Transforms/PropagateDefaultsFromConstraints.cpp
@@ -1,0 +1,61 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveDialect.h"
+#include "water/Dialect/Wave/IR/WaveOps.h"
+#include "water/Dialect/Wave/Transforms/Passes.h"
+#include "water/Dialect/Wave/Transforms/Utils.h"
+
+#define DEBUG_TYPE "wave-propagate-defaults-from-constraints"
+
+namespace wave {
+#define GEN_PASS_DEF_WATERWAVEPROPAGATEDEFAULTSFROMCONSTRAINTSPASS
+#include "water/Dialect/Wave/Transforms/Passes.h.inc"
+} // namespace wave
+
+using namespace mlir;
+using namespace wave;
+
+namespace {
+
+struct PropagateDefaultsFromConstraints
+    : public wave::impl::WaterWavePropagateDefaultsFromConstraintsPassBase<
+          PropagateDefaultsFromConstraints> {
+  void runOnOperation() override {
+    // Do a first pass looking for constraint top-down and, when found, visiting
+    // all MmaOps to which the constraints apply. Then do a second pass to check
+    // if we missed something. This is practically faster than looking up the
+    // ancestor for every MmaOp.
+    DenseMap<Operation *, Attribute> constraints;
+    if (failed(collectWaveConstraints(getOperation(), constraints)))
+      return signalPassFailure();
+
+    for (auto [op, attr] : constraints) {
+      auto it = llvm::find_if(cast<ArrayAttr>(attr).getValue(),
+                              llvm::IsaPred<HardwareConstraintAttr>);
+      if (it == cast<ArrayAttr>(attr).getValue().end())
+        continue;
+      op->walk([&](MmaOp mmaOp) {
+        if (!mmaOp.getKindAttr())
+          mmaOp.setKindAttr(cast<HardwareConstraintAttr>(*it).getMmaType());
+      });
+    }
+
+    WalkResult walkResult = getOperation()->walk([&](MmaOp mmaOp) {
+      if (mmaOp.getKindAttr())
+        return WalkResult::advance();
+
+      mmaOp.emitError("mma operation without kind attribute and no constraint "
+                      "to derive it from");
+      return WalkResult::interrupt();
+    });
+    if (walkResult.wasInterrupted())
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -560,12 +560,14 @@ def _emit_ops_from_graph(
                         # create YieldOp
                         YieldOp([value_map[output] for output in outputs])
                 elif isinstance(node, MMA):
-                    if node.mma_type is None:
-                        raise RuntimeError("MMA op missing mma_type")
-                    mma_kind = ir.Attribute.parse(
-                        f"#wave.mma_kind<{node.mma_type.name.lower()}>", context=ctx
+                    mma_kind = (
+                        ir.Attribute.parse(
+                            f"#wave.mma_kind<{node.mma_type.name.lower()}>", context=ctx
+                        )
+                        if node.mma_type is not None
+                        else None
                     )
-                    mlir_op = op_builder(result_type, *mlir_operands, mma_kind)
+                    mlir_op = op_builder(result_type, *mlir_operands, kind=mma_kind)
                 elif isinstance(node, Allocate):
                     mlir_op = op_builder(
                         result_type,


### PR DESCRIPTION
It may be missing from the input IR form and we should reflect it. Introduce a pass that propagates the MMA kind from hardware constraints to operations that are missing the attribute. This pass can later be extended to do the same for the elements-per-thread attribute.