### PR TITLE
Expand python bindings with more getters

### DIFF
--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -147,6 +147,10 @@ mlirWaveHyperparameterAttrGet(MlirAttribute mapping);
 /// Returns the typeID of a WaveHyperparameterAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveHyperparameterAttrGetTypeID();
 
+/// Gets the underlying dictionary mapping from a WaveHyperparameterAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveHyperparameterAttrGetMapping(MlirAttribute attr);
+
 //===---------------------------------------------------------------------===//
 // WaveWorkgroupDimAttr
 //===---------------------------------------------------------------------===//
@@ -284,6 +288,17 @@ mlirWaveExprListAttrGet(MlirAttribute *symbolNames, MlirAffineMap map);
 /// Returns the typeID of a WaveExprListAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveExprListAttrGetTypeID();
 
+/// Get the affine map from a WaveExprListAttr.
+MLIR_CAPI_EXPORTED MlirAffineMap mlirWaveExprListAttrGetMap(MlirAttribute attr);
+
+/// Get the number of symbols in a WaveExprListAttr.
+MLIR_CAPI_EXPORTED intptr_t
+mlirWaveExprListAttrGetNumSymbols(MlirAttribute attr);
+
+/// Get the symbol at index from a WaveExprListAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveExprListAttrGetSymbol(MlirAttribute attr, intptr_t index);
+
 //===---------------------------------------------------------------------===//
 // WaveReadWriteBoundsAttr
 //===---------------------------------------------------------------------===//
@@ -317,6 +332,20 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirHardwareConstraintAttrGet(
 /// Returns the typeID of a HardwareConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWHardwareConstraintAttrGetTypeID();
 
+/// Field getters for HardwareConstraintAttr.
+MLIR_CAPI_EXPORTED unsigned
+mlirHardwareConstraintAttrGetThreadsPerWave(MlirAttribute attr);
+MLIR_CAPI_EXPORTED intptr_t
+mlirHardwareConstraintAttrGetNumWavesPerBlock(MlirAttribute attr);
+MLIR_CAPI_EXPORTED unsigned
+mlirHardwareConstraintAttrGetWavesPerBlockElem(MlirAttribute attr, intptr_t i);
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirHardwareConstraintAttrGetMmaType(MlirAttribute attr);
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirHardwareConstraintAttrGetVectorShapes(MlirAttribute attr);
+MLIR_CAPI_EXPORTED unsigned
+mlirHardwareConstraintAttrGetMaxBitsPerLoad(MlirAttribute attr);
+
 //===---------------------------------------------------------------------===//
 // DeviceConstraintAttr
 //===---------------------------------------------------------------------===//
@@ -332,6 +361,16 @@ mlirDeviceConstraintAttrGet(MlirContext mlirCtx, MlirAttribute dim,
 
 /// Returns the typeID of a DeviceConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirDeviceConstraintAttrGetTypeID();
+
+/// Field getters.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirDeviceConstraintAttrGetDim(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirDeviceConstraintAttrGetTileSize(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED unsigned
+mlirDeviceConstraintAttrGetDeviceDim(MlirAttribute attr);
 
 //===---------------------------------------------------------------------===//
 // WorkgroupConstraintAttr
@@ -349,6 +388,19 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirWorkgroupConstraintAttrGet(
 /// Returns the typeID of a WorkgroupConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWorkgroupConstraintAttrGetTypeID();
 
+/// Field getters.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWorkgroupConstraintAttrGetDim(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWorkgroupConstraintAttrGetTileSize(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWorkgroupConstraintAttrGetWorkgroupDim(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED bool
+mlirWorkgroupConstraintAttrGetPrimary(MlirAttribute attr);
+
 //===---------------------------------------------------------------------===//
 // WaveConstraintAttr
 //===---------------------------------------------------------------------===//
@@ -362,6 +414,13 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirWaveConstraintAttrGet(
 
 /// Returns the typeID of a WaveConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWaveConstraintAttrGetTypeID();
+
+/// Field getters.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveConstraintAttrGetDim(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveConstraintAttrGetTileSize(MlirAttribute attr);
 
 //===---------------------------------------------------------------------===//
 // TilingConstraintAttr
@@ -377,6 +436,13 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirTilingConstraintAttrGet(
 
 /// Returns the typeID of a TilingConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirTilingConstraintAttrGetTypeID();
+
+/// Field getters.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirTilingConstraintAttrGetDim(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirTilingConstraintAttrGetTileSize(MlirAttribute attr);
 
 #ifdef __cplusplus
 }

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -190,6 +190,12 @@ MlirTypeID mlirWaveHyperparameterAttrGetTypeID() {
   return wrap(TypeID::get<wave::WaveHyperparameterAttr>());
 }
 
+MlirAttribute mlirWaveHyperparameterAttrGetMapping(MlirAttribute attr) {
+  auto mapping =
+      llvm::cast<wave::WaveHyperparameterAttr>(unwrap(attr)).getMapping();
+  return wrap(mapping);
+}
+
 //===---------------------------------------------------------------------===//
 // WaveWorkgroupDimAttr
 //===---------------------------------------------------------------------===//
@@ -287,6 +293,19 @@ MlirTypeID mlirWaveExprListAttrGetTypeID() {
   return wrap(TypeID::get<wave::WaveExprListAttr>());
 }
 
+MlirAffineMap mlirWaveExprListAttrGetMap(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WaveExprListAttr>(unwrap(attr)).getMap());
+}
+
+intptr_t mlirWaveExprListAttrGetNumSymbols(MlirAttribute attr) {
+  return llvm::cast<wave::WaveExprListAttr>(unwrap(attr)).getSymbols().size();
+}
+
+MlirAttribute mlirWaveExprListAttrGetSymbol(MlirAttribute attr,
+                                            intptr_t index) {
+  return wrap(
+      llvm::cast<wave::WaveExprListAttr>(unwrap(attr)).getSymbols()[index]);
+}
 //===---------------------------------------------------------------------===//
 // WaveReadWriteBoundsAttr
 //===---------------------------------------------------------------------===//
@@ -342,6 +361,33 @@ MlirTypeID mlirWHardwareConstraintAttrGetTypeID() {
   return wrap(TypeID::get<wave::HardwareConstraintAttr>());
 }
 
+unsigned mlirHardwareConstraintAttrGetThreadsPerWave(MlirAttribute attr) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getThreadsPerWave();
+}
+intptr_t mlirHardwareConstraintAttrGetNumWavesPerBlock(MlirAttribute attr) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getWavesPerBlock()
+      .size();
+}
+unsigned mlirHardwareConstraintAttrGetWavesPerBlockElem(MlirAttribute attr,
+                                                        intptr_t i) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getWavesPerBlock()[i];
+}
+MlirAttribute mlirHardwareConstraintAttrGetMmaType(MlirAttribute attr) {
+  return wrap(
+      llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr)).getMmaType());
+}
+MlirAttribute mlirHardwareConstraintAttrGetVectorShapes(MlirAttribute attr) {
+  return wrap(llvm::dyn_cast<wave::HardwareConstraintAttr>(unwrap(attr))
+                  .getVectorShapes());
+}
+unsigned mlirHardwareConstraintAttrGetMaxBitsPerLoad(MlirAttribute attr) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getMaxBitsPerLoad();
+}
+
 //===---------------------------------------------------------------------===//
 // DeviceConstraintAttr
 //===---------------------------------------------------------------------===//
@@ -364,6 +410,19 @@ MlirAttribute mlirDeviceConstraintAttrGet(MlirContext mlirCtx,
 
 MlirTypeID mlirDeviceConstraintAttrGetTypeID() {
   return wrap(TypeID::get<wave::DeviceConstraintAttr>());
+}
+
+MlirAttribute mlirDeviceConstraintAttrGetDim(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::DeviceConstraintAttr>(unwrap(attr)).getDim());
+}
+
+MlirAttribute mlirDeviceConstraintAttrGetTileSize(MlirAttribute attr) {
+  return wrap(
+      llvm::cast<wave::DeviceConstraintAttr>(unwrap(attr)).getTileSize());
+}
+
+unsigned mlirDeviceConstraintAttrGetDeviceDim(MlirAttribute attr) {
+  return llvm::cast<wave::DeviceConstraintAttr>(unwrap(attr)).getDeviceDim();
 }
 
 //===---------------------------------------------------------------------===//
@@ -393,6 +452,24 @@ MlirTypeID mlirWorkgroupConstraintAttrGetTypeID() {
   return wrap(TypeID::get<wave::WorkgroupConstraintAttr>());
 }
 
+MlirAttribute mlirWorkgroupConstraintAttrGetDim(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WorkgroupConstraintAttr>(unwrap(attr)).getDim());
+}
+
+MlirAttribute mlirWorkgroupConstraintAttrGetTileSize(MlirAttribute attr) {
+  return wrap(
+      llvm::cast<wave::WorkgroupConstraintAttr>(unwrap(attr)).getTileSize());
+}
+
+MlirAttribute mlirWorkgroupConstraintAttrGetWorkgroupDim(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WorkgroupConstraintAttr>(unwrap(attr))
+                  .getWorkgroupDim());
+}
+
+bool mlirWorkgroupConstraintAttrGetPrimary(MlirAttribute attr) {
+  return llvm::cast<wave::WorkgroupConstraintAttr>(unwrap(attr)).getPrimary();
+}
+
 //===---------------------------------------------------------------------===//
 // WaveConstraintAttr
 //===---------------------------------------------------------------------===//
@@ -411,6 +488,14 @@ MlirAttribute mlirWaveConstraintAttrGet(MlirContext mlirCtx, MlirAttribute dim,
 
 MlirTypeID mlirWaveConstraintAttrGetTypeID() {
   return wrap(TypeID::get<wave::WaveConstraintAttr>());
+}
+
+MlirAttribute mlirWaveConstraintAttrGetDim(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WaveConstraintAttr>(unwrap(attr)).getDim());
+}
+
+MlirAttribute mlirWaveConstraintAttrGetTileSize(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WaveConstraintAttr>(unwrap(attr)).getTileSize());
 }
 
 //===---------------------------------------------------------------------===//
@@ -433,6 +518,15 @@ MlirAttribute mlirTilingConstraintAttrGet(MlirContext mlirCtx,
 
 MlirTypeID mlirTilingConstraintAttrGetTypeID() {
   return wrap(TypeID::get<wave::TilingConstraintAttr>());
+}
+
+MlirAttribute mlirTilingConstraintAttrGetDim(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::TilingConstraintAttr>(unwrap(attr)).getDim());
+}
+
+MlirAttribute mlirTilingConstraintAttrGetTileSize(MlirAttribute attr) {
+  return wrap(
+      llvm::cast<wave::TilingConstraintAttr>(unwrap(attr)).getTileSize());
 }
 
 //===---------------------------------------------------------------------===//

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -246,6 +246,9 @@ struct PyWaveHyperparameterAttr
         },
         nb::arg("symbol_dict"), nb::arg("context") = nb::none(),
         "Gets a wave.WaveHyperparameterAttr from parameters.");
+    c.def_prop_ro("mapping", [](MlirAttribute self) {
+      return mlirWaveHyperparameterAttrGetMapping(self);
+    });
   }
 };
 
@@ -437,6 +440,18 @@ struct PyWaveExprListAttr
         },
         nb::arg("symbols"), nb::arg("map"),
         "Gets a wave.WaveExprListAttr from a list of symbol attributes.");
+    c.def_prop_ro("symbols", [](MlirAttribute self) {
+      std::vector<MlirAttribute> symbols;
+      intptr_t numSymbols = mlirWaveExprListAttrGetNumSymbols(self);
+      symbols.reserve(numSymbols);
+      for (intptr_t i = 0; i < numSymbols; i++) {
+        symbols.push_back(mlirWaveExprListAttrGetSymbol(self, i));
+      }
+      return symbols;
+    });
+    c.def_prop_ro("map", [](MlirAttribute self) {
+      return mlirWaveExprListAttrGetMap(self);
+    });
   }
 };
 
@@ -543,6 +558,33 @@ struct PyHardwareConstraintAttr
         nb::arg("mma_type") = nb::none(), nb::arg("vector_shapes") = nb::none(),
         nb::arg("max_bits_per_load") = 128, nb::arg("context") = nb::none(),
         "Gets a wave.HardwareConstraintAttr from parameters.");
+
+    c.def_prop_ro("threads_per_wave", [](MlirAttribute self) {
+      return mlirHardwareConstraintAttrGetThreadsPerWave(self);
+    });
+    c.def_prop_ro("waves_per_block", [](MlirAttribute self) {
+      std::vector<unsigned> out;
+      intptr_t n = mlirHardwareConstraintAttrGetNumWavesPerBlock(self);
+      out.reserve(n);
+      for (intptr_t i = 0; i < n; ++i)
+        out.push_back(mlirHardwareConstraintAttrGetWavesPerBlockElem(self, i));
+      return out;
+    });
+    c.def_prop_ro("mma_type", [](MlirAttribute self) -> nb::object {
+      MlirAttribute attr = mlirHardwareConstraintAttrGetMmaType(self);
+      if (mlirAttributeIsNull(attr))
+        return nb::none();
+      return nb::cast(attr);
+    });
+    c.def_prop_ro("vector_shapes", [](MlirAttribute self) -> nb::object {
+      MlirAttribute attr = mlirHardwareConstraintAttrGetVectorShapes(self);
+      if (mlirAttributeIsNull(attr))
+        return nb::none();
+      return nb::cast(attr);
+    });
+    c.def_prop_ro("max_bits_per_load", [](MlirAttribute self) {
+      return mlirHardwareConstraintAttrGetMaxBitsPerLoad(self);
+    });
   }
 };
 
@@ -578,6 +620,15 @@ struct PyDeviceConstraintAttr
         nb::arg("dim"), nb::arg("tile_size"), nb::arg("device_dim"),
         nb::arg("context") = nb::none(),
         "Gets a wave.DeviceConstraintAttr from parameters.");
+    c.def_prop_ro("dim", [](MlirAttribute self) {
+      return mlirDeviceConstraintAttrGetDim(self);
+    });
+    c.def_prop_ro("tile_size", [](MlirAttribute self) {
+      return mlirDeviceConstraintAttrGetTileSize(self);
+    });
+    c.def_prop_ro("device_dim", [](MlirAttribute self) {
+      return mlirDeviceConstraintAttrGetDeviceDim(self);
+    });
   }
 };
 
@@ -614,6 +665,18 @@ struct PyWorkgroupConstraintAttr
         nb::arg("dim"), nb::arg("tile_size"), nb::arg("workgroup_dim"),
         nb::arg("primary") = true, nb::arg("context") = nb::none(),
         "Gets a wave.WorkgroupConstraintAttr from parameters.");
+    c.def_prop_ro("dim", [](MlirAttribute self) {
+      return mlirWorkgroupConstraintAttrGetDim(self);
+    });
+    c.def_prop_ro("tile_size", [](MlirAttribute self) {
+      return mlirWorkgroupConstraintAttrGetTileSize(self);
+    });
+    c.def_prop_ro("workgroup_dim", [](MlirAttribute self) {
+      return mlirWorkgroupConstraintAttrGetWorkgroupDim(self);
+    });
+    c.def_prop_ro("primary", [](MlirAttribute self) {
+      return mlirWorkgroupConstraintAttrGetPrimary(self);
+    });
   }
 };
 
@@ -647,6 +710,12 @@ struct PyWaveConstraintAttr
         },
         nb::arg("dim"), nb::arg("tile_size"), nb::arg("context") = nb::none(),
         "Gets a wave.WaveConstraintAttr from parameters.");
+    c.def_prop_ro("dim", [](MlirAttribute self) {
+      return mlirWaveConstraintAttrGetDim(self);
+    });
+    c.def_prop_ro("tile_size", [](MlirAttribute self) {
+      return mlirWaveConstraintAttrGetTileSize(self);
+    });
   }
 };
 
@@ -680,6 +749,12 @@ struct PyTilingConstraintAttr
         },
         nb::arg("dim"), nb::arg("tile_size"), nb::arg("context") = nb::none(),
         "Gets a wave.TilingConstraintAttr from parameters.");
+    c.def_prop_ro("dim", [](MlirAttribute self) {
+      return mlirTilingConstraintAttrGetDim(self);
+    });
+    c.def_prop_ro("tile_size", [](MlirAttribute self) {
+      return mlirTilingConstraintAttrGetTileSize(self);
+    });
   }
 };
 

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -118,7 +118,10 @@ with ir.Context() as ctx:
         assert False, "Expected to fail with TypeError."
 
     # CHECK: #wave.hyperparameters<{A = 1 : i64, B = 2 : i64, C = 3 : i64}>
-    print(wave.WaveHyperparameterAttr.get({"A": 1, "B": 2, "C": 3}))
+    hyper_param = wave.WaveHyperparameterAttr.get({"A": 1, "B": 2, "C": 3})
+    print(hyper_param)
+    # CHECK: {A = 1 : i64, B = 2 : i64, C = 3 : i64}
+    print(hyper_param.mapping)
 
     try:
         wave.WaveHyperparameterAttr.get({"A": 1.0})
@@ -220,6 +223,8 @@ with ir.Context() as ctx:
     expr_map = ir.AffineMap.get(0, 2, [ir.AffineExpr.get_floor_div(s0, s1)])
     expr_attr = wave.WaveExprListAttr.get(symbol_attrs, expr_map)
     print(expr_attr)
+    # CHECK: ()[s0, s1] -> (s0 floordiv s1)
+    print(expr_attr.map)
 
     # CHECK: #wave.expr_list<[] -> (512)>
     int_expr_map = ir.AffineMap.get(0, 0, [ir.AffineExpr.get_constant(512)])
@@ -234,51 +239,88 @@ with ir.Context() as ctx:
     print(shape_dict)
 
     # CHECK: #wave.hardware_constraint<threads_per_wave = 64, mma_type = <f32_16x16x16_f16>>
-    print(
-        wave.HardwareConstraintAttr.get(
-            threads_per_wave=64, mma_type=mma_type_attr, max_bits_per_load=128
-        )
+    hardware_constr_1 = wave.HardwareConstraintAttr.get(
+        threads_per_wave=64, mma_type=mma_type_attr, max_bits_per_load=128
     )
-
+    print(hardware_constr_1)
+    # CHECK: 64
+    print(hardware_constr_1.threads_per_wave)
+    # CHECK: #wave.mma_kind<f32_16x16x16_f16>
+    print(hardware_constr_1.mma_type)
+    # CHECK: 128
+    print(hardware_constr_1.max_bits_per_load)
     # CHECK: #wave.hardware_constraint<threads_per_wave = 64, vector_shapes = {M = 512 : i64, N = 512 : i64}>
-    print(
-        wave.HardwareConstraintAttr.get(
-            threads_per_wave=64, vector_shapes=shape_dict, max_bits_per_load=128
-        )
+    hardware_constr_2 = wave.HardwareConstraintAttr.get(
+        threads_per_wave=64, vector_shapes=shape_dict, max_bits_per_load=128
     )
+    print(hardware_constr_2)
+    # CHECK: 64
+    print(hardware_constr_2.threads_per_wave)
+    # CHECK: None
+    print(hardware_constr_2.mma_type)
+    # CHECK: {M = 512 : i64, N = 512 : i64}
+    print(hardware_constr_2.vector_shapes)
+    # CHECK: 128
+    print(hardware_constr_2.max_bits_per_load)
 
     # CHECK: #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [2, 2, 1], vector_shapes = {M = 512 : i64, N = 512 : i64}>
-    print(
-        wave.HardwareConstraintAttr.get(
-            threads_per_wave=64,
-            waves_per_block=[2, 2, 1],
-            vector_shapes=shape_dict,
-            max_bits_per_load=128,
-        )
+    hardware_constr_3 = wave.HardwareConstraintAttr.get(
+        threads_per_wave=64,
+        waves_per_block=[2, 2, 1],
+        vector_shapes=shape_dict,
+        max_bits_per_load=128,
     )
+    print(hardware_constr_3)
+    # CHECK: [2, 2, 1]
+    print(hardware_constr_3.waves_per_block)
 
     # CHECK: #wave.device_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, device_dim = 0>
-    print(wave.DeviceConstraintAttr.get(dim="M", tile_size=expr_attr, device_dim=0))
+    device_constr = wave.DeviceConstraintAttr.get(
+        dim="M", tile_size=expr_attr, device_dim=0
+    )
+    print(device_constr)
+    # CHECK: #wave.symbol<"M">
+    print(device_constr.dim)
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    print(device_constr.tile_size)
+    # CHECK: 0
+    print(device_constr.device_dim)
 
     # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>>
-    print(
-        wave.WorkgroupConstraintAttr.get(
-            dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x
-        )
+    wg_constr = wave.WorkgroupConstraintAttr.get(
+        dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x
     )
+    print(wg_constr)
 
     # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>, primary = false>
-    print(
-        wave.WorkgroupConstraintAttr.get(
-            dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x, primary=False
-        )
+    wg_constr_1 = wave.WorkgroupConstraintAttr.get(
+        dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x, primary=False
     )
+    print(wg_constr_1)
+    # CHECK: #wave.symbol<"M">
+    print(wg_constr_1.dim)
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    print(wg_constr_1.tile_size)
+    # CHECK: #wave.workgroup_dim<x>
+    print(wg_constr_1.workgroup_dim)
+    # CHECK: False
+    print(wg_constr_1.primary)
 
     # CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>>
-    print(wave.WaveConstraintAttr.get(dim="M", tile_size=expr_attr))
+    wg_constr_2 = wave.WaveConstraintAttr.get(dim="M", tile_size=expr_attr)
+    print(wg_constr_2)
+    # CHECK: #wave.symbol<"M">
+    print(wg_constr_2.dim)
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    print(wg_constr_2.tile_size)
 
     # CHECK: #wave.tiling_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>>
-    print(wave.TilingConstraintAttr.get(dim="M", tile_size=expr_attr))
+    tiling_constr = wave.TilingConstraintAttr.get(dim="M", tile_size=expr_attr)
+    print(tiling_constr)
+    # CHECK: #wave.symbol<"M">
+    print(tiling_constr.dim)
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    print(tiling_constr.tile_size)
 
     # CHECK: #wave.normal_form<none>
     normal_form_attr = wave.WaveNormalFormAttr.get(wave.WaveNormalForm.None_)


### PR DESCRIPTION
This adds getters for the following attributes:
`WaveHyperparameterAttr`, `WaveExprListAttr`, `HardwareConstraintAttr`, `DeviceConstraintAttr`, `WorkgroupConstraintAttr`, `WaveConstraintAttr`, `TilingConstraint`
