### PR TITLE
Use reasonable upper bounds for dynamic gpu ids

### DIFF
--- a/tests/kernel/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave_gemm_mxfp_test.py
@@ -399,7 +399,7 @@ def testScaledBatchedGemmMXFP4Codegen(use_water_backend: bool, tmp_path: Path):
     if use_water_backend:
         vgpr_count = 140
         vgpr_spill_count = 0
-        sgpr_count = 59
+        sgpr_count = 58
         sgpr_spill_count = 0
         waitcounts = [
             "s_waitcnt lgkmcnt(0)",
@@ -423,7 +423,7 @@ def testScaledBatchedGemmMXFP4Codegen(use_water_backend: bool, tmp_path: Path):
     else:
         vgpr_count = 162
         vgpr_spill_count = 0
-        sgpr_count = 60
+        sgpr_count = 59
         sgpr_spill_count = 0
         waitcounts = [
             "s_waitcnt lgkmcnt(0)",
@@ -433,7 +433,6 @@ def testScaledBatchedGemmMXFP4Codegen(use_water_backend: bool, tmp_path: Path):
             "s_waitcnt lgkmcnt(7)",
             "s_waitcnt lgkmcnt(6)",
             "s_waitcnt lgkmcnt(5)",
-            "s_waitcnt lgkmcnt(4)",
             "s_waitcnt lgkmcnt(3)",
             "s_waitcnt lgkmcnt(1)",
             "s_waitcnt lgkmcnt(0)",

--- a/wave_lang/kernel/compiler/wave_codegen/emitter.py
+++ b/wave_lang/kernel/compiler/wave_codegen/emitter.py
@@ -80,10 +80,9 @@ logger = get_logger("wave.ops_location_check")
 
 def _get_upper_bound(expr: Any) -> Optional[Attribute]:
     res = subs_idxc(expr)
-    if is_literal(res):
-        return IntegerAttr.get(IndexType.get(), int(res))
-    else:
-        return None
+    # If bound is not statically known, use signed i32 max.
+    bound = int(res) if is_literal(res) else (1 << 31) - 1
+    return IntegerAttr.get(IndexType.get(), bound)
 
 
 @dataclass


### PR DESCRIPTION
It helps integer-range-analysis somewhat.