### PR TITLE
Optionally perform invocation under global lock

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -230,12 +230,12 @@ jobs:
       - name: Run e2e tests on AMD GPU
         if: ${{ env.HAS_GPU == 'true' && (github.event_name == 'pull_request') }}
         run: |
-          WAVE_CACHE_ON=0 pytest -n 4 --timeout=300 --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/
+          WAVE_CACHE_ON=0 WAVE_KERNEL_INVOCATION_UNDER_MUTEX=1 pytest -n 16 --timeout=300 --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/
 
       - name: Run expensive e2e tests on AMD GPU
         if: ${{ env.HAS_GPU == 'true' && (github.event_name != 'pull_request') }}
         run: |
-          WAVE_CACHE_ON=0 pytest -n 4 --timeout=600 --capture=tee-sys -vv --run-e2e --run-expensive-tests --durations=100 ./tests/kernel/
+          WAVE_CACHE_ON=0 WAVE_KERNEL_INVOCATION_UNDER_MUTEX=1 pytest -n 16 --timeout=600 --capture=tee-sys -vv --run-e2e --run-expensive-tests --durations=100 ./tests/kernel/
 
       - name: Run LIT tests
         env:


### PR DESCRIPTION
This may help with potentially racy behavior of the driver when we attempt to parallelize tests.

** DO NOT MERGE **