### PR TITLE
Move filter_fx_graph utility to _support

### DIFF
--- a/wave_lang/kernel/_support/fx.py
+++ b/wave_lang/kernel/_support/fx.py
@@ -1,0 +1,19 @@
+# Copyright 2025 The Wave Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch.fx as fx
+from typing import Callable
+
+
+def filter_fx_graph(
+    graph: fx.Graph, filter: Callable[[fx.Node], bool]
+) -> list[fx.Node]:
+    """Return a list of nodes in the graph that match the specified predicate."""
+    filtered_nodes: list[fx.Node] = []
+    for node in graph.nodes:
+        if filter(node):
+            filtered_nodes.append(node)
+    return filtered_nodes

--- a/wave_lang/kernel/compiler/kernel_codegen.py
+++ b/wave_lang/kernel/compiler/kernel_codegen.py
@@ -16,12 +16,13 @@ This level handles #2.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Optional, Type
+from typing import Any, Optional, Type
 
 import sympy
 import torch.fx as fx
 
 from wave_lang.kernel._support.dtype import DataType
+from wave_lang.kernel._support.fx import filter_fx_graph
 from wave_lang.support.ir_imports import (
     Block,
     FunctionType,
@@ -89,15 +90,6 @@ def create_argument_locations(bindings: list["BindingDesc"]) -> list[Location]:
 def is_placeholder(node: fx.Node):
     custom = get_custom(node)
     return isinstance(custom, Placeholder)
-
-
-# Util fn to filter nodes in a graph based on specfied filter fn.
-def filter_fx_graph(graph: fx.Graph, filter: Callable[[fx.Node], bool]):
-    filtered_nodes: list[fx.Node] = []
-    for node in graph.nodes:
-        if filter(node):
-            filtered_nodes.append(node)
-    return filtered_nodes
 
 
 class BindingType(Enum):

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from .._support.indexing import IndexSymbol
 from ...support.location_config import LocationCaptureConfig
-from ..compiler.kernel_codegen import KernelBufferUsage
+from ..lang.kernel_buffer import KernelBufferUsage
 from .scheduling.schedule_enums import SchedulingType
 from .utils.classes import KernelLaunchInfo, CoalescingType
 

--- a/wave_lang/kernel/wave/schedule_reordering.py
+++ b/wave_lang/kernel/wave/schedule_reordering.py
@@ -17,7 +17,7 @@ import wave_lang.kernel.lang as tkl
 
 from .._support.tracing import CapturedTrace
 from .._support.location import CapturedLocation
-from ..compiler.kernel_codegen import filter_fx_graph
+from .._support.fx import filter_fx_graph
 from ..lang.global_symbols import *
 from ..ops.wave_ops import (
     MMA,

--- a/wave_lang/kernel/wave/scheduling/scheduler_utils.py
+++ b/wave_lang/kernel/wave/scheduling/scheduler_utils.py
@@ -21,7 +21,7 @@ from .resources import Operation
 from typing import List
 from collections import deque
 from ..utils.classes import GemmOperationType
-from ...compiler.kernel_codegen import filter_fx_graph
+from ..._support.fx import filter_fx_graph
 
 ScheduleStage = TypeVar("ScheduleStage", bound=Enum)
 

--- a/wave_lang/kernel/wave/specialize.py
+++ b/wave_lang/kernel/wave/specialize.py
@@ -49,7 +49,7 @@ from .._support.tracing import CapturedTrace
 from .._support.location import CapturedLocation
 from .._support.indexing import IndexSequence, IndexSymbol, IndexExpr
 
-from ..compiler.kernel_codegen import filter_fx_graph
+from .._support.fx import filter_fx_graph
 from ..lang.global_symbols import *
 from ..ops.wave_ops import (
     MMA,


### PR DESCRIPTION
There is no need to import compiler or kernel codegen, which bring IREE, for a five-line function that filters the node in an FX graph. This will enable us to remove local imports in water.