### PR TITLE
fix mma kind enum values

### DIFF
--- a/lit_tests/kernel/wave/infer_index_exprs.py
+++ b/lit_tests/kernel/wave/infer_index_exprs.py
@@ -108,18 +108,25 @@ def _get_gemm_kernel(
 
 def testGemm():
     for use_shmem in [True, False]:
-        gemm, hyperparams = _get_gemm_kernel(
-            shape=(1024, 1024, 1024),
-            mfma_variant=MMAType.F32_16x16x16_F16,
-            use_shmem=use_shmem,
-        )
-        options = WaveCompileOptions(
-            subs=hyperparams,
-            run_bench=False,
-            check_water_analysis=True,
-        )
-        compiled_gemm = wave_compile(options, gemm)
-        assert compiled_gemm is not None
+        for mfma_variant, target in [
+            (MMAType.F32_32x32x16_F16, "gfx950"),
+            (MMAType.F32_16x16x16_F16, "gfx942"),
+        ]:
+            print(f"Testing {mfma_variant} on {target} with LDS={use_shmem}")
+            gemm, hyperparams = _get_gemm_kernel(
+                shape=(1024, 1024, 1024),
+                # shape = (32,	160,	1867),
+                mfma_variant=mfma_variant,
+                use_shmem=use_shmem,
+            )
+            options = WaveCompileOptions(
+                subs=hyperparams,
+                run_bench=False,
+                check_water_analysis=True,
+                target=target,
+            )
+            compiled_gemm = wave_compile(options, gemm)
+            assert compiled_gemm is not None
 
 
 if __name__ == "__main__":

--- a/wave_lang/kernel/wave/constraints.py
+++ b/wave_lang/kernel/wave/constraints.py
@@ -64,10 +64,10 @@ class MMAType(Enum):
     I32_32x32x16_I8 = 0x12C1
 
     # Intrinsics introduced in CDNA4
-    F32_32x32x16_BF16 = 0x1320
-    F32_16x16x32_BF16 = 0x1321
-    F32_32x32x16_F16 = 0x1322
-    F32_16x16x32_F16 = 0x1323
+    F32_16x16x32_F16 = 0x1320
+    F32_32x32x16_F16 = 0x1321
+    F32_16x16x32_BF16 = 0x1322
+    F32_32x32x16_BF16 = 0x1323
 
     # Intrinsics introduced in RDNA4
     RDNA4_WAVE32_F32_16x16x16_F16 = 0x1920


### PR DESCRIPTION
The values used were inconsistent with IREE defined in
https://github.com/iree-org/iree/blame/c65dc6dc28491b4768a72ff9d563edeb377627a9/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td#L188-L207
leading to errors discovered by Water flow. This may or may not have other
repercussions depending on whether the textual representation of the enum was
used in some Python logic. This is fundamentally impossible in C++ as enums
cannot be introspected.

Signed-off-by: Alex Zinenko <git@ozinenko.com>