### PR TITLE
triple buffered gemm optimization

### DIFF
--- a/wave_lang/kernel/wave/schedules/gemm_triple_buffer.py
+++ b/wave_lang/kernel/wave/schedules/gemm_triple_buffer.py
@@ -89,10 +89,12 @@ def get_async_two_cluster_triple_buffer():
             shared_load_b, dim=K, num_partitions=2
         )
 
-        # Create cluster ordering with async operations
+        independent_global_count = len(global_to_shared_a) + len(global_to_shared_b)
+
         clusters = [
             tkw.cluster(
                 [
+                    tkw.MemoryCounterWaitBarrier(load=independent_global_count),
                     tkw.WorkgroupBarrier(),
                     shared_load_a_0,
                     shared_load_b_0,
@@ -132,11 +134,19 @@ def get_async_two_cluster_triple_buffer():
                 ],
             ),
         ]
+
         # Apply the cluster-based reordering to the KERNEL stage
         tkw.reorder_graph(pipeline_loop.KERNEL, clusters)
 
         # Apply staggering waves scheduling to allow two waves to execute clusters in parallel with a stagger offset
         tkw.stagger(pipeline_loop.KERNEL)
+
+        # Unroll factor requires per-GEMM tuning:
+        # Over-unrolling leads to bloated code and instruction cache pressure.
+        # Under-unrolling prevents the backend from resolving memory aliasing
+        # metadata
+        unroll_factor = 2
+        tkw.unroll(pipeline_loop.KERNEL, unroll_factor)
 
     return async_two_cluster_three_stage_schedule
 


### PR DESCRIPTION
This PR ensures the triple buffered GEMM is robust across multiple shapes and introduces several performance tunings:

- To prevent the backend from inserting overly conservative wait instructions, I have unrolled the loop and disabled the "minimize_shared_allocs" pass. 

- I have implemented a double barrier at the start of the loop. Given the temporal offset between clusters (staggering), there is an increased risk of a wave consuming data before the producer wave has finished the write. The double barrier provides the necessary latency buffer to ensure data integrity across the workgroup.

-  I Added a MemoryCounterWait before the double barrier. This ensures that from a specific wave's perspective sufficient data has arrived to begin the subsequent iteration safely.

Note: Unroll factors require manual tuning. Over-unrolling leads to bloated code and cache misses, while under-unrolling prevents the backend's ability to resolve aliasing metadata and hence insert conservative barriers. 

