### PR TITLE
[water] Add resolved_allocations normal form

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -98,6 +98,8 @@ def NORMAL_FORM_INDEX_EXPRS : I32BitEnumAttrCaseBit<
     "IndexExprsSpecified",       2, "index_exprs">;
 def NORMAL_FORM_MEMORY_ONLY_TYPES : I32BitEnumAttrCaseBit<
     "MemoryOnlyTypes",           3, "memory_only_types">;
+def NORMAL_FORM_RESOLVED_ALLOCATIONS : I32BitEnumAttrCaseBit<
+    "ResolvedAllocations",       4, "resolved_allocations">;
 
 def NORMAL_FORM_FULL_TYPES : I32BitEnumAttrCaseGroup<
     "AllTypesSpecified", [
@@ -112,6 +114,7 @@ def WaveNormalFormEnum : I32BitEnumAttr<"WaveNormalForm", "", [
   NORMAL_FORM_OP_TYPES,
   NORMAL_FORM_INDEX_EXPRS,
   NORMAL_FORM_MEMORY_ONLY_TYPES,
+  NORMAL_FORM_RESOLVED_ALLOCATIONS,
 
   // Group aliases.
   NORMAL_FORM_FULL_TYPES

--- a/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -7,6 +7,7 @@
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
 #include "water/Dialect/Wave/IR/WaveDialect.h"
 #include "water/Dialect/Wave/IR/WaveInterfaces.h"
+#include "water/Dialect/Wave/IR/WaveOps.h"
 #include "water/Dialect/Wave/IR/WaveTypes.h"
 #include "water/Dialect/Wave/IR/WaveUtils.h"
 
@@ -902,6 +903,19 @@ wave::detail::verifyNormalFormAttr(Operation *root, wave::WaveNormalForm form,
                  "provided for all supported wave dialect operations";
         }
         return WalkResult::interrupt();
+      }
+    }
+
+    if (wave::bitEnumContainsAll(form,
+                                 wave::WaveNormalForm::ResolvedAllocations)) {
+      if (auto allocOp = llvm::dyn_cast<wave::AllocateOp>(op)) {
+        if (!llvm::isa<MemRefType>(allocOp.getResult().getType())) {
+          if (emitDiagnostics) {
+            op->emitError() << "normal form requires all wave.allocate "
+                               "operations to have memref result type";
+          }
+          return WalkResult::interrupt();
+        }
       }
     }
 

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -56,7 +56,8 @@ struct LowerWaveToMLIRPass
     // TODO: require index expressions to be present
     if (failed(wave::verifyNormalFormPassPrecondition(
             wave::WaveNormalForm::AllTypesSpecified |
-                wave::WaveNormalForm::MemoryOnlyTypes,
+                wave::WaveNormalForm::MemoryOnlyTypes |
+                wave::WaveNormalForm::ResolvedAllocations,
             op, getPassName())))
       return signalPassFailure();
 

--- a/water/lib/Dialect/Wave/Transforms/ResolveDistributedAllocations.cpp
+++ b/water/lib/Dialect/Wave/Transforms/ResolveDistributedAllocations.cpp
@@ -87,6 +87,10 @@ struct ResolveDistributedAllocations
 
     if (walkResult.wasInterrupted())
       return signalPassFailure();
+
+    if (llvm::failed(wave::setNormalFormPassPostcondition(
+            wave::WaveNormalForm::ResolvedAllocations, getOperation())))
+      return signalPassFailure();
   }
 };
 

--- a/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
@@ -1,6 +1,6 @@
 // RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir --split-input-file --verify-diagnostics
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   func.func @binary_ops_pattern_failure() {
     %cst = arith.constant 1.0 : f32
     // expected-error @below {{wave dialect operation with no hyperparameters provided by any ancestor}}
@@ -12,7 +12,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 // -----
 
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // expected-error @+1 {{failed to convert starting at this operation}}
   func.func @read_pattern_failure(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
     attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128}>} {
@@ -26,7 +26,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // expected-error @+1 {{failed to convert starting at this operation}}
   func.func @write_pattern_failure(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
     attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128}>} {

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -1,6 +1,6 @@
 // RUN: water-opt %s -allow-unregistered-dialect -lower-wave-to-mlir --mlir-print-local-scope --split-input-file --verify-diagnostics | FileCheck %s
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   func.func @no_hyperparams() {
     %cst = arith.constant 0.0 : f32
     // expected-error @below {{wave dialect operation with no hyperparameters provided by any ancestor}}
@@ -11,7 +11,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_exp2
   func.func @lower_exp2() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.exp2
@@ -27,7 +27,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_mma_f16_f32
   func.func @lower_mma_f16_f32() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     %cst_f16 = arith.constant 0.0 : f16
@@ -54,7 +54,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_all_mmas
   func.func @lower_all_mmas() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // Common scalars
@@ -183,7 +183,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_register
   func.func @lower_register() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.register
@@ -204,7 +204,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_allocate_memref
   // Test lowering when wave.allocate already has MemRefType result
   // (after ResolveDistributedAllocations pass).
@@ -221,7 +221,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_nested_register
   func.func @lower_nested_register(%cond: i1) attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.register
@@ -242,7 +242,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_add
   func.func @lower_add() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.add
@@ -270,7 +270,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_mul
   func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.mul
@@ -298,7 +298,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_div
   func.func @lower_div() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.div
@@ -326,7 +326,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: func.func @lower_alloc_view
 func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28}>}  {
   // CHECK: %[[BUFF:.*]] = memref.alloc() : memref<256xi8, #gpu.address_space<workgroup>>
@@ -345,7 +345,7 @@ func.func @lower_alloc_view() attributes {wave.hyperparameters = #wave.hyperpara
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: @lower_alloc
 func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 4, BLOCK_K = 28}>}  {
   // CHECK: memref.alloc() : memref<4x32xbf16, #gpu.address_space<workgroup>>
@@ -358,7 +358,7 @@ func.func @lower_alloc() attributes {wave.hyperparameters = #wave.hyperparameter
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: @lower_read
 func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %0 = wave.read %mem index [{
@@ -380,7 +380,7 @@ func.func @lower_read(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes 
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: @lower_read_non_innermost_dim
 func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %0 = wave.read %mem index [{
@@ -402,7 +402,7 @@ func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <glo
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @lower_read_masked
   func.func @lower_read_masked(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 100, N = 50}>} {
@@ -444,7 +444,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @lower_read_masked_non_innermost_dim
   func.func @lower_read_masked_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 100, N = 50}>} {
@@ -464,7 +464,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @read_with_vector_result
   func.func @read_with_vector_result(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128}>} {
@@ -484,7 +484,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: @lower_write
 func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %cst = arith.constant 0.0 : f16
@@ -508,7 +508,7 @@ func.func @lower_write(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
 // CHECK-LABEL: @lower_write_non_innermost
 func.func @lower_write_non_innermost(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>}  {
   %cst = arith.constant 0.0 : f16
@@ -532,7 +532,7 @@ func.func @lower_write_non_innermost(%mem: !wave.tensor<[@M, @N] of f16, <global
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_float_extension
   func.func @lower_cast_float_extension() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -547,7 +547,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_float_truncation
   func.func @lower_cast_float_truncation() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -562,7 +562,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_integer_extension
   func.func @lower_cast_integer_extension() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -577,7 +577,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_integer_truncation
   func.func @lower_cast_integer_truncation() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -592,7 +592,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_float_to_integer
   func.func @lower_cast_float_to_integer() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -607,7 +607,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_integer_to_float
   func.func @lower_cast_integer_to_float() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.cast
@@ -622,7 +622,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_cast_mixed_types
   func.func @lower_cast_mixed_types() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // Test f16 -> f32 extension
@@ -646,7 +646,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_extract_slice_constants
   func.func @lower_extract_slice_constants() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK:     %[[INPUT:.*]] = arith.constant dense<0.000000e+00> : vector<16xf32>
@@ -667,7 +667,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_iterate
   func.func @lower_iterate(%init: vector<8xf32>) attributes {
     wave.hyperparameters = #wave.hyperparameters<{K = 128, BLOCK_K = 32}>,
@@ -693,7 +693,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @lower_iterate_with_operations
   func.func @lower_iterate_with_operations(%init: vector<4xf32>) attributes {
     wave.hyperparameters = #wave.hyperparameters<{K = 64, BLOCK_K = 16, M = 32}>,
@@ -724,7 +724,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // CHECK: module {
 // CHECK-NOT: wave.normal_form
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: func.func @test_normal_form_cleared
   func.func @test_normal_form_cleared() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     return
@@ -733,7 +733,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @func_with_wave_input
   // CHECK-SAME: (%[[ARG0:.*]]: memref<32x32xf16, #gpu.address_space<global>>)
   func.func @func_with_wave_input(%arg0: !wave.tensor<[@M, @N] of f16, <global>>)
@@ -744,7 +744,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @func_with_multiple_wave_inputs
   // CHECK-SAME: (%[[ARG0:.*]]: memref<32x32xf16, #gpu.address_space<global>>, %[[ARG1:.*]]: memref<32x32xf16, #gpu.address_space<global>>, %[[ARG2:.*]]: memref<32x32xf16, #gpu.address_space<global>>)
   func.func @func_with_multiple_wave_inputs(
@@ -758,7 +758,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @func_with_mixed_input_types
   // CHECK-SAME: (%[[ARG0:.*]]: memref<64x64xf32, #gpu.address_space<global>>, %[[ARG1:.*]]: i32, %[[ARG2:.*]]: memref<16x16xf16, #gpu.address_space<global>>)
   func.func @func_with_mixed_input_types(
@@ -772,7 +772,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @func_without_wave_tensors
   // CHECK-SAME: (%[[ARG0:.*]]: f32, %[[ARG1:.*]]: i64) -> memref<32x32xf32>
   func.func @func_without_wave_tensors(%arg0: f32, %arg1: i64) -> memref<32x32xf32>
@@ -784,7 +784,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @lower_iterate_with_vector_iter_args
   func.func @lower_iterate_with_vector_iter_args() attributes {
     wave.hyperparameters = #wave.hyperparameters<{K = 128, BLOCK_K = 32}>,
@@ -813,7 +813,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @lower_iterate_multiple_vector_iter_args
   func.func @lower_iterate_multiple_vector_iter_args() attributes {
     wave.hyperparameters = #wave.hyperparameters<{I = 8}>,
@@ -842,7 +842,7 @@ module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_t
 
 // -----
 
-module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types>} {
+module attributes {wave.normal_form = #wave.normal_form<full_types,memory_only_types,resolved_allocations>} {
   // CHECK-LABEL: @lower_iterate_with_vector_captures
   func.func @lower_iterate_with_vector_captures() attributes {
     wave.hyperparameters = #wave.hyperparameters<{I = 4}>,

--- a/water/test/Dialect/Wave/normal-forms-invalid.mlir
+++ b/water/test/Dialect/Wave/normal-forms-invalid.mlir
@@ -26,3 +26,14 @@ module attributes {wave.normal_form = #wave.normal_form<index_exprs>} {
     return
   }
 }
+
+// -----
+
+module attributes {wave.normal_form = #wave.normal_form<resolved_allocations>} {
+  func.func @unresolved_allocate() {
+    // expected-error @below {{normal form requires all wave.allocate operations to have memref result type}}
+    %0 = wave.allocate {distributed_shape = #wave.expr_list<[#wave.symbol<"M">] -> (M)>}
+      : !wave.tensor<[@M] of f32, <shared>>
+    return
+  }
+}


### PR DESCRIPTION
Introduce a new normal form bit `resolved_allocations` that indicates all wave.allocate operations have been resolved to return MemRefType instead of WaveTensorType. This occurs after the ResolveDistributedAllocations pass runs.

The LowerWaveToMLIR pass now requires this normal form as a precondition, ensuring allocate ops have memref results before lowering.