### PR TITLE
[water] harden WaveIndexMappingAttr

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -401,19 +401,20 @@ def WaveIndexMappingAttr : AttrDef<WaveDialect, "WaveIndexMapping"> {
     "::mlir::AffineMap":$stride
   );
 
+  let builders = [
+    AttrBuilder<(ins "::llvm::ArrayRef<::mlir::Attribute>":$symbols,
+                 "::mlir::AffineMap":$start,
+                 "::mlir::AffineMap":$step,
+                 "::mlir::AffineMap":$stride)>
+  ];
+
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
+  let skipDefaultBuilders = 1;
 
   let extraClassDeclaration = [{
     // Return a new mapping with all uses of the given input removed.
     ::wave::WaveIndexMappingAttr removeInput(::mlir::Attribute input) const;
-
-    // Return positions of symbols that are used in any of the expressions in
-    // this mapping. They are not returned in any particular order.
-    ::llvm::SmallVector<unsigned> getUsedSymbolPositions() const;
-
-    // Return a copy of the mapping with unused symbols removed.
-    ::wave::WaveIndexMappingAttr removeUnusedInputs() const;
   }];
 }
 

--- a/water/lib/Dialect/Wave/IR/IndexExpr.cpp
+++ b/water/lib/Dialect/Wave/IR/IndexExpr.cpp
@@ -87,9 +87,8 @@ namespace wave {
 
 WaveIndexMappingAttr applyConstraint(WorkgroupConstraintAttr constraint,
                                      WaveIndexMappingAttr baseMapping) {
-  llvm::SmallVector<Attribute> symbols =
-      llvm::map_to_vector(constraint.getTileSize().getSymbols(),
-                          [](Attribute symbol) { return symbol; });
+  llvm::SmallVector<mlir::Attribute> symbols =
+      llvm::to_vector(constraint.getTileSize().getSymbols());
 
   MLIRContext *context = constraint.getContext();
 

--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -791,9 +791,8 @@ struct MmaIndexingExprBuilder {
     };
     auto buildOne = [&](const MmaSingleIndexExprBuilder &builder) {
       return wave::WaveIndexMappingAttr::get(
-                 ctx, symbols, buildMap(builder.offsetExpr),
-                 buildMap(builder.sizeExpr), buildMap(builder.strideExpr))
-          .removeUnusedInputs();
+          ctx, symbols, buildMap(builder.offsetExpr),
+          buildMap(builder.sizeExpr), buildMap(builder.strideExpr));
     };
 
     if (mSymbol)

--- a/water/test/Dialect/Wave/attr-type-invalid.mlir
+++ b/water/test/Dialect/Wave/attr-type-invalid.mlir
@@ -27,3 +27,103 @@ module attributes {wave.unexpected = 42} {}
 
 // expected-error @below {{symbols names starting with '_' are reserved for internal use}}
 module attributes {wave_test.symbol = #wave.symbol<"_A">}
+
+// -----
+
+// expected-error @below {{start map should have exactly one result, got 2}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0, s0 + 1)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{step map should have exactly one result, got 2}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<()[s0] -> (s0, s0 + 1)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{stride map should have exactly one result, got 2}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0, s0 + 1)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{start map should have the same number of symbols as given to the attribute, got 2 symbols for 1 symbols}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0, s1] -> (s0)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{step map should have the same number of symbols as given to the attribute, got 2 symbols for 1 symbols}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<()[s0, s1] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{stride map should have the same number of symbols as given to the attribute, got 2 symbols for 1 symbols}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<()[s0, s1] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{start map should have no dimensions, got 1 dimensions}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<(d0)[s0] -> (s0)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{step map should have no dimensions, got 1 dimensions}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<(d0)[s0] -> (s0)>,
+  stride = affine_map<()[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{stride map should have no dimensions, got 1 dimensions}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>],
+  start = affine_map<()[s0] -> (s0)>,
+  step = affine_map<()[s0] -> (s0)>,
+  stride = affine_map<(d0)[s0] -> (s0)>
+} : () -> ()
+
+// -----
+
+// expected-error @below {{duplicate symbol: #wave.index_symbol<WG0>}}
+"wave_test.create_index_mapping"() {
+  symbols = [#wave.index_symbol<WG0>, #wave.index_symbol<WG0>],
+  start = affine_map<()[s0, s1] -> (s0)>,
+  step = affine_map<()[s0, s1] -> (s0)>,
+  stride = affine_map<()[s0, s1] -> (s0)>
+} : () -> ()

--- a/water/test/Dialect/Wave/attr-type.mlir
+++ b/water/test/Dialect/Wave/attr-type.mlir
@@ -24,5 +24,46 @@ func.func private @iter_symbol_in_mapping() attributes { wave_test.index = #wave
 // CHECK: #wave<index_mapping[#wave.symbol<"A">] -> (<NULL>, A, <NULL>)>
 func.func private @null_exprs_in_mapping() attributes { wave_test.index = #wave<index_mapping[#wave.symbol<"A">] -> (<NULL>, A, <NULL>)>}
 
+// CHECK: #wave<index_mapping[#wave.symbol<"B">] -> (B, 0, 0)>
+func.func private @mapping_with_unused_symbols() attributes { wave_test.index = #wave<index_mapping[#wave.symbol<"A">, #wave.symbol<"B">, #wave.symbol<"C">] -> (B, 0, 0)>}
+
+// Nit: we do ceildiv 2 on the first value to avoid having a subexpression directly
+// adding two symbols since there is a pesky "canonicalization" that would reorder them
+// based on commutativity of addition inside the affine expression constructor.
+// CHECK: #wave<index_mapping
+// CHECK:   #wave.index_symbol<WG0>
+// CHECK:   #wave.index_symbol<T0>
+// CHECK:   #wave.index_symbol<T1>
+// CHECK:   #wave.index_symbol<T2>
+// CHECK:   #wave.iter<"I">
+// CHECK:   #wave.iter<"J">
+// CHECK:   #wave.symbol<"A">
+// CHECK:   #wave.symbol<"B">
+// CHECK: B ceildiv 2 + A + _Iter_J + _Iter_I + T2 + T0 + T1 + WG0
+func.func private @mapping_reorder_symbols() attributes { wave_test.index = #wave<index_mapping[
+    #wave.symbol<"B">, #wave.symbol<"A">,
+    #wave.iter<"J">, #wave.iter<"I">,
+    #wave.index_symbol<T2>, #wave.index_symbol<T0>, #wave.index_symbol<T1>, #wave.index_symbol<WG0>] -> (B ceildiv 2 + A + _Iter_J + _Iter_I + T2 + T0 + T1 + WG0, 1, 1)>}
+
+// CHECK: #wave<index_mapping
+// CHECK:   #wave.index_symbol<WG0>
+// CHECK:   #wave.index_symbol<T2>
+// CHECK:   #wave.iter<"I">
+// CHECK:   #wave.symbol<"B">
+// CHECK: B ceildiv 2 + _Iter_I + T2 + WG0
+func.func private @mapping_reorder_and_unused_symbols() attributes { wave_test.index = #wave<index_mapping[
+    #wave.symbol<"B">, #wave.symbol<"A">,
+    #wave.iter<"J">, #wave.iter<"I">,
+    #wave.index_symbol<T2>, #wave.index_symbol<T0>, #wave.index_symbol<T1>, #wave.index_symbol<WG0>] -> ((B ceildiv 2) + _Iter_I + T2 + WG0, 1, 1)>}
+
+
+// CHECK: #wave<index_mapping
+// CHECK:   #wave.symbol<"A">
+// CHECK:   #wave.symbol<"B">
+// CHECK: A ceildiv B + B - A
+func.func private @mapping_duplicate_symbols() attributes { wave_test.index = #wave<index_mapping[
+    #wave.symbol<"B">, #wave.symbol<"A">,
+    #wave.symbol<"A">, #wave.iter<"B">] -> (A ceildiv B + B - A, 1, 1)> }
+
 // CHECK: #wave.expr_list<[#wave.iter<"A">, #wave.symbol<"B">] -> (_Iter_A + B)>
 func.func private @iter_symbol_in_expr() attributes { wave_test.index = #wave.expr_list<[#wave.iter<"A">, #wave.symbol<"B">] -> (_Iter_A + B)>}

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -366,11 +366,11 @@ func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes 
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
-      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
+      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 8)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
+      N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
      : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
      // CHECK: %[[VEC:.+]] = vector.load {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
 
@@ -388,11 +388,11 @@ func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <glo
     // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
     // Note: BLOCK_M = 64
     // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 * 8)>()[%[[BIDX_X]], %[[TIDX_X]]]
-    M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 * 8 , 8, 64),
-    // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+    M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 * 8 , 8, 64),
     // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
-    // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-    N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}]
+    // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+    // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 8)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
+    N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}]
     : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
     // CHECK: %[[PAD:.*]] = arith.constant {{.*}} : f16
     // CHECK: vector.transfer_read {{.*}}[%[[ROW]], %[[COL]]], %[[PAD]] {permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
@@ -411,7 +411,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
         // CHECK: %[[BIDX_X:.*]] = gpu.block_id x
         // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
         // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1)>()[%[[BIDX_X]], %[[TIDX_X]]]
-        M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 * BLOCK_M + T0, 1, 64),
+        M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (WG0 * BLOCK_M + T0, 1, 64),
         // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
         // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
         // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 32)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
@@ -449,7 +449,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
   func.func @lower_read_masked_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 100, N = 50}>} {
     %v = wave.read %mem index [{
-        M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 * BLOCK_M + T0, 8, 64),
+        M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (WG0 * BLOCK_M + T0, 8, 64),
         N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + T1 * 32, 1, 1)
       }] { bounds = #wave.read_write_bounds<{
         M = #wave.expr_list<[#wave.symbol<"M">] -> (M)>,
@@ -494,11 +494,11 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
-      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
+      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 8)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
+      N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, BLOCK_N ceildiv 8, 1)}]
      : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
      // CHECK: vector.store {{.*}}[%[[ROW]], %[[COL]]] : memref<{{.*}}xf16{{.*}}>, vector<8xf16>
      // CHECK-NOT: vector.transfer_write
@@ -518,11 +518,11 @@ func.func @lower_write_non_innermost(%mem: !wave.tensor<[@M, @N] of f16, <global
       // CHECK: %[[TIDX_X:.*]] = gpu.thread_id x
       // Note: BLOCK_M = 64
       // CHECK: %[[ROW:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + s1 mod 64)>()[%[[BIDX_X]], %[[TIDX_X]]]
-      M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 8, 64),
-      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 8, 64),
       // CHECK: %[[BIDX_Y:.*]] = gpu.block_id y
-      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s1 * 64 + s0 * 8)>()[%[[TIDX_Y]], %[[BIDX_Y]]]
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}]
+      // CHECK: %[[TIDX_Y:.*]] = gpu.thread_id y
+      // CHECK: %[[COL:.*]] = affine.apply affine_map<()[s0, s1] -> (s0 * 64 + s1 * 8)>()[%[[BIDX_Y]], %[[TIDX_Y]]]
+      N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}]
      : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
      // CHECK: vector.transfer_write {{.*}}, {{.*}}[{{.*}}, {{.*}}] {permutation_map = affine_map<(d0, d1) -> (d0)>} : vector<8xf16>, memref<{{.*}}xf16{{.*}}>
 

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -294,7 +294,7 @@ func.func @index_attr_wrong_value_type(%arg0: f32) {
 
 func.func @index_attr_iter_not_allowed(%arg0: f32) {
   // expected-error @below {{index expression uses iterator symbol M which is not defined by any parent op}}
-  wave.register %arg0 index [{M : [#wave.iter<"M">] -> (0, 1, 1)}] : !wave.tensor<[@M] of f32, <register>>
+  wave.register %arg0 index [{M : [#wave.iter<"M">] -> (_Iter_M, 1, 1)}] : !wave.tensor<[@M] of f32, <register>>
   return
 }
 

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -44,7 +44,7 @@ with ir.Context() as ctx:
     else:
         assert False, "Expected to fail with TypeError."
 
-    # CHECK: #wave<index_mapping[#wave.index_symbol<WG0>, #wave.symbol<"BLOCK_M">, #wave.index_symbol<T0>] -> (WG0 * 3, WG0 + BLOCK_M, T0 mod WG0)>
+    # CHECK: #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (WG0 * 3, WG0 + BLOCK_M, T0 mod WG0)>
     symbols = [
         wave.WaveIndexSymbolAttr.get(wave.WaveIndexSymbol.WORKGROUP_0),
         wave.WaveSymbolAttr.get("BLOCK_M"),
@@ -64,10 +64,12 @@ with ir.Context() as ctx:
     # CHECK: ()[s0, s1, s2] -> (s0 * 3)
     print(index_mapping_attr.start)
 
-    # CHECK: ()[s0, s1, s2] -> (s0 + s1)
+    # Note that symbols were reordered to ensure a consistent order in the
+    # mapping, in particular s1 and s2 were swapped.
+    # CHECK: ()[s0, s1, s2] -> (s0 + s2)
     print(index_mapping_attr.step)
 
-    # CHECK: ()[s0, s1, s2] -> (s2 mod s0)
+    # CHECK: ()[s0, s1, s2] -> (s1 mod s0)
     print(index_mapping_attr.stride)
 
     # CHECK: 3
@@ -77,10 +79,10 @@ with ir.Context() as ctx:
     # CHECK: #wave.index_symbol<WG0>
     print(retrieved_symbols[0])
 
-    # CHECK: #wave.symbol<"BLOCK_M">
+    # CHECK: #wave.index_symbol<T0>
     print(retrieved_symbols[1])
 
-    # CHECK: #wave.index_symbol<T0>
+    # CHECK: #wave.symbol<"BLOCK_M">
     print(retrieved_symbols[2])
 
     try:

--- a/water/test/lib/Transforms/TestWaveDialectFunctions.cpp
+++ b/water/test/lib/Transforms/TestWaveDialectFunctions.cpp
@@ -55,19 +55,59 @@ static llvm::LogicalResult testCreateTensor(Operation *op) {
   return llvm::failure(type == nullptr);
 }
 
+static llvm::LogicalResult testCreateIndexMapping(mlir::Operation *op) {
+  const static llvm::StringLiteral kSymbols = "symbols";
+  const static llvm::StringLiteral kStart = "start";
+  const static llvm::StringLiteral kStep = "step";
+  const static llvm::StringLiteral kStride = "stride";
+
+  auto symbolsAttr = op->getAttrOfType<mlir::ArrayAttr>(kSymbols);
+  if (!symbolsAttr)
+    return op->emitOpError()
+           << "expected the \"" << kSymbols << "\" array attribute";
+
+  auto startAttr = op->getAttrOfType<mlir::AffineMapAttr>(kStart);
+  if (!startAttr)
+    return op->emitOpError()
+           << "expected the \"" << kStart << "\" affine map attribute";
+
+  auto stepAttr = op->getAttrOfType<mlir::AffineMapAttr>(kStep);
+  if (!stepAttr)
+    return op->emitOpError()
+           << "expected the \"" << kStep << "\" affine map attribute";
+
+  auto strideAttr = op->getAttrOfType<mlir::AffineMapAttr>(kStride);
+  if (!strideAttr)
+    return op->emitOpError()
+           << "expected the \"" << kStride << "\" affine map attribute";
+
+  return llvm::success(wave::WaveIndexMappingAttr::getChecked(
+                           op->getLoc(), op->getContext(),
+                           symbolsAttr.getValue(), startAttr.getValue(),
+                           stepAttr.getValue(),
+                           strideAttr.getValue()) != nullptr);
+}
+
 class TestWaveDialectFunctionsPass
     : public mlir::water::test::impl::TestWaveDialectFunctionsPassBase<
           TestWaveDialectFunctionsPass> {
 public:
   void runOnOperation() override {
-    OperationName createTensorOpName("wave_test.create_tensor", &getContext());
-    WalkResult walkResult = getOperation()->walk([&](Operation *op) {
-      if (op->getName() == createTensorOpName) {
-        if (failed(testCreateTensor(op)))
-          return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
+    mlir::OperationName createTensorOpName("wave_test.create_tensor",
+                                           &getContext());
+    mlir::OperationName createIndexMappingOpName(
+        "wave_test.create_index_mapping", &getContext());
+    mlir::WalkResult walkResult =
+        getOperation()->walk([&](mlir::Operation *op) {
+          if (op->getName() == createTensorOpName) {
+            if (failed(testCreateTensor(op)))
+              return mlir::WalkResult::interrupt();
+          } else if (op->getName() == createIndexMappingOpName) {
+            if (failed(testCreateIndexMapping(op)))
+              return mlir::WalkResult::interrupt();
+          }
+          return mlir::WalkResult::advance();
+        });
     if (walkResult.wasInterrupted())
       return signalPassFailure();
 


### PR DESCRIPTION
Add multiple verifiers on the invariants we always had but did not enforce
(potentially dropped by accident during refactoring). Sort symbols on
construction to ensure symbolically equal maps with different positions compare
as equal.

Signed-off-by: Alex Zinenko <git@ozinenko.com>