### PR TITLE
[water] Add NoOpElementsPerThreadOpTrait to ExtractSliceOp

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -272,7 +272,7 @@ def AllocateOp : WaveOp<"allocate"> {
   let hasVerifier = 1;
 }
 
-def ExtractSliceOp : WaveOp<"extract_slice", [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait, CompatibleOperandsAndResultsOpTrait]> {
+def ExtractSliceOp : WaveOp<"extract_slice", [WaveInferTypeOpInterface, IdentityTypeInferenceOpTrait, CompatibleOperandsAndResultsOpTrait, NoOpElementsPerThreadOpTrait]> {
   let summary = "Extracts a subvector from an n-D tensor";
   let description = [{
     Extracts an n-D subvector from an n-D tensor using k-D offset, size, and


### PR DESCRIPTION
ExtractSliceOp needs to propagate elements_per_thread information through without modification. Without this trait, the PropagateElementsPerThread pass fails with "cannot propagate elements per thread information across an operation not implementing the corresponding interface" when extract_slice is used between read/write operations.

Last bit to fix #605.