### PR TITLE
[water] allow empty operand list in wave.yield

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -238,7 +238,7 @@ def YieldOp : Op<WaveDialect, "yield",
     Arg<Variadic<WaveIterableType>, "Yielded values">:$values
   );
 
-  let assemblyFormat = "$values attr-dict `:` type($values)";
+  let assemblyFormat = "$values attr-dict (`:` type($values)^)?";
 }
 
 //-----------------------------------------------------------------------------

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -436,3 +436,15 @@ func.func @iterate_vector_types() {
 }
 
 }
+
+// -----
+
+// CHECK-LABEL: @empty_yield
+func.func @empty_yield() {
+  // CHECK: wave.iterate @I
+  wave.iterate @I iter_args() {
+    // CHECK: wave.yield
+    wave.yield
+  } : () -> ()
+  return
+}


### PR DESCRIPTION
We don't always have a value returned.