### PR TITLE
[asm] Refactor loop control registers from physical to virtual SGPRs

### DIFF
--- a/tests/kernel/wave/test_cfg_liveness.py
+++ b/tests/kernel/wave/test_cfg_liveness.py
@@ -28,6 +28,7 @@ from wave_lang.kernel.wave.asm.kernel_liveness import (
     compute_block_local_info,
     LiveRange,
 )
+from wave_lang.kernel.wave.asm.instruction_registry import Instruction
 
 
 class TestCFGConstruction:
@@ -40,8 +41,8 @@ class TestCFGConstruction:
         v1 = program.alloc_vreg()
 
         # Simple sequence: v0 = 1; v1 = v0 + 1
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
 
         cfg = build_cfg(program)
 
@@ -57,8 +58,8 @@ class TestCFGConstruction:
         v0 = program.alloc_vreg()
 
         # label: v0 = 1
-        program.emit(KInstr("_label", (), (), comment="my_label"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="my_label"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
 
         cfg = build_cfg(program)
 
@@ -72,11 +73,11 @@ class TestCFGConstruction:
         v0 = program.alloc_vreg()
 
         # v0 = 1; branch target; v0 = 2; target: v0 = 3
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("s_branch", (), (), comment="target"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(2),)))
-        program.emit(KInstr("_label", (), (), comment="target"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(3),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="target"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(2),)))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="target"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(3),)))
 
         cfg = build_cfg(program)
 
@@ -91,10 +92,10 @@ class TestCFGConstruction:
         v0 = program.alloc_vreg()
 
         # cbranch target; v0 = 1; target: v0 = 2
-        program.emit(KInstr("s_cbranch_scc1", (), (), comment="target"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("_label", (), (), comment="target"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(2),)))
+        program.emit(KInstr(Instruction.S_CBRANCH_SCC1, (), (), comment="target"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="target"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(2),)))
 
         cfg = build_cfg(program)
 
@@ -107,9 +108,9 @@ class TestCFGConstruction:
         v0 = program.alloc_vreg()
 
         # loop_header: v0 = 1; branch loop_header
-        program.emit(KInstr("_label", (), (), comment="loop_header"))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("s_branch", (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop_header"))
 
         cfg = build_cfg(program)
 
@@ -120,8 +121,8 @@ class TestCFGConstruction:
         program = KernelProgram()
         v0 = program.alloc_vreg()
 
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(2),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(2),)))
 
         cfg = build_cfg(program)
 
@@ -136,7 +137,7 @@ class TestBlockLocalInfo:
         program = KernelProgram()
         v0 = program.alloc_vreg()
 
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
 
         cfg = build_cfg(program)
         compute_block_local_info(cfg.blocks[0], program.instructions)
@@ -151,7 +152,7 @@ class TestBlockLocalInfo:
         v1 = program.alloc_vreg()
 
         # Manually set up: use v0 (not defined locally), then define v1
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
 
         cfg = build_cfg(program)
         compute_block_local_info(cfg.blocks[0], program.instructions)
@@ -168,8 +169,8 @@ class TestBlockLocalInfo:
 
         # v0 = 1; v1 = v0 + 1
         # v0 should not be in use_set because it's defined first
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
 
         cfg = build_cfg(program)
         compute_block_local_info(cfg.blocks[0], program.instructions)
@@ -189,10 +190,10 @@ class TestCFGLiveness:
 
         # Block 0: v0 = 1; branch block1
         # Block 1: v1 = v0 + 1
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("s_branch", (), (), comment="block1"))
-        program.emit(KInstr("_label", (), (), comment="block1"))
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="block1"))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="block1"))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
 
         cfg = build_cfg(program)
         compute_cfg_liveness(cfg, program.instructions)
@@ -209,16 +210,16 @@ class TestCFGLiveness:
         v2 = program.alloc_vreg()  # Accumulator
 
         # Prologue: v0 = 42 (loop-invariant)
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(42),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(42),)))
 
         # Loop header
-        program.emit(KInstr("_label", (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_header"))
 
         # Loop body: use v0 (loop-invariant)
-        program.emit(KInstr("v_add_u32", (v2,), (v0, v1)))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v2,), (v0, v1)))
 
         # Loop latch: branch back
-        program.emit(KInstr("s_branch", (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop_header"))
 
         cfg = build_cfg(program)
         compute_cfg_liveness(cfg, program.instructions)
@@ -244,9 +245,9 @@ class TestLiveRangeExtension:
         v1 = program.alloc_vreg()
 
         # v0 = 1; v1 = v0 + 1; (v0 dead after this)
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(1),)))
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))
-        program.emit(KInstr("v_mov_b32", (v1,), (KImm(2),)))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
+        program.emit(KInstr(Instruction.V_MOV_B32, (v1,), (KImm(2),)))
 
         info = compute_liveness(program, use_cfg=True)
 
@@ -260,16 +261,18 @@ class TestLiveRangeExtension:
         v1 = program.alloc_vreg()  # Used in loop
 
         # v0 = 42 (defined before loop)
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(42),)))  # idx 0
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(42),)))  # idx 0
 
         # loop_header:
-        program.emit(KInstr("_label", (), (), comment="loop_header"))  # idx 1
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_header"))  # idx 1
 
         # v1 = v0 + 1 (use v0 in loop body)
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))  # idx 2
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))  # idx 2
 
         # branch loop_header (back-edge)
-        program.emit(KInstr("s_branch", (), (), comment="loop_header"))  # idx 3
+        program.emit(
+            KInstr(Instruction.S_BRANCH, (), (), comment="loop_header")
+        )  # idx 3
 
         info = compute_liveness(program, use_cfg=True)
 
@@ -286,16 +289,16 @@ class TestLiveRangeExtension:
         v1 = program.alloc_vreg()
 
         # v0 = 42
-        program.emit(KInstr("v_mov_b32", (v0,), (KImm(42),)))  # idx 0
+        program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(42),)))  # idx 0
 
         # loop:
-        program.emit(KInstr("_label", (), (), comment="loop"))  # idx 1
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop"))  # idx 1
 
         # v1 = v0 + 1
-        program.emit(KInstr("v_add_u32", (v1,), (v0, KImm(1))))  # idx 2
+        program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))  # idx 2
 
         # branch loop
-        program.emit(KInstr("s_branch", (), (), comment="loop"))  # idx 3
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop"))  # idx 3
 
         # Compare CFG-based vs linear liveness
         info_cfg = compute_liveness(program, use_cfg=True)
@@ -316,37 +319,45 @@ class TestIntegration:
 
         # Pre-loop: compute thread ID (loop-invariant)
         tid = program.alloc_vreg()
-        program.emit(KInstr("v_mov_b32", (tid,), (KImm(0),), comment="tid"))  # idx 0
+        program.emit(
+            KInstr(Instruction.V_MOV_B32, (tid,), (KImm(0),), comment="tid")
+        )  # idx 0
 
         # Loop counter
         counter = program.alloc_sreg()
         bound = program.alloc_sreg()
-        program.emit(KInstr("s_mov_b32", (counter,), (KImm(0),)))  # idx 1
-        program.emit(KInstr("s_mov_b32", (bound,), (KImm(4),)))  # idx 2
+        program.emit(KInstr(Instruction.S_MOV_B32, (counter,), (KImm(0),)))  # idx 1
+        program.emit(KInstr(Instruction.S_MOV_B32, (bound,), (KImm(4),)))  # idx 2
 
         # loop_header:
-        program.emit(KInstr("_label", (), (), comment="loop_header"))  # idx 3
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_header"))  # idx 3
 
         # Compare and conditional branch
-        program.emit(KInstr("s_cmp_lt_u32", (), (counter, bound)))  # idx 4
-        program.emit(KInstr("s_cbranch_scc0", (), (), comment="loop_exit"))  # idx 5
+        program.emit(KInstr(Instruction.S_CMP_LT_U32, (), (counter, bound)))  # idx 4
+        program.emit(
+            KInstr(Instruction.S_CBRANCH_SCC0, (), (), comment="loop_exit")
+        )  # idx 5
 
         # Loop body: use tid (loop-invariant)
         acc = program.alloc_vreg()
-        program.emit(KInstr("v_add_u32", (acc,), (tid, KImm(1))))  # idx 6
+        program.emit(KInstr(Instruction.V_ADD_U32, (acc,), (tid, KImm(1))))  # idx 6
 
         # Increment counter
-        program.emit(KInstr("s_add_u32", (counter,), (counter, KImm(1))))  # idx 7
+        program.emit(
+            KInstr(Instruction.S_ADD_U32, (counter,), (counter, KImm(1)))
+        )  # idx 7
 
         # Branch back
-        program.emit(KInstr("s_branch", (), (), comment="loop_header"))  # idx 8
+        program.emit(
+            KInstr(Instruction.S_BRANCH, (), (), comment="loop_header")
+        )  # idx 8
 
         # loop_exit:
-        program.emit(KInstr("_label", (), (), comment="loop_exit"))  # idx 9
+        program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_exit"))  # idx 9
 
         # Epilogue: use result
         result = program.alloc_vreg()
-        program.emit(KInstr("v_mov_b32", (result,), (acc,)))  # idx 10
+        program.emit(KInstr(Instruction.V_MOV_B32, (result,), (acc,)))  # idx 10
 
         info = compute_liveness(program, use_cfg=True)
 

--- a/wave_lang/kernel/wave/asm/handlers_arith_affine.py
+++ b/wave_lang/kernel/wave/asm/handlers_arith_affine.py
@@ -14,6 +14,7 @@ from wave_lang.support.ir_imports import (
 )
 
 from .handlers_shared import *
+from .kernel_ir import KSReg
 from .kernel_model import KernelInfo
 from .utils import simplify_expression, tid_upper_bound_from_thread_id
 
@@ -228,6 +229,12 @@ class _ArithAffineHandlers:
                 ):
                     # SGPR references (e.g., "s4" for loop counter) can be used as symbol values
                     symbol_values.append(operand_value)
+                elif isinstance(operand_value, KSReg):
+                    # Virtual SGPR references (loop counters) can be used as symbol values
+                    # Convert to ks{id} symbol format for expression evaluation
+                    symbol_values.append(
+                        sympy.Symbol(f"ks{operand_value.id}", nonnegative=True)
+                    )
                 else:
                     # If we can't resolve the symbol value, we can't simplify
                     return None

--- a/wave_lang/kernel/wave/asm/handlers_control.py
+++ b/wave_lang/kernel/wave/asm/handlers_control.py
@@ -74,9 +74,8 @@ class _ControlFlowHandlers:
         counter_sreg = loop_ctx["counter_sreg"]
 
         # Store mapping from SSA induction variable to SGPR
-        # Use string format "s{idx}" for compatibility with expression simplification
-        # The KPhysSReg has an index attribute we can use
-        kernel_info.index_env[induction_var_ssa] = f"s{counter_sreg.index}"
+        # Store the virtual SGPR directly - the utils.py to_sympy() handles KSReg
+        kernel_info.index_env[induction_var_ssa] = counter_sreg
         loop_ctx["induction_var_ssa"] = induction_var_ssa
 
         # Allocate and initialize VGPRs for iter_args (accumulators)

--- a/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
+++ b/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
@@ -963,6 +963,58 @@ instructions:
     special:
       branch: true
 
+  s_cbranch_vccz:
+    mnemonic: s_cbranch_vccz
+    category: control
+    format: sopp
+    defs: []
+    uses:
+      - {name: label, type: label}
+    latency: 0
+    special:
+      branch: true
+      conditional: true
+      reads_vcc: true
+
+  s_cbranch_vccnz:
+    mnemonic: s_cbranch_vccnz
+    category: control
+    format: sopp
+    defs: []
+    uses:
+      - {name: label, type: label}
+    latency: 0
+    special:
+      branch: true
+      conditional: true
+      reads_vcc: true
+
+  s_cbranch_execz:
+    mnemonic: s_cbranch_execz
+    category: control
+    format: sopp
+    defs: []
+    uses:
+      - {name: label, type: label}
+    latency: 0
+    special:
+      branch: true
+      conditional: true
+      reads_exec: true
+
+  s_cbranch_execnz:
+    mnemonic: s_cbranch_execnz
+    category: control
+    format: sopp
+    defs: []
+    uses:
+      - {name: label, type: label}
+    latency: 0
+    special:
+      branch: true
+      conditional: true
+      reads_exec: true
+
   # ===========================================================================
   # Pseudo-ops (not real instructions)
   # ===========================================================================
@@ -996,3 +1048,81 @@ instructions:
     latency: 0
     special:
       raw: true
+
+  # Internal pseudo-ops for code generation
+  _srd_define:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs:
+      - {name: srd, type: sgpr_quad}
+    uses: []
+    latency: 0
+
+  _srd_copy_define:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs:
+      - {name: srd, type: sgpr_quad}
+    uses: []
+    latency: 0
+
+  _g2s_srd_copy:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
+  _srd_load_base:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
+  _srd_fill_size:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
+  _srd_fill_stride:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
+  _loop_inc:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs:
+      - {name: counter, type: sgpr}
+    uses:
+      - {name: counter, type: sgpr}
+      - {name: step, type: imm}
+    latency: 0
+
+  _mfma_acc:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
+  _init_acc_quad:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0

--- a/wave_lang/kernel/wave/asm/instruction_defs/gfx942.yaml
+++ b/wave_lang/kernel/wave/asm/instruction_defs/gfx942.yaml
@@ -7,6 +7,8 @@
 # - Improved MFMA throughput
 # - Additional FP8 instructions
 # - Enhanced memory subsystem
+#
+# Latencies sourced from: AMD Instinct MI300 CDNA3 ISA, Table 28 "MFMA VALU Opcodes"
 
 instructions:
   # ===========================================================================
@@ -14,6 +16,7 @@ instructions:
   # ===========================================================================
 
   # FP8 Matrix Multiply-Add (CDNA3 only)
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_FP8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_fp8_fp8:
     mnemonic: v_mfma_f32_16x16x32_fp8_fp8
     category: mfma
@@ -24,11 +27,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 64
+    latency: 16
     architectures: [gfx942]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_FP8 32x32x16 = 32 cycles
   v_mfma_f32_32x32x16_fp8_fp8:
     mnemonic: v_mfma_f32_32x32x16_fp8_fp8
     category: mfma
@@ -39,11 +43,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_16}
-    latency: 64
+    latency: 32
     architectures: [gfx942]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_BF8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_bf8_bf8:
     mnemonic: v_mfma_f32_16x16x32_bf8_bf8
     category: mfma
@@ -54,11 +59,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 64
+    latency: 16
     architectures: [gfx942]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_BF8 32x32x16 = 32 cycles
   v_mfma_f32_32x32x16_bf8_bf8:
     mnemonic: v_mfma_f32_32x32x16_bf8_bf8
     category: mfma
@@ -69,12 +75,13 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_16}
-    latency: 64
+    latency: 32
     architectures: [gfx942]
     special:
       accumulator: true
 
   # Mixed precision MFMA (FP8/BF8 with F32 accumulator)
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_BF8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_fp8_bf8:
     mnemonic: v_mfma_f32_16x16x32_fp8_bf8
     category: mfma
@@ -85,11 +92,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 64
+    latency: 16
     architectures: [gfx942]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_FP8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_bf8_fp8:
     mnemonic: v_mfma_f32_16x16x32_bf8_fp8
     category: mfma
@@ -100,7 +108,135 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 64
+    latency: 16
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 32x32x8 = 32 cycles
+  v_mfma_f32_32x32x8_bf16:
+    mnemonic: v_mfma_f32_32x32x8_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 16x16x16 = 16 cycles
+  v_mfma_f32_16x16x16_bf16:
+    mnemonic: v_mfma_f32_16x16x16_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_I32_{*}_I8 32x32x16 = 32 cycles
+  v_mfma_i32_32x32x16_i8:
+    mnemonic: v_mfma_i32_32x32x16_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_I32_{*}_I8 16x16x32 = 16 cycles
+  v_mfma_i32_16x16x32_i8:
+    mnemonic: v_mfma_i32_16x16x32_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_XF32 32x32x4 = 32 cycles
+  v_mfma_f32_32x32x4_xf32:
+    mnemonic: v_mfma_f32_32x32x4_xf32
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_XF32 16x16x8 = 16 cycles
+  v_mfma_f32_16x16x8_xf32:
+    mnemonic: v_mfma_f32_16x16x8_xf32
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F64_{*}_F64 16x16x4 = 32 cycles
+  v_mfma_f64_16x16x4_f64:
+    mnemonic: v_mfma_f64_16x16x4_f64
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_8, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_8}
+    latency: 32
+    architectures: [gfx942]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F64_{*}_F64 4x4x4_4B = 16 cycles
+  v_mfma_f64_4x4x4_4b_f64:
+    mnemonic: v_mfma_f64_4x4x4_4b_f64
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_pair, alignment: 2}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_pair}
+    latency: 16
     architectures: [gfx942]
     special:
       accumulator: true
@@ -194,6 +330,7 @@ instructions:
       memory: true
 
   # MFMA latency for MI300
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 16x16x16 = 16 cycles
   v_mfma_f32_16x16x16_f16:
     mnemonic: v_mfma_f32_16x16x16_f16
     category: mfma
@@ -204,11 +341,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 32  # Lower than generic 64 on MI300
+    latency: 16
     architectures: [gfx942]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 32x32x8 = 32 cycles
   v_mfma_f32_32x32x8_f16:
     mnemonic: v_mfma_f32_32x32x8_f16
     category: mfma

--- a/wave_lang/kernel/wave/asm/instruction_defs/gfx950.yaml
+++ b/wave_lang/kernel/wave/asm/instruction_defs/gfx950.yaml
@@ -1,20 +1,24 @@
-# GFX950 (CDNA3+ / MI350) specific instructions and overrides
+# GFX950 (CDNA4 / MI350) specific instructions and overrides
 #
 # This file extends common.yaml with instructions specific to GFX950.
 # GFX950 builds on GFX942 with additional features.
 #
-# GFX950 features:
+# GFX950 (CDNA4) features:
 # - All GFX942 features plus:
-# - Enhanced FP8/BF8 support
+# - Enhanced FP8/BF8 support with higher K dimensions
+# - New FP4/FP6 mixed precision (F8F6F4) instructions
 # - Improved gather-to-LDS operations
 # - Higher memory bandwidth
+#
+# Latencies sourced from: CDNA4 Instruction Set Architecture, Table 28 "MFMA VALU Opcodes"
 
 instructions:
   # ===========================================================================
-  # GFX950-specific MFMA Instructions (same as GFX942 + improvements)
+  # GFX950-specific MFMA Instructions
   # ===========================================================================
 
   # FP8 Matrix Multiply-Add
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_FP8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_fp8_fp8:
     mnemonic: v_mfma_f32_16x16x32_fp8_fp8
     category: mfma
@@ -25,11 +29,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 48  # Improved over GFX942
+    latency: 16
     architectures: [gfx950]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_FP8 32x32x16 = 32 cycles
   v_mfma_f32_32x32x16_fp8_fp8:
     mnemonic: v_mfma_f32_32x32x16_fp8_fp8
     category: mfma
@@ -40,11 +45,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_16}
-    latency: 48
+    latency: 32
     architectures: [gfx950]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_BF8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_bf8_bf8:
     mnemonic: v_mfma_f32_16x16x32_bf8_bf8
     category: mfma
@@ -55,11 +61,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 48
+    latency: 16
     architectures: [gfx950]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_BF8 32x32x16 = 32 cycles
   v_mfma_f32_32x32x16_bf8_bf8:
     mnemonic: v_mfma_f32_32x32x16_bf8_bf8
     category: mfma
@@ -70,12 +77,13 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_16}
-    latency: 48
+    latency: 32
     architectures: [gfx950]
     special:
       accumulator: true
 
-  # Mixed precision MFMA
+  # Mixed precision MFMA (FP8/BF8)
+  # Per ISA Table 28: V_MFMA_F32_{*}_FP8_BF8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_fp8_bf8:
     mnemonic: v_mfma_f32_16x16x32_fp8_bf8
     category: mfma
@@ -86,11 +94,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 48
+    latency: 16
     architectures: [gfx950]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF8_FP8 16x16x32 = 16 cycles
   v_mfma_f32_16x16x32_bf8_fp8:
     mnemonic: v_mfma_f32_16x16x32_bf8_fp8
     category: mfma
@@ -101,15 +110,16 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 48
+    latency: 16
     architectures: [gfx950]
     special:
       accumulator: true
 
   # ===========================================================================
-  # GFX950 Standard MFMA (improved latency)
+  # GFX950 Standard MFMA (F16)
   # ===========================================================================
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 16x16x16 = 16 cycles
   v_mfma_f32_16x16x16_f16:
     mnemonic: v_mfma_f32_16x16x16_f16
     category: mfma
@@ -120,11 +130,12 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_quad}
-    latency: 24  # Even better than GFX942
+    latency: 16
     architectures: [gfx950]
     special:
       accumulator: true
 
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 32x32x8 = 32 cycles
   v_mfma_f32_32x32x8_f16:
     mnemonic: v_mfma_f32_32x32x8_f16
     category: mfma
@@ -135,7 +146,284 @@ instructions:
       - {name: a, type: vgpr_pair}
       - {name: b, type: vgpr_pair}
       - {name: c, type: vgpr_16}
-    latency: 24
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # CDNA4-specific: Higher K dimension F16 variants
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 16x16x32 = 16 cycles
+  v_mfma_f32_16x16x32_f16:
+    mnemonic: v_mfma_f32_16x16x32_f16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_F16 32x32x16 = 32 cycles
+  v_mfma_f32_32x32x16_f16:
+    mnemonic: v_mfma_f32_32x32x16_f16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # ===========================================================================
+  # GFX950 Standard MFMA (BF16)
+  # ===========================================================================
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 16x16x16 = 16 cycles
+  v_mfma_f32_16x16x16_bf16:
+    mnemonic: v_mfma_f32_16x16x16_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 32x32x8 = 32 cycles
+  v_mfma_f32_32x32x8_bf16:
+    mnemonic: v_mfma_f32_32x32x8_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # CDNA4-specific: Higher K dimension BF16 variants
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 16x16x32 = 16 cycles
+  v_mfma_f32_16x16x32_bf16:
+    mnemonic: v_mfma_f32_16x16x32_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_{*}_BF16 32x32x16 = 32 cycles
+  v_mfma_f32_32x32x16_bf16:
+    mnemonic: v_mfma_f32_32x32x16_bf16
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # ===========================================================================
+  # GFX950 Integer MFMA (I8)
+  # ===========================================================================
+
+  # Per ISA Table 28: V_MFMA_I32_{*}_I8 16x16x32 = 16 cycles
+  v_mfma_i32_16x16x32_i8:
+    mnemonic: v_mfma_i32_16x16x32_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_I32_{*}_I8 32x32x16 = 32 cycles
+  v_mfma_i32_32x32x16_i8:
+    mnemonic: v_mfma_i32_32x32x16_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # CDNA4-specific: Higher K dimension I8 variants
+  # Per ISA Table 28: V_MFMA_I32_16X16X64_I8 = 16 cycles
+  v_mfma_i32_16x16x64_i8:
+    mnemonic: v_mfma_i32_16x16x64_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_quad}
+    latency: 16
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_I32_32X32X32_I8 = 32 cycles
+  v_mfma_i32_32x32x32_i8:
+    mnemonic: v_mfma_i32_32x32x32_i8
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_quad}
+      - {name: b, type: vgpr_quad}
+      - {name: c, type: vgpr_16}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # ===========================================================================
+  # GFX950 F64 MFMA
+  # ===========================================================================
+
+  # Per ISA Table 28: V_MFMA_F64_{*}_F64 16x16x4 = 64 cycles
+  v_mfma_f64_16x16x4_f64:
+    mnemonic: v_mfma_f64_16x16x4_f64
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_8, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_8}
+    latency: 64
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F64_{*}_F64 4x4x4_4B = 32 cycles
+  v_mfma_f64_4x4x4_4b_f64:
+    mnemonic: v_mfma_f64_4x4x4_4b_f64
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_pair, alignment: 2}
+    uses:
+      - {name: a, type: vgpr_pair}
+      - {name: b, type: vgpr_pair}
+      - {name: c, type: vgpr_pair}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # ===========================================================================
+  # GFX950 Mixed Precision (F8F6F4) MFMA - CDNA4 specific
+  # These support FP4, FP6, or FP8 independently for A and B matrices
+  # ===========================================================================
+
+  # Per ISA Table 28: V_MFMA_F32_16x16x128_F8F6F4 = 16 cycles (FP4/FP6) or 32 cycles (FP8)
+  v_mfma_f32_16x16x128_f8f6f4:
+    mnemonic: v_mfma_f32_16x16x128_f8f6f4
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_8}  # F8: 8 VGPRs, F6: 6 VGPRs, F4: 4 VGPRs
+      - {name: b, type: vgpr_8}
+      - {name: c, type: vgpr_quad}
+    latency: 32  # Conservative: 16 for FP4/FP6, 32 for FP8
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_F32_32x32x64_F8F6F4 = 32 cycles (FP4/FP6) or 64 cycles (FP8)
+  v_mfma_f32_32x32x64_f8f6f4:
+    mnemonic: v_mfma_f32_32x32x64_f8f6f4
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_8}
+      - {name: b, type: vgpr_8}
+      - {name: c, type: vgpr_16}
+    latency: 64  # Conservative: 32 for FP4/FP6, 64 for FP8
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Scaled variants with block scaling
+  # Per ISA Table 28: V_MFMA_SCALE_F32_16X16X128_F8F6F4 = 16 or 32 cycles
+  v_mfma_scale_f32_16x16x128_f8f6f4:
+    mnemonic: v_mfma_scale_f32_16x16x128_f8f6f4
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_quad, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_8}
+      - {name: b, type: vgpr_8}
+      - {name: c, type: vgpr_quad}
+    latency: 32
+    architectures: [gfx950]
+    special:
+      accumulator: true
+
+  # Per ISA Table 28: V_MFMA_SCALE_F32_32X32X64_F8F6F4 = 32 or 64 cycles
+  v_mfma_scale_f32_32x32x64_f8f6f4:
+    mnemonic: v_mfma_scale_f32_32x32x64_f8f6f4
+    category: mfma
+    format: vop3p
+    defs:
+      - {name: dst, type: vgpr_16, alignment: 4}
+    uses:
+      - {name: a, type: vgpr_8}
+      - {name: b, type: vgpr_8}
+      - {name: c, type: vgpr_16}
+    latency: 64
     architectures: [gfx950]
     special:
       accumulator: true
@@ -153,7 +441,7 @@ instructions:
     uses:
       - {name: src0, type: vgpr|sgpr|imm}
       - {name: src1, type: vgpr|sgpr|imm}
-    latency: 2  # Faster on GFX950
+    latency: 4
     architectures: [gfx950]
 
   v_cvt_pk_bf8_f32:
@@ -165,7 +453,7 @@ instructions:
     uses:
       - {name: src0, type: vgpr|sgpr|imm}
       - {name: src1, type: vgpr|sgpr|imm}
-    latency: 2
+    latency: 4
     architectures: [gfx950]
 
   v_cvt_f32_fp8:
@@ -176,7 +464,7 @@ instructions:
       - {name: dst, type: vgpr}
     uses:
       - {name: src, type: vgpr|sgpr|imm}
-    latency: 2
+    latency: 4
     architectures: [gfx950]
 
   v_cvt_f32_bf8:
@@ -187,11 +475,11 @@ instructions:
       - {name: dst, type: vgpr}
     uses:
       - {name: src, type: vgpr|sgpr|imm}
-    latency: 2
+    latency: 4
     architectures: [gfx950]
 
   # ===========================================================================
-  # GFX950 Memory Operations (improved latency)
+  # GFX950 Memory Operations
   # ===========================================================================
 
   buffer_load_dword:
@@ -205,7 +493,7 @@ instructions:
       - {name: srd, type: sgpr_quad}
       - {name: soffset, type: sgpr|imm}
       - {name: offset, type: offset, optional: true}
-    latency: 120  # Even lower on GFX950
+    latency: 120
     architectures: [gfx950]
     special:
       memory: true
@@ -272,7 +560,7 @@ instructions:
     uses:
       - {name: base, type: sgpr_pair}
       - {name: offset, type: imm|sgpr}
-    latency: 80  # Very low on GFX950
+    latency: 80
     architectures: [gfx950]
     special:
       memory: true
@@ -304,7 +592,7 @@ instructions:
     uses:
       - {name: addr, type: vgpr}
       - {name: offset, type: offset, optional: true}
-    latency: 12  # Very fast on GFX950
+    latency: 12
     architectures: [gfx950]
     special:
       memory: true

--- a/wave_lang/kernel/wave/asm/instruction_formatter.py
+++ b/wave_lang/kernel/wave/asm/instruction_formatter.py
@@ -35,6 +35,7 @@ from .instruction_registry import (
     OperandType,
     InstructionCategory,
     get_registry,
+    Instruction,
 )
 
 # Enable strict operand validation (fail on missing/extra operands)
@@ -336,12 +337,12 @@ class InstructionFormatter:
         comment: str,
     ) -> str:
         """Format pseudo-op."""
-        if instr_def.name == "_comment":
+        if instr_def.name == Instruction._COMMENT:
             return f"    // {comment or (uses[0] if uses else '')}"
-        elif instr_def.name == "_label":
+        elif instr_def.name == Instruction._LABEL:
             label = uses[0] if uses else comment
             return f"{label}:"
-        elif instr_def.name == "_raw_asm":
+        elif instr_def.name == Instruction._RAW_ASM:
             return uses[0] if uses else comment
         return ""
 
@@ -384,11 +385,11 @@ class InstructionFormatter:
                     line = parts[0] + " offset:" + parts[1]
 
         # Buffer instructions: special formatting
-        if instr_def.mnemonic.startswith("buffer_"):
+        if instr_def.category == InstructionCategory.VMEM:
             line = self._format_buffer_instruction(instr_def, line)
 
         # s_waitcnt: format wait count nicely
-        if instr_def.name == "s_waitcnt":
+        if instr_def.name == Instruction.S_WAITCNT:
             line = self._format_waitcnt(line, operands)
 
         return line
@@ -472,11 +473,11 @@ class InstructionFormatter:
         if lgkmcnt is not None:
             parts.append(f"lgkmcnt({lgkmcnt})")
         waitcnt_str = " ".join(parts) if parts else "0"
-        return self.format("s_waitcnt", uses=[waitcnt_str], comment=comment)
+        return self.format(Instruction.S_WAITCNT, uses=[waitcnt_str], comment=comment)
 
     def format_endpgm(self, comment: str = None) -> str:
         """Format an s_endpgm instruction."""
-        return self.format("s_endpgm", comment=comment)
+        return self.format(Instruction.S_ENDPGM, comment=comment)
 
     def format_label(self, label: str) -> str:
         """Format a label."""

--- a/wave_lang/kernel/wave/asm/kernel_generator.py
+++ b/wave_lang/kernel/wave/asm/kernel_generator.py
@@ -398,8 +398,20 @@ class KernelGenerator:
         return None
 
     def _handle_loop_inc(self, instr: KInstr) -> str:
-        """Handle loop increment (physical register, no def)."""
-        if len(instr.uses) >= 2:
+        """Handle loop increment (counter = counter + step)."""
+        # The counter is both defined and used - use the def for the destination
+        if len(instr.defs) >= 1 and len(instr.uses) >= 2:
+            counter = self._resolve_operand(instr.defs[0])
+            counter_use = self._resolve_operand(instr.uses[0])
+            step = self._resolve_operand(instr.uses[1])
+            return self._formatter.format(
+                "s_add_u32",
+                defs=[counter],
+                uses=[counter_use, step],
+                comment=instr.comment,
+            )
+        # Fallback for legacy format (no def, just uses)
+        elif len(instr.uses) >= 2:
             counter = self._resolve_operand(instr.uses[0])
             step = self._resolve_operand(instr.uses[1])
             return self._formatter.format(

--- a/wave_lang/kernel/wave/asm/kernel_module_compiler.py
+++ b/wave_lang/kernel/wave/asm/kernel_module_compiler.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List
 
 from .kernel_compilation_context import KernelCompilationContext
 
@@ -146,10 +146,3 @@ class KernelModuleCompiler:
                 all_lines.extend(epilogue_lines)
 
         return "\n".join(all_lines)
-
-    def _extract_kernel_metadata(self, fn) -> Tuple[Tuple[int, int, int], int]:
-        """Deprecated: use mlir_analysis.extract_translation_info instead."""
-        from .mlir_analysis import extract_translation_info
-
-        ti = extract_translation_info(fn)
-        return ti.wg_size, ti.subgroup_size

--- a/wave_lang/kernel/wave/asm/utils.py
+++ b/wave_lang/kernel/wave/asm/utils.py
@@ -381,6 +381,8 @@ def build_memref_byte_offset_expr(
 
     def to_sympy(value) -> sympy.Expr:
         """Convert index value to SymPy expression."""
+        from .kernel_ir import KSReg, KPhysSReg
+
         if isinstance(value, sympy.Expr):
             return value
         if isinstance(value, int):
@@ -392,6 +394,13 @@ def build_memref_byte_offset_expr(
             if value.startswith("s") and value[1:].isdigit():
                 return sympy.Symbol(value, nonnegative=True)
             raise ValueError(f"Unknown ID string: {value}")
+        # Handle virtual SGPR (loop counter) - create symbol using virtual register id
+        # The symbol name uses ks{id} to indicate it's a virtual SGPR
+        if isinstance(value, KSReg):
+            return sympy.Symbol(f"ks{value.id}", nonnegative=True)
+        # Handle physical SGPR references
+        if isinstance(value, KPhysSReg):
+            return sympy.Symbol(f"s{value.index}", nonnegative=True)
         raise ValueError(f"Unsupported index type: {type(value)}")
 
     # Build element index expression: sum(index[i] * stride[i])


### PR DESCRIPTION
Refactor loop control registers from physical to virtual SGPRs,
replace string comparisons with type-safe Instruction enum,
and remove backward compatibility code

This change addresses three main improvements:

1. LOOP CONTROL REGISTER REFACTORING

Previously, loop control registers (counter, step, upper_bound) were
hardcoded to physical SGPRs starting at s24. This caused potential
conflicts when SGPR pressure increased (e.g., G2S, extra SRD copies).

Changes:
- kernel_loops.py: Use virtual SGPRs instead of KPhysSReg(24+)
- kernel_ir.py: Added _loop_control_sregs set and register_loop_control_sreg()
  to mark SGPRs as loop control (exempt from SSA validation)
- kernel_passes.py: Removed manual reservation of s24+ for loop control;
  virtual SGPRs now go through normal register allocation

2. TYPE-SAFE INSTRUCTION ENUM

Replace string comparisons (e.g., instr.name == "v_add_u32") with a
dynamically generated Instruction enum for type safety and IDE support.

Changes:
- instruction_registry.py: Generate Instruction enum from YAML at load time;
  enum inherits from str for direct comparison; added helper functions
  (get_instruction_category, is_branch_instruction, is_conditional_branch)
- kernel_ir.py: Added category-based properties (is_valu, is_mfma, is_vmem,
  is_branch, is_conditional_branch) to KInstr class
- Multiple files: Replace string literals with Instruction enum members
- unified_emitter.py: Use InstructionCategory.PSEUDO instead of startswith("_")
- kernel_passes.py: Use instr.is_valu instead of name.startswith("v_")

3. BACKWARD COMPATIBILITY CODE REMOVAL

Removed ~214 lines of deprecated/unused backward compatibility code:

unified_emitter.py:
- Removed VReg, SReg, Imm wrapper classes (unused)
- Removed EmissionMode.DIRECT mode and create_direct_emitter()
- Removed direct emission methods (_emit_direct, _format_arg)
- Removed line management methods (get_lines, clear, emit_line, etc.)
- Simplified to only support KERNEL_IR mode

mlir_walker.py:
- Removed _SSAToVGPRAdapter class (57 lines)
- Removed ssa_to_vgpr property

handlers_memory.py:
- Migrated from walker.ssa_to_vgpr to walker.kernel_ctx.ssa_to_reg

kernel_module_compiler.py:
- Removed _extract_kernel_metadata() deprecated method

4. INSTRUCTION LATENCY UPDATES

- gfx942.yaml: Added MFMA latencies from CDNA3 ISA (Table 28)
- gfx950.yaml: Added MFMA latencies from CDNA4 ISA (Table 28)
- common.yaml: Added missing branch instructions and internal pseudo-ops

5. TEST CLEANUP

- Removed KernelBuilder instruction emission helpers (v_mov_b32, etc.)
- Updated tests to use KInstr(Instruction.X, ...) directly
- KernelBuilder retained for register allocation helpers only