### PR TITLE
[water] make WaveIndexMappingAttr more robust against null elements

### DIFF
--- a/tests/mlir_wave_iface/mlir_to_wave_test.py
+++ b/tests/mlir_wave_iface/mlir_to_wave_test.py
@@ -291,6 +291,22 @@ class TestConvertIndexMappingAttrToSympy:
         assert result.size == 16
         assert result.stride == 1
 
+    def test_index_mapping_with_null_start(self):
+        attr = ir.Attribute.parse("#wave<index_mapping[] -> (<NULL>, 1, 1)>")
+        result = _convert_index_mapping_attr_to_sympy(attr)
+        assert isinstance(result, IndexSequence)
+        assert result.start is None
+        assert result.size == 1
+        assert result.stride == 1
+
+    def test_index_mapping_with_null_step_stride(self):
+        attr = ir.Attribute.parse("#wave<index_mapping[] -> (1, <NULL>, <NULL>)>")
+        result = _convert_index_mapping_attr_to_sympy(attr)
+        assert isinstance(result, IndexSequence)
+        assert result.start == 1
+        assert result.size is None
+        assert result.stride is None
+
 
 class TestConvertIndexMappingDictToSympy:
     """Tests for _convert_index_mapping_dict_to_sympy function."""

--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -53,37 +53,6 @@ LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
                << val;
 
       auto mapping = cast<wave::WaveIndexMappingAttr>(val);
-      auto checkNoDims = [&](AffineMap map, StringRef which) -> LogicalResult {
-        if (map.getNumDims() != 0)
-          return op->emitError(
-                     "wave indexing " + which +
-                     " map should have no dimensions, only symbols, got ")
-                 << map.getNumDims() << " dimensions for symbol "
-                 << named.getName();
-        return success();
-      };
-
-      AffineMap startMap = mapping.getStart();
-      AffineMap stepMap = mapping.getStep();
-      AffineMap strideMap = mapping.getStride();
-      if (failed(checkNoDims(startMap, "start")) ||
-          failed(checkNoDims(stepMap, "step")) ||
-          failed(checkNoDims(strideMap, "stride")))
-        return failure();
-
-      unsigned declared = mapping.getSymbols().size();
-      if (startMap.getNumSymbols() != declared ||
-          stepMap.getNumSymbols() != declared ||
-          strideMap.getNumSymbols() != declared) {
-        return op->emitError(
-                   "inconsistent symbol count between symbol_names and "
-                   "affine maps for index symbol '")
-               << named.getName() << "' (expected " << declared
-               << ", got start=" << startMap.getNumSymbols()
-               << ", step=" << stepMap.getNumSymbols()
-               << ", stride=" << strideMap.getNumSymbols() << ")";
-      }
-
       for (auto symbol : mapping.getSymbols()) {
         auto iterSymbol = dyn_cast<wave::WaveIterSymbolAttr>(symbol);
         if (!iterSymbol)

--- a/water/lib/Dialect/Wave/IR/WaveUtils.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveUtils.cpp
@@ -32,6 +32,8 @@ wave::getUncollapsedVectorShape(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
     if (!entry)
       return ShapedType::kDynamic;
     auto mapAttr = cast<wave::WaveIndexMappingAttr>(entry);
+    if (!mapAttr.getStep())
+      return ShapedType::kDynamic;
     std::optional<SmallVector<int64_t>> folded =
         wave::evaluateMapWithHyperparams(mapAttr.getStep(),
                                          mapAttr.getSymbols(), hyper);

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -167,13 +167,25 @@ struct PyWaveIndexMappingAttr
         nb::arg("stride"), nb::arg("context") = nb::none(),
         "Gets a wave.WaveIndexMappingAttr from a list of symbol attributes.");
     c.def_prop_ro("start", [](MlirAttribute self) {
-      return mlirWaveIndexMappingAttrGetStart(self);
+      MlirAffineMap start = mlirWaveIndexMappingAttrGetStart(self);
+      if (mlirAffineMapIsNull(start)) {
+        return nb::none();
+      }
+      return nb::cast(start);
     });
     c.def_prop_ro("step", [](MlirAttribute self) {
-      return mlirWaveIndexMappingAttrGetStep(self);
+      MlirAffineMap step = mlirWaveIndexMappingAttrGetStep(self);
+      if (mlirAffineMapIsNull(step)) {
+        return nb::none();
+      }
+      return nb::cast(step);
     });
     c.def_prop_ro("stride", [](MlirAttribute self) {
-      return mlirWaveIndexMappingAttrGetStride(self);
+      MlirAffineMap stride = mlirWaveIndexMappingAttrGetStride(self);
+      if (mlirAffineMapIsNull(stride)) {
+        return nb::none();
+      }
+      return nb::cast(stride);
     });
     c.def_prop_ro("symbols", [](MlirAttribute self) {
       std::vector<MlirAttribute> symbols;

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -117,6 +117,20 @@ with ir.Context() as ctx:
     else:
         assert False, "Expected to fail with TypeError."
 
+    mapping = ir.Attribute.parse("#wave<index_mapping[] -> (<NULL>, 1, 1)>")
+    assert mapping.start is None
+    assert isinstance(mapping.step, ir.AffineMap)
+    assert isinstance(mapping.stride, ir.AffineMap)
+    # CHECK: #wave<index_mapping[] -> (<NULL>, 1, 1)>
+    print(mapping)
+
+    mapping = ir.Attribute.parse("#wave<index_mapping[] -> (1, <NULL>, <NULL>)>")
+    assert isinstance(mapping.start, ir.AffineMap)
+    assert mapping.step is None
+    assert mapping.stride is None
+    # CHECK: #wave<index_mapping[] -> (1, <NULL>, <NULL>)>
+    print(mapping)
+
     # CHECK: #wave.hyperparameters<{A = 1 : i64, B = 2 : i64, C = 3 : i64}>
     hyper_param = wave.WaveHyperparameterAttr.get({"A": 1, "B": 2, "C": 3})
     print(hyper_param)

--- a/wave_lang/kernel/wave/mlir_converter/mlir_to_wave.py
+++ b/wave_lang/kernel/wave/mlir_converter/mlir_to_wave.py
@@ -130,18 +130,16 @@ def _convert_index_mapping_attr_to_sympy(
             raise ValueError(f"Unsupported symbol attribute: {symbol_name}")
 
     symbols = list(map(wrap_symbol, attr.symbols))
-    assert (
-        len(attr.start.results) == 1
-    ), f"Expected start map to have one expression, got {attr.start}"
-    assert (
-        len(attr.step.results) == 1
-    ), f"Expected step map to have one expression, got {attr.step}"
-    assert (
-        len(attr.stride.results) == 1
-    ), f"Expected stride map to have one expression, got {attr.stride}"
-    start = _convert_affine_expr_to_sympy_expr(attr.start.results[0], symbols)
-    step = _convert_affine_expr_to_sympy_expr(attr.step.results[0], symbols)
-    stride = _convert_affine_expr_to_sympy_expr(attr.stride.results[0], symbols)
+
+    def convert_map(map: ir.AffineMap | None) -> sympy.Expr | None:
+        if map is None:
+            return None
+        assert len(map.results) == 1, f"Expected map to have one expression, got {map}"
+        return _convert_affine_expr_to_sympy_expr(map.results[0], symbols)
+
+    start = convert_map(attr.start)
+    step = convert_map(attr.step)
+    stride = convert_map(attr.stride)
     return IndexSequence(start, step, stride)
 
 


### PR DESCRIPTION
Since 93488b339ebcf37d0699fa999d6bedab6984f4ce, we allow null elements in the indexing map attribute, make the logic in printing and conversion from mlir to python more robust to there being a null expression in the mapping.

Drop redundant verification that was not accounting for null elements, but never actually reporting any errors since the attribute verifier had been intercepting the same cases.