### PR TITLE
[water] sideways and non-conflictual index for wave.write

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -458,7 +458,14 @@ private:
 };
 
 void operator<<(mlir::Diagnostic &diag, const IndexExprsLatticeStorage &value);
+} // namespace wave
 
+namespace llvm {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const wave::IndexExprsLatticeStorage &value);
+} // namespace llvm
+
+namespace wave {
 namespace detail {
 
 // Default propagation of index expressions from all operands to all results
@@ -520,6 +527,14 @@ public:
                                                 operandExprs, resultExprs);
   }
 };
+
+// A tag trait indicating that the operation requires index expressions to be
+// propagated between operands during backward analysis. This needs no methods,
+// its mere presence is enough.
+template <typename OpTy>
+class RequiresIndexExprsSidewaysBackwardPropagationOpTrait
+    : public mlir::OpTrait::TraitBase<
+          OpTy, RequiresIndexExprsSidewaysBackwardPropagationOpTrait> {};
 
 } // namespace wave
 

--- a/water/include/water/Dialect/Wave/IR/WaveInterfaces.td
+++ b/water/include/water/Dialect/Wave/IR/WaveInterfaces.td
@@ -249,4 +249,9 @@ def IdentityIndexExprsOpTrait
   let cppNamespace = "::wave";
 }
 
+def RequiresIndexExprsSidewaysBackwardPropagationOpTrait
+    : NativeOpTrait<"RequiresIndexExprsSidewaysBackwardPropagationOpTrait"> {
+  let cppNamespace = "::wave";
+}
+
 #endif // WATER_DIALECT_WAVE_WAVEINTERFACES

--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -245,7 +245,8 @@ def YieldOp : Op<WaveDialect, "yield",
 // Memory-related operations
 //-----------------------------------------------------------------------------
 
-def AllocateOp : WaveOp<"allocate"> {
+def AllocateOp : WaveOp<"allocate", [
+    WaveInferIndexExprsOpInterface, IdentityIndexExprsOpTrait]> {
   let summary = "Represents an allocation in an address space";
   let description = [{
     Allocates memory for a Wave tensor in the address space indicated by the
@@ -359,7 +360,8 @@ def WriteOp : WaveOp<"write", [
     WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
     DeclareOpInterfaceMethods<WaveElementsPerThreadOpInterface>,
     CompatibleOperandsAndResultsIgnoreSpaceOpTrait,
-    DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>]> {
+    DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>,
+    RequiresIndexExprsSidewaysBackwardPropagationOpTrait]> {
   let summary = "Writes into memory";
   let description = [{
     Moves data from a register-resident tensor into a memory-resident tensor

--- a/water/include/water/Dialect/Wave/Transforms/Utils.h
+++ b/water/include/water/Dialect/Wave/Transforms/Utils.h
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef WATER_DIALECT_WAVE_TRANSFORMS_UTILS_H
+#define WATER_DIALECT_WAVE_TRANSFORMS_UTILS_H
+
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
 
 namespace wave {
@@ -43,3 +46,5 @@ llvm::LogicalResult verifyNormalFormPassPrecondition(wave::WaveNormalForm form,
                                                      llvm::StringRef passName);
 
 } // namespace wave
+
+#endif


### PR DESCRIPTION
Add two features to index inference that make it consistent with PyWave behavior for memory writes even though they appear at odds with classical dataflow propagation.

1. Propagate index expressions lattice values between two operands of write operation during backward analysis (instead of propagating from results that write does not have anyway). This requires manually adding supplementary dependencies between lattice states in the framework since it is not set up for such sideways propagation. Practically, this ensures we index expressions are propagated between different _uses_ of the same memory operand, which in turn allows us to infer index expressions for, e.g., reads from global memory that are stored to shared memory before being reloaded. Arguably, this is not desirable and is concretely at odds with the elements-per-thread propagation, but this is currently expected by Pywave that corrects index sequences in a later "minimize global loads" pass that would otherwise be considered an optimization. Note that inferred index expressions are correct, at least for simple cases, just severely suboptimal.

2. Not update an operand lattice from another operand in a write operation if such an update would lead to a conflict as indicated by newly reaching lattice top state. This is equally questionable from the UX perspective since subtle changes in the input that would lead to conflicts without a write would not lead to them with a write. This is necessary, however, to avoid getting conflicts due to 1.