### PR TITLE
Fix `pytest.ini` warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-testspath = ./tests
+testpaths =
+  ./tests
 filterwarnings =
   # TODO: Remove once flatbuffer 'imp' usage resolved.
   ignore::DeprecationWarning


### PR DESCRIPTION
There is no option `testspath`, I assume `testpaths` was intended.