### PR TITLE
[water] Support read/write lowering with MemRefType memory operands

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/ResolveDistributedAllocations.cpp
+++ b/water/lib/Dialect/Wave/Transforms/ResolveDistributedAllocations.cpp
@@ -55,6 +55,7 @@ struct ResolveDistributedAllocations
         return;
       }
 
+      // Update the result type in place.
       allocateOp.getResult().setType(memrefType);
     });
     return result;


### PR DESCRIPTION

After ResolveDistributedAllocations converts WaveTensorType to MemRefType,
read/write ops need to determine dimension ordering for correct lowering.

With IndexExprsSpecified as a precondition for LowerWaveToMLIR, read/write
ops are guaranteed to have index expressions. Since DictAttr is internally
an ArrayRef<NamedAttribute>, the index dictionary keys are ordered and can
be used directly for dimension ordering.

Fixes https://github.com/iree-org/wave/issues/659.