### PR TITLE
[water] Use distributed shape when accessing allocated LDS

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -270,6 +270,36 @@ def AllocateOp : WaveOp<"allocate"> {
     " (`in` $parent^ `:` type($parent))? attr-dict `:` type($result)";
 
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns true if this is a parent allocation (flat buffer with no index expressions).
+    /// Parent allocations have the following characteristics:
+    /// - No index attribute (no per-thread access patterns)
+    /// - Empty symbol list in distributed_shape
+    /// - Distributed shape rank = 1 (flattened buffer)
+    /// - Distributed shape is constant (no symbolic expressions)
+    bool isParentAllocation() {
+      mlir::ArrayAttr indexAttr = getIndexAttr();
+      if (indexAttr && !indexAttr.empty())
+        return false;  // Regular allocations have index expressions.
+
+      wave::WaveExprListAttr distributedShape = getDistributedShape();
+
+      // Empty symbol list in distributed_shape.
+      if (!distributedShape.getSymbols().empty())
+        return false;
+
+      // Distributed shape rank must be 1 (flattened).
+      if (distributedShape.getMap().getNumResults() != 1)
+        return false;
+
+      // Distributed shape must be constant.
+      if (!distributedShape.getMap().isConstant())
+        return false;
+
+      return true;
+    }
+  }];
 }
 
 def ExtractSliceOp : WaveOp<"extract_slice", [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait, CompatibleOperandsAndResultsOpTrait]> {

--- a/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -124,7 +124,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types>} {
 // CHECK-LABEL: func.func @alloc_is_harmless
 func.func @alloc_is_harmless() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28, M = 128, N=128, K= 128}>}  {
   // CHECK: wave.allocate
-  %parent = wave.allocate { distributed_shape = #wave.expr_list<[] -> (256)> }
+  %parent = wave.allocate { distributed_shape = #wave.expr_list<[] -> (128, 128, 128)> }
     : !wave.tensor<[@M,@N,@K] of i8, <shared>>
 
   // CHECK: wave.allocate


### PR DESCRIPTION
When accessing shared memory allocated by wave.allocate, the read/write ops are supposed to operate on the distributed shape and not the logical shape. This PR implements the logic to handle this when lowering read/write ops to vector.load/store, transforming logical indices to distributed indices.

Fixes #659.