### PR TITLE
[mlir] hide symbols in libWaterPythonCAPI

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -233,10 +233,9 @@ jobs:
 
       - name: Run LIT tests
         env:
-           WAVE_TEST_WATER: ${{ env.IS_CDNA3 == 'true' && '1' || '0'  }}
+           WAVE_TEST_WATER: ${{ (env.IS_CDNA3 == 'true' || env.is_CDNA4 == 'true')  && '1' || '0'  }}
            WAVE_TEST_DWARFDUMP: ${{ env.IS_RDNA4 == 'false' && '1' || '0' }}
         run: |
-          # TODO: mlir_converter tests segfault on mi35x
           # TODO: can't sudo to install dwarfdump on rdna4
           echo "WAVE_TEST_WATER=$WAVE_TEST_WATER"
           echo "WAVE_TEST_DWARFDUMP=$WAVE_TEST_DWARFDUMP"

--- a/water/python/CMakeLists.txt
+++ b/water/python/CMakeLists.txt
@@ -36,6 +36,8 @@ if (WATER_ENABLE_PYTHON)
       WaterExtensionNanobind.cpp
     EMBED_CAPI_LINK_LIBS
       WaterCAPI
+    PRIVATE_LINK_LIBS
+      LLVMSupport
   )
 
   add_mlir_python_common_capi_library(WaterPythonCAPI
@@ -63,4 +65,29 @@ if (WATER_ENABLE_PYTHON)
     COMMON_CAPI_LINK_LIBS
       WaterPythonCAPI
   )
+
+  if (UNIX)
+    target_compile_options(WaterPythonCAPI
+      PRIVATE "-fvisibility=hidden"
+    )
+    target_link_options(WaterPythonCAPI
+      PRIVATE "-fvisibility=hidden"
+    )
+    if (APPLE)
+      # See https://github.com/numba/numba-mlir/blob/fd9609d81dab96b0658392886ebc470ea2fa4eeb/numba_mlir/numba_mlir/mlir_compiler/CMakeLists.txt#L71
+      message(SEND_ERROR "symbol management not implemented on Darwin")
+    else()
+      target_link_options(WaterPythonCAPI
+        PRIVATE
+        "-Wl,--no-undefined"
+        "-Wl,-z,defs"
+        "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/capi.lds"
+      )
+      set_target_properties(WaterPythonCAPI
+        PROPERTIES
+	LINK_DEPENDS
+	"${CMAKE_CURRENT_SOURCE_DIR}/capi.lds"
+      )
+    endif()
+  endif()
 endif()

--- a/water/python/capi.lds
+++ b/water/python/capi.lds
@@ -1,0 +1,8 @@
+{
+  global:
+    # Bindings symbols should remain visible.
+    mlir*;
+  local:
+    # Hide everything else.
+    *;
+};


### PR DESCRIPTION
Add a cmake configuration to hide all symbols except for the binding symbols when building libWaterPythonCAPI.so on Linux systems. Otherwise these clash with symbols loaded from libLLVM.so by ROCm 7 that unconditionally loads libLLVM.so whenever torch is loaded. Arguably it shouldn't and it's a clutch, but we need to make progress ourselves without waiting for ROCm to figure it out.