### PR TITLE
Conditon execution engine test on GPU presence

### DIFF
--- a/tests/unittests/test_execution_engine_wrapper.py
+++ b/tests/unittests/test_execution_engine_wrapper.py
@@ -12,6 +12,7 @@ import gc
 import os
 import pytest
 import weakref
+import torch
 
 from wave_lang.kernel.wave.execution_engine import (
     clear_engine_cache,
@@ -21,8 +22,8 @@ from wave_lang.kernel.wave.execution_engine import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not is_execution_engine_available(),
-    reason="ExecutionEngine not available (C++ extension not built)",
+    not is_execution_engine_available() or (torch.cuda.device_count() < 1),
+    reason="ExecutionEngine not available (C++ extension not built) or no GPU found",
 )
 
 


### PR DESCRIPTION
It doesn't actually require a GPU but it requires the GPU driver to be present, and seing a GPU from torch is a good indicator of that. Otherwise this test throws from C++ on a machine without GPU and aborts the python process.