### PR TITLE
Separate wave control flow lowering into dedicated pass

### DIFF
--- a/water/include/water/Dialect/Wave/Transforms/Passes.td
+++ b/water/include/water/Dialect/Wave/Transforms/Passes.td
@@ -9,11 +9,24 @@
 
 include "mlir/Pass/PassBase.td"
 
-def LowerWaveToMLIRPass : Pass<"lower-wave-to-mlir"> {
-  let summary = "Lower Wave dialect to upstream MLIR dialects";
+def LowerWaveControlFlowPass : Pass<"lower-wave-control-flow"> {
+  let summary = "Lower Wave control flow operations to SCF";
   let description = [{
-    This pass lowers operations from the Wave dialect to upstream MLIR
-    dialects, notably arith and vector.
+    This pass lowers control flow operations from the Wave dialect to SCF,
+    specifically converting wave.iterate to scf.for. Other Wave operations
+    are left unchanged for subsequent lowering passes.
+  }];
+  let dependentDialects = [
+    "::mlir::scf::SCFDialect",
+  ];
+}
+
+def LowerWaveToMLIRPass : Pass<"lower-wave-to-mlir"> {
+  let summary = "Lower Wave dialect operations to upstream MLIR dialects";
+  let description = [{
+    This pass lowers remaining Wave dialect operations to upstream MLIR
+    dialects, notably arith and vector. Control flow operations should
+    be lowered separately using lower-wave-control-flow.
   }];
   let dependentDialects = [
     "::mlir::arith::ArithDialect",

--- a/water/lib/Dialect/Wave/Transforms/CMakeLists.txt
+++ b/water/lib/Dialect/Wave/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(MLIRWaveTransforms
   InferTypes.cpp
   LoweringPatterns.cpp
   LowerReadWriteOps.cpp
+  LowerWaveControlFlow.cpp
   LowerWaveToMLIR.cpp
   TypeConverter.cpp
   PropagateDefaultsFromConstraints.cpp

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveControlFlow.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveControlFlow.cpp
@@ -1,0 +1,223 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "water/Dialect/Wave/IR/WaveAttrs.h"
+#include "water/Dialect/Wave/IR/WaveDialect.h"
+#include "water/Dialect/Wave/IR/WaveUtils.h"
+#include "water/Dialect/Wave/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "water/Dialect/Wave/IR/WaveOps.h"
+
+#define GEN_PASS_DEF_LOWERWAVECONTROLFLOWPASS
+#include "water/Dialect/Wave/Transforms/Passes.h.inc"
+
+using namespace mlir;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// IterateOp
+//===----------------------------------------------------------------------===//
+
+/// Lower `wave.iterate` to `scf.for`.
+class IterateOpLoweringPattern : public OpConversionPattern<wave::IterateOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(wave::IterateOp op, wave::IterateOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    // Get hyperparameters from the function.
+    func::FuncOp parentFunc = op->getParentOfType<func::FuncOp>();
+    if (!parentFunc) {
+      return rewriter.notifyMatchFailure(op, "iterate op not in function");
+    }
+
+    auto hyperparamAttr =
+        parentFunc->getAttrOfType<wave::WaveHyperparameterAttr>(
+            wave::WaveDialect::kHyperparameterAttrName);
+    if (!hyperparamAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "no hyperparameters found in function");
+    }
+
+    // Get the iterator symbol (e.g., "K").
+    wave::WaveSymbolAttr iteratorSymbol = op.getIterator();
+    StringRef symbolName = iteratorSymbol.getName();
+
+    // Look for tiling constraints in function attributes.
+    ArrayAttr constraints = parentFunc->getAttrOfType<ArrayAttr>(
+        wave::WaveDialect::kWaveConstraintsAttrName);
+    if (!constraints) {
+      return rewriter.notifyMatchFailure(
+          op, "no wave constraints found in function");
+    }
+
+    // Get the dimension size (e.g., K = 640) from hyperparameters.
+    std::optional<SmallVector<int64_t>> resolvedDims =
+        wave::resolveSymbolNames(iteratorSymbol, hyperparamAttr);
+    if (!resolvedDims || resolvedDims->size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "iterator symbol not found in hyperparameters");
+    }
+    int64_t dimSize = resolvedDims->front();
+
+    // Find tiling constraint for this dimension to get tile_size.
+    std::optional<int64_t> tileSize;
+    for (Attribute constraintAttr : constraints) {
+      auto tilingConstraint =
+          dyn_cast<wave::TilingConstraintAttr>(constraintAttr);
+      if (!tilingConstraint)
+        continue;
+
+      wave::WaveSymbolAttr constraintDim = tilingConstraint.getDim();
+      if (constraintDim.getName() != symbolName)
+        continue;
+
+      wave::WaveExprListAttr tileSizeAttr = tilingConstraint.getTileSize();
+      AffineMap tileSizeMap = tileSizeAttr.getMap();
+      ArrayRef<Attribute> tileSizeSymbols = tileSizeAttr.getSymbols();
+
+      // Evaluate the tile size using hyperparameters.
+      std::optional<SmallVector<int64_t>> evaluatedTileSize =
+          wave::evaluateMapWithHyperparams(tileSizeMap, tileSizeSymbols,
+                                           hyperparamAttr);
+      if (!evaluatedTileSize) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to evaluate tile size from tiling constraint");
+      }
+      if (evaluatedTileSize->size() != 1) {
+        return rewriter.notifyMatchFailure(op,
+                                           "tile size must be single value");
+      }
+      tileSize = (*evaluatedTileSize)[0];
+      break;
+    }
+
+    if (!tileSize) {
+      return rewriter.notifyMatchFailure(
+          op, "no tiling constraint found for iterator symbol");
+    }
+
+    // TODO(tyb): we reject non-exact division for now, which should require
+    // peeling or padding to be correct.
+    // TODO(tyb): make these errors better visible to the caller from python.
+    if (*tileSize == 0) {
+      return rewriter.notifyMatchFailure(op, "tile size cannot be zero");
+    }
+    if (dimSize % *tileSize != 0) {
+      return op.emitOpError("non-exact division not supported to prevent "
+                            "potential out-of-bounds access");
+    }
+    int64_t numIterations = dimSize / *tileSize;
+
+    // Create loop bounds.
+    Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value upperBound =
+        rewriter.create<arith::ConstantIndexOp>(loc, numIterations);
+    Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    rewriter.setInsertionPoint(op);
+
+    // Create the scf.for loop.
+    auto forOp = rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step,
+                                             adaptor.getIterArgs());
+
+    // Copy the iterator attribute from wave.iterate to scf.for so that
+    // WaveIndexSequenceInterface can still resolve their iterator symbols.
+    forOp->setAttr("iterator", iteratorSymbol);
+
+    // Convert the body.
+    Block &waveBody = op.getBody().front();
+    Block &scfBody = *forOp.getBody();
+
+    // Set up insertion point inside the loop body.
+    rewriter.setInsertionPointToStart(&scfBody);
+
+    // Create mapping from old block arguments to new ones.
+    IRMapping mapping;
+
+    // Map iter_args.
+    // Note: wave.iterate doesn't expose the induction variable, so we skip it.
+    for (auto [oldArg, newArg] : llvm::zip_equal(
+             waveBody.getArguments(), scfBody.getArguments().drop_front())) {
+      mapping.map(oldArg, newArg);
+    }
+
+    // Clone all operations except the terminator.
+    for (Operation &bodyOp : waveBody.without_terminator()) {
+      rewriter.clone(bodyOp, mapping);
+    }
+
+    // Convert wave.yield to scf.yield.
+    auto yieldOp = cast<wave::YieldOp>(waveBody.getTerminator());
+    SmallVector<Value> yieldValues;
+    yieldValues.reserve(yieldOp.getValues().size());
+    for (Value value : yieldOp.getValues()) {
+      yieldValues.push_back(mapping.lookup(value));
+    }
+    rewriter.create<scf::YieldOp>(yieldOp.getLoc(), yieldValues);
+
+    // Replace the original op with the for loop results.
+    rewriter.replaceOp(op, forOp.getResults());
+
+    return success();
+  }
+};
+
+struct LowerWaveControlFlowPass
+    : public ::impl::LowerWaveControlFlowPassBase<LowerWaveControlFlowPass> {
+  using LowerWaveControlFlowPassBase::LowerWaveControlFlowPassBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, scf::SCFDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    Operation *op = getOperation();
+
+    ConversionTarget target(*ctx);
+    target.addLegalDialect<
+        // clang-format off
+      arith::ArithDialect,
+      func::FuncDialect,
+      scf::SCFDialect,
+      wave::WaveDialect
+        // clang-format on
+        >();
+
+    // Only mark wave.iterate and wave.yield as illegal.
+    target.addIllegalOp<wave::IterateOp, wave::YieldOp>();
+
+    // Mark cloned operations in scf.for body region as legal, as they will be
+    // lowered by lower-wave-to-mlir next.
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+
+    RewritePatternSet patterns(ctx);
+
+    // We don't need a type converter for this pass since we're only
+    // lowering control flow and leaving data types unchanged
+    patterns.add<IterateOpLoweringPattern>(ctx);
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> wave::createLowerWaveControlFlowPass() {
+  return std::make_unique<LowerWaveControlFlowPass>();
+}

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -76,8 +76,8 @@ struct LowerWaveToMLIRPass
         >();
     target.addIllegalOp<wave::AddOp, wave::AllocateOp, wave::CastOp,
                         wave::DivOp, wave::Exp2Op, wave::ExtractSliceOp,
-                        wave::IterateOp, wave::MmaOp, wave::MulOp, wave::ReadOp,
-                        wave::RegisterOp, wave::WriteOp, wave::YieldOp>();
+                        wave::MmaOp, wave::MulOp, wave::ReadOp,
+                        wave::RegisterOp, wave::WriteOp>();
 
     // Mark functions as illegal if they have Wave tensor types in their
     // signature.

--- a/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -361,156 +360,13 @@ public:
   }
 };
 
-//===----------------------------------------------------------------------===//
-// IterateOp
-//===----------------------------------------------------------------------===//
-
-/// Lower `wave.iterate` to `scf.for`.
-class IterateOpLoweringPattern : public OpConversionPattern<wave::IterateOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(wave::IterateOp op, wave::IterateOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-
-    // Get hyperparameters from type converter.
-    auto *waveTypeConverter =
-        static_cast<const wave::WaveTypeConverter *>(getTypeConverter());
-    wave::WaveHyperparameterAttr hyperparams =
-        waveTypeConverter->getHyperparameters();
-
-    // Get the iterator symbol (e.g., "K").
-    wave::WaveSymbolAttr iteratorSymbol = op.getIterator();
-    StringRef symbolName = iteratorSymbol.getName();
-
-    // Find the tiling constraint for this iterator symbol.
-    func::FuncOp parentFunc = op->getParentOfType<func::FuncOp>();
-    if (!parentFunc) {
-      return rewriter.notifyMatchFailure(op, "iterate op not in function");
-    }
-
-    // Look for tiling constraints in function attributes.
-    ArrayAttr constraints = parentFunc->getAttrOfType<ArrayAttr>(
-        wave::WaveDialect::kWaveConstraintsAttrName);
-    if (!constraints) {
-      return rewriter.notifyMatchFailure(
-          op, "no wave constraints found in function");
-    }
-
-    // Get the dimension size (e.g., K = 640) from hyperparameters.
-    std::optional<SmallVector<int64_t>> resolvedDims =
-        wave::resolveSymbolNames(iteratorSymbol, hyperparams);
-    if (!resolvedDims || resolvedDims->size() != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "iterator symbol not found in hyperparameters");
-    }
-    int64_t dimSize = resolvedDims->front();
-
-    // Find tiling constraint for this dimension to get tile_size.
-    std::optional<int64_t> tileSize;
-    for (Attribute constraintAttr : constraints) {
-      auto tilingConstraint =
-          dyn_cast<wave::TilingConstraintAttr>(constraintAttr);
-      if (!tilingConstraint)
-        continue;
-
-      wave::WaveSymbolAttr constraintDim = tilingConstraint.getDim();
-      if (constraintDim.getName() != symbolName)
-        continue;
-
-      wave::WaveExprListAttr tileSizeAttr = tilingConstraint.getTileSize();
-      AffineMap tileSizeMap = tileSizeAttr.getMap();
-      ArrayRef<Attribute> tileSizeSymbols = tileSizeAttr.getSymbols();
-
-      // Evaluate the tile size using hyperparameters.
-      std::optional<SmallVector<int64_t>> evaluatedTileSize =
-          wave::evaluateMapWithHyperparams(tileSizeMap, tileSizeSymbols,
-                                           hyperparams);
-      if (!evaluatedTileSize) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to evaluate tile size from tiling constraint");
-      }
-      if (evaluatedTileSize->size() != 1) {
-        return rewriter.notifyMatchFailure(op,
-                                           "tile size must be single value");
-      }
-      tileSize = (*evaluatedTileSize)[0];
-      break;
-    }
-
-    if (!tileSize) {
-      return rewriter.notifyMatchFailure(
-          op, "no tiling constraint found for iterator symbol");
-    }
-
-    // TODO(tyb): we reject non-exact division for now, which should require
-    // peeling or padding to be correct.
-    // TODO(tyb): make these errors better visible to the caller from python.
-    if (*tileSize == 0) {
-      return rewriter.notifyMatchFailure(op, "tile size cannot be zero");
-    }
-    if (dimSize % *tileSize != 0) {
-      return op.emitOpError("non-exact division not supported to prevent "
-                            "potential out-of-bounds access");
-    }
-    int64_t numIterations = dimSize / *tileSize;
-
-    // Create loop bounds.
-    Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
-    Value upperBound =
-        arith::ConstantIndexOp::create(rewriter, loc, numIterations);
-    Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
-
-    // Create the scf.for loop.
-    auto forOp = scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step,
-                                    adaptor.getIterArgs());
-
-    // Convert the body.
-    Block &waveBody = op.getBody().front();
-    Block &scfBody = *forOp.getBody();
-
-    // Set up insertion point inside the loop body.
-    rewriter.setInsertionPointToStart(&scfBody);
-
-    // Create mapping from old block arguments to new ones.
-    IRMapping mapping;
-
-    // Map iter_args.
-    // Note: wave.iterate doesn't expose the induction variable, so we skip it.
-    for (auto [oldArg, newArg] : llvm::zip_equal(
-             waveBody.getArguments(), scfBody.getArguments().drop_front())) {
-      mapping.map(oldArg, newArg);
-    }
-
-    // Clone all operations except the terminator.
-    for (Operation &bodyOp : waveBody.without_terminator()) {
-      rewriter.clone(bodyOp, mapping);
-    }
-
-    // Convert wave.yield to scf.yield.
-    auto yieldOp = cast<wave::YieldOp>(waveBody.getTerminator());
-    SmallVector<Value> yieldValues;
-    yieldValues.reserve(yieldOp.getValues().size());
-    for (Value value : yieldOp.getValues()) {
-      yieldValues.push_back(mapping.lookup(value));
-    }
-    scf::YieldOp::create(rewriter, yieldOp.getLoc(), yieldValues);
-
-    // Replace the original op with the for loop results.
-    rewriter.replaceOp(op, forOp.getResults());
-
-    return success();
-  }
-};
 
 } // namespace
 
 void wave::populateWaveMiscellaneousOpsLoweringPatterns(
     WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<CastOpLoweringPattern, ExtractSliceOpLoweringPattern,
-               IterateOpLoweringPattern, RegisterOpLoweringPattern>(
+               RegisterOpLoweringPattern>(
       typeConverter, patterns.getContext());
 }
 

--- a/water/test/Dialect/Wave/lower-wave-control-flow.mlir
+++ b/water/test/Dialect/Wave/lower-wave-control-flow.mlir
@@ -1,0 +1,148 @@
+// RUN: water-opt %s -allow-unregistered-dialect -lower-wave-control-flow --mlir-print-local-scope --split-input-file --verify-diagnostics | FileCheck %s
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @lower_iterate() attributes {
+    wave.hyperparameters = #wave.hyperparameters<{K = 64, M = 64, BLOCK_K = 16}>,
+    wave.constraints = [
+      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
+    ]
+  } {
+    %alloc = memref.alloc() : memref<64xf32, #gpu.address_space<workgroup>>
+    %0 = builtin.unrealized_conversion_cast %alloc : memref<64xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@M] of f32, <shared>>
+
+    // CHECK-LABEL: func.func @lower_iterate
+    // CHECK-NOT: wave.iterate
+    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
+    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
+    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
+    // CHECK:     %{{.*}} = scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (!wave.tensor<[@M] of f32, <shared>>) {
+    // CHECK:       scf.yield %{{.*}} : !wave.tensor<[@M] of f32, <shared>>
+    // CHECK:     } {iterator = #wave.symbol<"K">}
+    %result = wave.iterate @K iter_args(%0) {
+    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
+      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
+    } : (!wave.tensor<[@M] of f32, <shared>>) -> (!wave.tensor<[@M] of f32, <shared>>)
+
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @lower_iterate_with_operations() attributes {
+    wave.hyperparameters = #wave.hyperparameters<{K = 64, M = 32, BLOCK_K = 16}>,
+    wave.constraints = [
+      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
+    ]
+  } {
+    %alloc = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+    %0 = builtin.unrealized_conversion_cast %alloc : memref<32xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@M] of f32, <shared>>
+
+    // CHECK-LABEL: func.func @lower_iterate_with_operations
+    // CHECK-NOT: wave.iterate
+    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
+    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
+    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
+    // CHECK:     %{{.*}} = scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (!wave.tensor<[@M] of f32, <shared>>) {
+    // CHECK:       %{{.*}} = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+    // CHECK:       scf.yield %{{.*}} : !wave.tensor<[@M] of f32, <shared>>
+    // CHECK:     } {iterator = #wave.symbol<"K">}
+    %result = wave.iterate @K iter_args(%0) {
+    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
+      %alloc_new = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
+    } : (!wave.tensor<[@M] of f32, <shared>>) -> (!wave.tensor<[@M] of f32, <shared>>)
+
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @lower_iterate_with_iter_args() attributes {
+    wave.hyperparameters = #wave.hyperparameters<{K = 64, M = 32, BLOCK_K = 16}>,
+    wave.constraints = [
+      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
+    ]
+  } {
+    %alloc = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+    %0 = builtin.unrealized_conversion_cast %alloc : memref<32xf32, #gpu.address_space<workgroup>> to !wave.tensor<[@M] of f32, <shared>>
+    %cst = arith.constant 0.0 : f32
+    %1 = wave.register %cst : vector<4xf32>
+
+    // CHECK-LABEL: func.func @lower_iterate_with_iter_args
+    // CHECK-NOT: wave.iterate
+    // CHECK:     %{{.*}} = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (!wave.tensor<[@M] of f32, <shared>>, vector<4xf32>) {
+    // CHECK:       scf.yield %{{.*}}, %{{.*}} : !wave.tensor<[@M] of f32, <shared>>, vector<4xf32>
+    // CHECK:     } {iterator = #wave.symbol<"K">}
+    %result:2 = wave.iterate @K iter_args(%0, %1) {
+    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>, %arg1: vector<4xf32>):
+      wave.yield %arg0, %arg1 : !wave.tensor<[@M] of f32, <shared>>, vector<4xf32>
+    } : (!wave.tensor<[@M] of f32, <shared>>, vector<4xf32>) -> (!wave.tensor<[@M] of f32, <shared>>, vector<4xf32>)
+
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @lower_iterate_allocate() attributes {
+    wave.hyperparameters = #wave.hyperparameters<{K = 128, BLOCK_K = 32, M = 64}>,
+    wave.constraints = [
+      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
+    ]
+  } {
+    %alloc = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
+      : !wave.tensor<[@M] of f32, <shared>>
+
+    // CHECK-LABEL: func.func @lower_iterate_allocate
+    // CHECK-NOT: wave.iterate
+    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
+    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
+    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
+    // CHECK:     %{{.*}} = scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (!wave.tensor<[@M] of f32, <shared>>) {
+    // CHECK:       scf.yield %{{.*}} : !wave.tensor<[@M] of f32, <shared>>
+    // CHECK:     } {iterator = #wave.symbol<"K">}
+    %result = wave.iterate @K iter_args(%alloc) {
+    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
+      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
+    } : (!wave.tensor<[@M] of f32, <shared>>) -> (!wave.tensor<[@M] of f32, <shared>>)
+
+    return
+  }
+}
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+  func.func @lower_iterate_with_allocate_inside() attributes {
+    wave.hyperparameters = #wave.hyperparameters<{K = 64, BLOCK_K = 16, M = 32}>,
+    wave.constraints = [
+      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
+    ]
+  } {
+    %alloc = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
+      : !wave.tensor<[@M] of f32, <shared>>
+
+    // CHECK-LABEL: func.func @lower_iterate_with_allocate_inside
+    // CHECK-NOT: wave.iterate
+    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
+    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
+    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
+    // CHECK:     %{{.*}} = scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (!wave.tensor<[@M] of f32, <shared>>) {
+    // CHECK:       %{{.*}} = wave.allocate {distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)>} : <[@M] of f32, <shared>>
+    // CHECK:       scf.yield %{{.*}} : !wave.tensor<[@M] of f32, <shared>>
+    // CHECK:     } {iterator = #wave.symbol<"K">}
+    %result = wave.iterate @K iter_args(%alloc) {
+    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
+      %temp = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
+        : !wave.tensor<[@M] of f32, <shared>>
+      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
+    } : (!wave.tensor<[@M] of f32, <shared>>) -> (!wave.tensor<[@M] of f32, <shared>>)
+
+    return
+  }
+}

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -665,66 +665,6 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
   }
 }
 
-// -----
-
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
-  // CHECK-LABEL: func.func @lower_iterate
-  func.func @lower_iterate() attributes {
-    wave.hyperparameters = #wave.hyperparameters<{K = 128, BLOCK_K = 32, M = 64}>,
-    wave.constraints = [
-      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
-    ]
-  } {
-    %alloc = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
-      : !wave.tensor<[@M] of f32, <shared>>
-
-    // CHECK-NOT: wave.iterate
-    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
-    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
-    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
-    // CHECK:     scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (memref<64xf32, #gpu.address_space<workgroup>>) {
-    // CHECK:       scf.yield %{{.*}} : memref<64xf32, #gpu.address_space<workgroup>>
-    // CHECK:     }
-    %result = wave.iterate @K iter_args(%alloc) {
-    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
-      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
-    } : (!wave.tensor<[@M] of f32, <shared>>) -> !wave.tensor<[@M] of f32, <shared>>
-
-    return
-  }
-}
-
-// -----
-
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
-  // CHECK-LABEL: func.func @lower_iterate_with_operations
-  func.func @lower_iterate_with_operations() attributes {
-    wave.hyperparameters = #wave.hyperparameters<{K = 64, BLOCK_K = 16, M = 32}>,
-    wave.constraints = [
-      #wave.tiling_constraint<dim = <"K">, tile_size = <[#wave.symbol<"BLOCK_K">] -> (BLOCK_K)>>
-    ]
-  } {
-    %alloc = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
-      : !wave.tensor<[@M] of f32, <shared>>
-
-    // CHECK-NOT: wave.iterate
-    // CHECK:     %[[LB:.*]] = arith.constant 0 : index
-    // CHECK:     %[[UB:.*]] = arith.constant 4 : index
-    // CHECK:     %[[STEP:.*]] = arith.constant 1 : index
-    // CHECK:     scf.for %{{.*}} = %[[LB]] to %[[UB]] step %[[STEP]] iter_args(%{{.*}} = %{{.*}}) -> (memref<32xf32, #gpu.address_space<workgroup>>) {
-    // CHECK:       %[[TEMP:.*]] = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
-    // CHECK:       scf.yield %{{.*}} : memref<32xf32, #gpu.address_space<workgroup>>
-    // CHECK:     }
-    %result = wave.iterate @K iter_args(%alloc) {
-    ^bb0(%arg0: !wave.tensor<[@M] of f32, <shared>>):
-      %temp = wave.allocate { distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)> }
-        : !wave.tensor<[@M] of f32, <shared>>
-      wave.yield %arg0 : !wave.tensor<[@M] of f32, <shared>>
-    } : (!wave.tensor<[@M] of f32, <shared>>) -> !wave.tensor<[@M] of f32, <shared>>
-
-    return
-  }
-}
 
 // -----
 
@@ -787,3 +727,4 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
     func.return %alloc : memref<32x32xf32>
   }
 }
+

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -228,10 +228,10 @@ func.func @mma_elements_per_thread_interface_explicit() attributes {
   %rhs_init = arith.constant 2.0 : f16
   %acc_init = arith.constant 0.0 : f32
 
-  // Create register values with explicit elements_per_thread.
-  %lhs = wave.register %lhs_init {elements_per_thread = 8} : !wave.tensor<[@M, @K] of f16, <register>>
-  %rhs = wave.register %rhs_init {elements_per_thread = 8} : !wave.tensor<[@N, @K] of f16, <register>>
-  %acc = wave.register %acc_init {elements_per_thread = 16} : !wave.tensor<[@M, @N] of f32, <register>>
+  // Create register values - elements_per_thread determined by MMA backward propagation.
+  %lhs = wave.register %lhs_init : !wave.tensor<[@M, @K] of f16, <register>>
+  %rhs = wave.register %rhs_init : !wave.tensor<[@N, @K] of f16, <register>>
+  %acc = wave.register %acc_init : !wave.tensor<[@M, @N] of f32, <register>>
 
   // CHECK: wave.mma {{.*}} {kind = #wave.mma_kind<f32_32x32x8_f16>}
   // f32_32x32x8_f16: 32*32/64 threads = 16 elements per thread.
@@ -254,9 +254,9 @@ func.func @mma_elements_per_thread_32_threads_explicit() attributes {
   %rhs_init = arith.constant 2.0 : f16
   %acc_init = arith.constant 0.0 : f32
 
-  // Create register values with explicit elements_per_thread.
-  %lhs = wave.register %lhs_init {elements_per_thread = 8} : !wave.tensor<[@M, @K] of f16, <register>>
-  %rhs = wave.register %rhs_init {elements_per_thread = 8} : !wave.tensor<[@N, @K] of f16, <register>>
+  // Create register values - elements_per_thread determined by MMA backward propagation.
+  %lhs = wave.register %lhs_init : !wave.tensor<[@M, @K] of f16, <register>>
+  %rhs = wave.register %rhs_init : !wave.tensor<[@N, @K] of f16, <register>>
   %acc = wave.register %acc_init {elements_per_thread = 8} : !wave.tensor<[@M, @N] of f32, <register>>
 
   // CHECK: wave.mma {{.*}} {kind = #wave.mma_kind<f32_16x16x16_f16>}


### PR DESCRIPTION
Creates a new LowerWaveControlFlowPass that specifically handles wave.iterate -> scf.for conversion, avoiding the issue where mixed lowering was creating unlegalizable IR.

The problem is that if LowerWaveToMLIRPass tries to do both:
1. Control flow lowering (wave.iterate -> scf.for)
2. Operation lowering (wave.read, wave.mma, etc. -> standard ops)

This will cause ` wave.iterate` bodies to be cloned with unconverted wave operations inside `scf.for` loops, creating IR that couldn't be legalized.

The solution separates the pipeline into two phases:
1. LowerWaveControlFlowPass: wave.iterate -> scf.for (leaves other wave ops unchanged)
2. LowerWaveToMLIRPass: Remaining wave ops -> standard MLIR ops

This enables a clean two-phase lowering pipeline where control flow is handled first, then remaining wave operations are lowered in the standard `scf.for` context.