### PR TITLE
[water] Replace DictionaryAttr with WaveIndexExprsAttr for ordered index expressions

### DIFF
--- a/lit_tests/kernel/wave/mlir_converter.py
+++ b/lit_tests/kernel/wave/mlir_converter.py
@@ -248,48 +248,48 @@ def mlir_converter_matrix_add():
     # CHECK-SAME: N = 128 : i64
 
     # CHECK: %[[READ_A:.*]] = wave.read %[[ARG0]]
-    # CHECK-SAME: index
-    # CHECK-SAME: M : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
-    # CHECK-SAME: N : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: bounds
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
     # CHECK-SAME: elements_per_thread = 32 : i64
+    # CHECK-SAME: index
+    # CHECK-SAME: <"M"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
+    # CHECK-SAME: <"N"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: (!wave.tensor<[@M, @N] of f16, <global>>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     # CHECK: %[[READ_B:.*]] = wave.read %[[ARG1]]
-    # CHECK-SAME: index
-    # CHECK-SAME: M : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
-    # CHECK-SAME: N : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: bounds
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
     # CHECK-SAME: elements_per_thread = 32 : i64
+    # CHECK-SAME: index
+    # CHECK-SAME: <"M"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
+    # CHECK-SAME: <"N"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: (!wave.tensor<[@M, @N] of f16, <global>>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     # CHECK: %[[ADD:.*]] = wave.add %[[READ_A]], %[[READ_B]]
     # CHECK-SAME: index
-    # CHECK-SAME: M : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
-    # CHECK-SAME: N : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
+    # CHECK-SAME: <"M"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
+    # CHECK-SAME: <"N"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: (!wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@M, @N] of f16, <register>>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     # CHECK: %[[CAST:.*]] = wave.cast %[[ADD]]
     # CHECK-SAME: index
-    # CHECK-SAME: M : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
-    # CHECK-SAME: N : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
+    # CHECK-SAME: <"M"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
+    # CHECK-SAME: <"N"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: : !wave.tensor<[@M, @N] of f16, <register>> to !wave.tensor<[@M, @N] of f32, <register>>
 
     # CHECK: wave.write %[[CAST]], %[[ARG2]]
-    # CHECK-SAME: index
-    # CHECK-SAME: M : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
-    # CHECK-SAME: N : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: bounds
     # CHECK-SAME: #wave.read_write_bounds
     # CHECK-SAME: M = #wave.expr_list
     # CHECK-SAME: N = #wave.expr_list
     # CHECK-SAME: elements_per_thread = 32 : i64
+    # CHECK-SAME: index
+    # CHECK-SAME: <"M"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, 1, 64)
+    # CHECK-SAME: <"N"> : [{{.*}}, {{.*}}, {{.*}}] -> ({{.*}}, BLOCK_N ceildiv 2, 1)
     # CHECK-SAME: !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <global>>
 
     # CHECK: return
@@ -425,7 +425,7 @@ def mlir_converter_matmul():
     # Python propagation algorithm that is immediately caught by the verifier on construction.
     #
     # CHECK-SAME:   index =
-    # CHECK-SAME:     K = #wave<index_mapping
+    # CHECK-SAME:     <"K"> :
     # CHECK-NOT:      ARGK
     #
     # CHECK-NEXT: %[[ALLOCATE_2:.*]] = wave.allocate
@@ -446,20 +446,24 @@ def mlir_converter_matmul():
     # CHECK-NEXT:     %[[READ_SHARED_B_2:.*]] = wave.read %[[ALLOCATE_2]]
     # CHECK-NEXT:     %[[READ_SHARED_B_3:.*]] = wave.read %[[ALLOCATE_2]]
     # CHECK-NEXT:     %[[MMA_0:.*]] = wave.mma %[[READ_SHARED_B_0]], %[[READ_SHARED_A_0]], %[[ARG3]]
-    # CHECK-COUNT-2:  {K : [
-    # CHECK-SAME:     {M : [
+    # CHECK-SAME:     index =
+    # CHECK-COUNT-2:  <"K"> :
+    # CHECK-SAME:     <"M"> :
     # CHECK-SAME:     #wave.mma_kind<f32_32x32x8_f16>
     # CHECK-NEXT:     %[[MMA_1:.*]] = wave.mma %[[READ_SHARED_B_1]], %[[READ_SHARED_A_1]], %[[MMA_0]]
-    # CHECK-COUNT-2:  {K : [
-    # CHECK-SAME:     {M : [
+    # CHECK-SAME:     index =
+    # CHECK-COUNT-2:  <"K"> :
+    # CHECK-SAME:     <"M"> :
     # CHECK-SAME:     #wave.mma_kind<f32_32x32x8_f16>
     # CHECK-NEXT:     %[[MMA_2:.*]] = wave.mma %[[READ_SHARED_B_2]], %[[READ_SHARED_A_2]], %[[MMA_1]]
-    # CHECK-COUNT-2:  {K : [
-    # CHECK-SAME:     {M : [
+    # CHECK-SAME:     index =
+    # CHECK-COUNT-2:  <"K"> :
+    # CHECK-SAME:     <"M"> :
     # CHECK-SAME:     #wave.mma_kind<f32_32x32x8_f16>
     # CHECK-NEXT:     %[[MMA_3:.*]] = wave.mma %[[READ_SHARED_B_3]], %[[READ_SHARED_A_3]], %[[MMA_2]]
-    # CHECK-COUNT-2:  {K : [
-    # CHECK-SAME:     {M : [
+    # CHECK-SAME:     index =
+    # CHECK-COUNT-2:  <"K"> :
+    # CHECK-SAME:     <"M"> :
     # CHECK-SAME:     #wave.mma_kind<f32_32x32x8_f16>
     # CHECK-NEXT:     wave.yield %[[MMA_3]] : !wave.tensor<[@M, @N] of f32, <register>>
     # CHECK-NEXT: }

--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -589,4 +589,13 @@ def WaveIndexExprsAttr : AttrDef<WaveDialect, "WaveIndexExprs"> {
   }];
 }
 
+//-----------------------------------------------------------------------------
+// Typed array attributes
+//-----------------------------------------------------------------------------
+
+def WaveIndexExprsArrayAttr : TypedArrayAttrBase<WaveIndexExprsAttr,
+  "array of WaveIndexExprsAttr"> {
+  let constBuilderCall = "$_builder.getArrayAttr($0)";
+}
+
 #endif // WATER_DIALECT_WAVE_WAVEATTRS

--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -40,10 +40,11 @@ def WaveMemoryType : Type<Or<[WaveTensorInMemory.predicate, AnyMemRef.predicate]
 class WaveOp<string mnemonic, list<Trait> traits = []>
     : Op<WaveDialect, mnemonic, !listconcat(traits, [HasWaveIndexMapping])> {
   dag commonArguments = (ins
-    Arg<OptionalAttr<DictArrayAttr>, "Index expression">:$index
+    Arg<OptionalAttr<WaveIndexExprsArrayAttr>, "Index expression">:$index
   );
 
-  string commonArgumentsSyntax = "( `index` custom<WaveIndexDict>($index)^ )?";
+  // Index is now printed as part of attr-dict using standard WaveIndexExprsAttr format.
+  string commonArgumentsSyntax = "";
 }
 
 //-----------------------------------------------------------------------------

--- a/water/include/water/Dialect/Wave/IR/WaveUtils.h
+++ b/water/include/water/Dialect/Wave/IR/WaveUtils.h
@@ -21,11 +21,11 @@ namespace wave {
 /// Return the position of the dimension that is vectorized based on the index
 /// sequence. The dimension with the largest step is considered to be
 /// vectorized. In case of a tie, take the dimension that is farther in the
-/// index dictionary, which is secretly a list. Return failure when the index
-/// sequence step cannot be evaluated statically.
+/// index expressions. Return failure when the index sequence step cannot be
+/// evaluated statically.
 std::optional<uint64_t>
 getPositionOfVectorizedDim(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
-                           mlir::DictionaryAttr indexDict,
+                           wave::WaveIndexExprsAttr indexExprs,
                            wave::WaveHyperparameterAttr hyper);
 
 // Return the vector shape implied by the index sequence and hyperparameteters,
@@ -34,7 +34,7 @@ getPositionOfVectorizedDim(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
 // it cannot be fully evaluated.
 llvm::SmallVector<int64_t>
 getUncollapsedVectorShape(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
-                          mlir::DictionaryAttr indexDict,
+                          wave::WaveIndexExprsAttr indexExprs,
                           wave::WaveHyperparameterAttr hyper);
 
 /// Resolve named Wave symbols to concrete integer values using the

--- a/water/include/water/Dialect/Wave/Transforms/DataFlowAnalyses.h
+++ b/water/include/water/Dialect/Wave/Transforms/DataFlowAnalyses.h
@@ -18,12 +18,13 @@ class DataFlowSolver;
 class SymbolTableCollection;
 class Operation;
 class Value;
-class DictionaryAttr;
 } // namespace mlir
 
 namespace wave {
+class WaveIndexExprsAttr;
+
 using SetIndexLatticeFn =
-    llvm::function_ref<void(mlir::Value, mlir::DictionaryAttr)>;
+    llvm::function_ref<void(mlir::Value, wave::WaveIndexExprsAttr)>;
 using OverrideInitializationFn = llvm::function_ref<llvm::LogicalResult(
     mlir::Operation *, SetIndexLatticeFn)>;
 

--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -132,6 +132,51 @@ MLIR_CAPI_EXPORTED MlirAttribute
 mlirWaveIndexMappingAttrGetSymbol(MlirAttribute attr, intptr_t index);
 
 //===---------------------------------------------------------------------===//
+// WaveIndexEntryAttr
+//===---------------------------------------------------------------------===//
+
+/// Checks whether the given MLIR attribute is a WaveIndexEntryAttr.
+MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveIndexEntryAttr(MlirAttribute attr);
+
+/// Creates a new WaveIndexEntryAttr with the given dimension symbol and
+/// mapping.
+MLIR_CAPI_EXPORTED MlirAttribute mlirWaveIndexEntryAttrGet(
+    MlirContext mlirCtx, MlirAttribute dimension, MlirAttribute mapping);
+
+/// Returns the typeID of a WaveIndexEntryAttr.
+MLIR_CAPI_EXPORTED MlirTypeID mlirWaveIndexEntryAttrGetTypeID();
+
+/// Gets the dimension symbol from a WaveIndexEntryAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveIndexEntryAttrGetDimension(MlirAttribute attr);
+
+/// Gets the mapping from a WaveIndexEntryAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveIndexEntryAttrGetMapping(MlirAttribute attr);
+
+//===---------------------------------------------------------------------===//
+// WaveIndexExprsAttr
+//===---------------------------------------------------------------------===//
+
+/// Checks whether the given MLIR attribute is a WaveIndexExprsAttr.
+MLIR_CAPI_EXPORTED bool mlirAttributeIsAWaveIndexExprsAttr(MlirAttribute attr);
+
+/// Creates a new WaveIndexExprsAttr with the given list of entries.
+MLIR_CAPI_EXPORTED MlirAttribute mlirWaveIndexExprsAttrGet(
+    MlirContext mlirCtx, intptr_t numEntries, MlirAttribute *entries);
+
+/// Returns the typeID of a WaveIndexExprsAttr.
+MLIR_CAPI_EXPORTED MlirTypeID mlirWaveIndexExprsAttrGetTypeID();
+
+/// Gets the number of entries in a WaveIndexExprsAttr.
+MLIR_CAPI_EXPORTED intptr_t
+mlirWaveIndexExprsAttrGetNumEntries(MlirAttribute attr);
+
+/// Gets the entry at the given index from a WaveIndexExprsAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirWaveIndexExprsAttrGetEntry(MlirAttribute attr, intptr_t index);
+
+//===---------------------------------------------------------------------===//
 // WaveHyperparameterAttr
 //===---------------------------------------------------------------------===//
 

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -165,6 +165,71 @@ MlirAttribute mlirWaveIndexMappingAttrGetSymbol(MlirAttribute attr,
 }
 
 //===---------------------------------------------------------------------===//
+// WaveIndexEntryAttr
+//===---------------------------------------------------------------------===//
+
+bool mlirAttributeIsAWaveIndexEntryAttr(MlirAttribute attr) {
+  return llvm::isa<wave::WaveIndexEntryAttr>(unwrap(attr));
+}
+
+MlirAttribute mlirWaveIndexEntryAttrGet(MlirContext mlirCtx,
+                                        MlirAttribute dimension,
+                                        MlirAttribute mapping) {
+  MLIRContext *ctx = unwrap(mlirCtx);
+  auto dimAttr = llvm::cast<wave::WaveSymbolAttr>(unwrap(dimension));
+  auto mapAttr = llvm::cast<wave::WaveIndexMappingAttr>(unwrap(mapping));
+  return wrap(wave::WaveIndexEntryAttr::get(ctx, dimAttr, mapAttr));
+}
+
+MlirTypeID mlirWaveIndexEntryAttrGetTypeID() {
+  return wrap(TypeID::get<wave::WaveIndexEntryAttr>());
+}
+
+MlirAttribute mlirWaveIndexEntryAttrGetDimension(MlirAttribute attr) {
+  return wrap(
+      llvm::cast<wave::WaveIndexEntryAttr>(unwrap(attr)).getDimension());
+}
+
+MlirAttribute mlirWaveIndexEntryAttrGetMapping(MlirAttribute attr) {
+  return wrap(llvm::cast<wave::WaveIndexEntryAttr>(unwrap(attr)).getMapping());
+}
+
+//===---------------------------------------------------------------------===//
+// WaveIndexExprsAttr
+//===---------------------------------------------------------------------===//
+
+bool mlirAttributeIsAWaveIndexExprsAttr(MlirAttribute attr) {
+  return llvm::isa<wave::WaveIndexExprsAttr>(unwrap(attr));
+}
+
+MlirAttribute mlirWaveIndexExprsAttrGet(MlirContext mlirCtx,
+                                        intptr_t numEntries,
+                                        MlirAttribute *entries) {
+  MLIRContext *ctx = unwrap(mlirCtx);
+  llvm::SmallVector<wave::WaveIndexEntryAttr> entryAttrs;
+  entryAttrs.reserve(numEntries);
+  for (intptr_t i = 0; i < numEntries; ++i) {
+    entryAttrs.push_back(
+        llvm::cast<wave::WaveIndexEntryAttr>(unwrap(entries[i])));
+  }
+  return wrap(wave::WaveIndexExprsAttr::get(ctx, entryAttrs));
+}
+
+MlirTypeID mlirWaveIndexExprsAttrGetTypeID() {
+  return wrap(TypeID::get<wave::WaveIndexExprsAttr>());
+}
+
+intptr_t mlirWaveIndexExprsAttrGetNumEntries(MlirAttribute attr) {
+  return llvm::cast<wave::WaveIndexExprsAttr>(unwrap(attr)).getEntries().size();
+}
+
+MlirAttribute mlirWaveIndexExprsAttrGetEntry(MlirAttribute attr,
+                                             intptr_t index) {
+  return wrap(
+      llvm::cast<wave::WaveIndexExprsAttr>(unwrap(attr)).getEntries()[index]);
+}
+
+//===---------------------------------------------------------------------===//
 // WaveHyperparameterAttr
 //===---------------------------------------------------------------------===//
 

--- a/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -722,9 +722,12 @@ Attribute WaveIndexEntryAttr::parse(AsmParser &parser, Type type) {
 
 void WaveIndexEntryAttr::print(AsmPrinter &printer) const {
   // Print: @M : [symbols] -> (start, step, stride)
-  printer.printAttributeWithoutType(getDimension());
+  // Use printStrippedAttrOrType to avoid the #wave.symbol<...> prefix in
+  // generic mode, so we get just <"M"> instead of #wave.symbol<"M">.
+  printer << " ";
+  printer.printStrippedAttrOrType(getDimension());
   printer << " : ";
-  printer.printAttributeWithoutType(getMapping());
+  printer.printStrippedAttrOrType(getMapping());
 }
 
 //===----------------------------------------------------------------------===//
@@ -756,9 +759,10 @@ Attribute WaveIndexExprsAttr::parse(AsmParser &parser, Type type) {
 
 void WaveIndexExprsAttr::print(AsmPrinter &printer) const {
   // Print: <[@M : <mapping>, @K : <mapping>]>
+  // Use printStrippedAttrOrType to avoid #wave<index_entry ...> prefix.
   printer << "<[";
   llvm::interleaveComma(getEntries(), printer, [&](WaveIndexEntryAttr entry) {
-    printer.printAttributeWithoutType(entry);
+    printer.printStrippedAttrOrType(entry);
   });
   printer << "]>";
 }

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -1186,13 +1186,15 @@ public:
             for (Value capture : iterateOp.getCaptureBlockArgs()) {
               if (!llvm::isa<wave::WaveTensorType>(capture.getType()))
                 continue;
-              auto dict = DictionaryAttr::get(
+              auto indexExprs = wave::WaveIndexExprsAttr::get(
                   iterSymbolAttr.getContext(),
-                  {{iterSymbolAttr.getName(),
-                    wave::applyConstraint(tilingConstraint)}});
+                  {wave::WaveIndexEntryAttr::get(
+                      iterSymbolAttr.getContext(), iterSymbolAttr,
+                      wave::applyConstraint(tilingConstraint))});
               LDBG() << "setting iterate block argument lattice " << capture
-                     << " from " << PrintNoRegions(iterateOp) << " to " << dict;
-              unsafeSet(getLatticeElement(capture), dict);
+                     << " from " << PrintNoRegions(iterateOp) << " to "
+                     << indexExprs;
+              unsafeSet(getLatticeElement(capture), indexExprs);
             }
           }
         }
@@ -1204,11 +1206,11 @@ public:
 
     if (overrideInitialization) {
       if (llvm::failed(overrideInitialization(
-              top, [&](Value value, DictionaryAttr dict) {
-                if (!dict)
+              top, [&](Value value, wave::WaveIndexExprsAttr indexExprs) {
+                if (!indexExprs)
                   return unsafeSet(getLatticeElement(value),
                                    IndexExprsLatticeStorage::top());
-                unsafeSet(getLatticeElement(value), dict);
+                unsafeSet(getLatticeElement(value), indexExprs);
               })))
         return llvm::failure();
     }
@@ -1491,11 +1493,11 @@ public:
 
     if (overrideInitialization) {
       if (llvm::failed(overrideInitialization(
-              top, [&](Value value, DictionaryAttr dict) {
-                if (!dict)
+              top, [&](Value value, wave::WaveIndexExprsAttr indexExprs) {
+                if (!indexExprs)
                   return unsafeSet(getLatticeElement(value),
                                    IndexExprsLatticeStorage::top());
-                unsafeSet(getLatticeElement(value), dict);
+                unsafeSet(getLatticeElement(value), indexExprs);
               })))
         return llvm::failure();
     }

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -200,6 +200,91 @@ struct PyWaveIndexMappingAttr
 };
 
 //===---------------------------------------------------------------------===//
+// WaveIndexEntryAttr
+//===---------------------------------------------------------------------===//
+
+struct PyWaveIndexEntryAttr
+    : mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::PyConcreteAttribute<
+          PyWaveIndexEntryAttr> {
+  static constexpr IsAFunctionTy isaFunction =
+      mlirAttributeIsAWaveIndexEntryAttr;
+  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
+      mlirWaveIndexEntryAttrGetTypeID;
+  static constexpr const char *pyClassName = "WaveIndexEntryAttr";
+  using PyConcreteAttribute::PyConcreteAttribute;
+
+  static void bindDerived(ClassTy &c) {
+    c.def_static(
+        "get",
+        [](MlirAttribute dimension, MlirAttribute mapping,
+           mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::DefaultingPyMlirContext
+               context) {
+          return PyWaveIndexEntryAttr(
+              context->getRef(),
+              mlirWaveIndexEntryAttrGet(context->get(), dimension, mapping));
+        },
+        nb::arg("dimension"), nb::arg("mapping"),
+        nb::arg("context") = nb::none(),
+        "Gets a wave.WaveIndexEntryAttr from a dimension symbol and mapping.");
+    c.def_prop_ro("dimension", [](MlirAttribute self) {
+      return mlirWaveIndexEntryAttrGetDimension(self);
+    });
+    c.def_prop_ro("mapping", [](MlirAttribute self) {
+      return mlirWaveIndexEntryAttrGetMapping(self);
+    });
+  }
+};
+
+//===---------------------------------------------------------------------===//
+// WaveIndexExprsAttr
+//===---------------------------------------------------------------------===//
+
+struct PyWaveIndexExprsAttr
+    : mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::PyConcreteAttribute<
+          PyWaveIndexExprsAttr> {
+  static constexpr IsAFunctionTy isaFunction =
+      mlirAttributeIsAWaveIndexExprsAttr;
+  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
+      mlirWaveIndexExprsAttrGetTypeID;
+  static constexpr const char *pyClassName = "WaveIndexExprsAttr";
+  using PyConcreteAttribute::PyConcreteAttribute;
+
+  static void bindDerived(ClassTy &c) {
+    c.def_static(
+        "get",
+        [](std::vector<MlirAttribute> &entries,
+           mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::DefaultingPyMlirContext
+               context) {
+          return PyWaveIndexExprsAttr(
+              context->getRef(),
+              mlirWaveIndexExprsAttrGet(context->get(), entries.size(),
+                                        entries.data()));
+        },
+        nb::arg("entries"), nb::arg("context") = nb::none(),
+        "Gets a wave.WaveIndexExprsAttr from a list of entry attributes.");
+    c.def_prop_ro("entries", [](MlirAttribute self) {
+      std::vector<MlirAttribute> entries;
+      intptr_t numEntries = mlirWaveIndexExprsAttrGetNumEntries(self);
+      entries.reserve(numEntries);
+      for (intptr_t i = 0; i < numEntries; i++) {
+        entries.push_back(mlirWaveIndexExprsAttrGetEntry(self, i));
+      }
+      return entries;
+    });
+    c.def("__len__", [](MlirAttribute self) {
+      return mlirWaveIndexExprsAttrGetNumEntries(self);
+    });
+    c.def("__getitem__", [](MlirAttribute self, intptr_t index) {
+      intptr_t numEntries = mlirWaveIndexExprsAttrGetNumEntries(self);
+      if (index < 0 || index >= numEntries) {
+        throw nb::index_error("index out of range");
+      }
+      return mlirWaveIndexExprsAttrGetEntry(self, index);
+    });
+  }
+};
+
+//===---------------------------------------------------------------------===//
 // WaveHyperparameterAttr
 //===---------------------------------------------------------------------===//
 
@@ -847,6 +932,8 @@ NB_MODULE(_waterDialects, m) {
   PyWaveIterSymbolAttr::bind(d);
   PyWaveIndexSymbolAttr::bind(d);
   PyWaveIndexMappingAttr::bind(d);
+  PyWaveIndexEntryAttr::bind(d);
+  PyWaveIndexExprsAttr::bind(d);
   PyWaveHyperparameterAttr::bind(d);
   PyWaveNormalFormAttr::bind(d);
   PyWaveWorkgroupDimAttr::bind(d);

--- a/water/test/Dialect/Wave/detect-normal-forms.mlir
+++ b/water/test/Dialect/Wave/detect-normal-forms.mlir
@@ -39,10 +39,10 @@ module @index_exprs_satisfied_module {
   func.func @index_exprs_satisfied() {
     %c = arith.constant 0.0 : f32
     %0 = wave.register %c
-      index [{
-        M : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
-        N : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
-      }]
+      {index = [#wave.index_exprs<[
+        <"M"> : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
+        <"N"> : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
+      ]>]}
       : !wave.tensor<[@M, @N] of f32, <register>>
     return
   }
@@ -103,10 +103,10 @@ module @multiple_ops_with_index_module {
   func.func @multiple_ops_with_index() {
     %c = arith.constant 0.0 : f32
     %0 = wave.register %c
-      index [{M : [] -> (0, 1, 1)}]
+      {index = [#wave.index_exprs<[ <"M"> : [] -> (0, 1, 1)]>]}
       : !wave.tensor<[@M] of f32, <register>>
     %1 = wave.register %c
-      index [{N : [] -> (0, 1, 1)}]
+      {index = [#wave.index_exprs<[ <"N"> : [] -> (0, 1, 1)]>]}
       : !wave.tensor<[@N] of f32, <register>>
     return
   }

--- a/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
@@ -18,9 +18,9 @@ normalform.module [#wave.normal_form<full_types>] {
       #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
     ]
   } {
-    %lhs_override = wave.read %lhs { wave_test.override_result_index = [{
-        N = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>
-    }]} : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %lhs_override = wave.read %lhs { wave_test.override_result_index = [
+        #wave.index_exprs<[<"N"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)]>
+    ]} : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
     // expected-error @below {{conflict when propagating forward to the result lattice in MmaOp}}
     // expected-note @below {{Result lattice}}
     // expected-note @below {{LHS lattice}}
@@ -50,7 +50,7 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-note @below {{result lattice}}
     %r = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>,
       wave_test.override_result_index = [
-        {K = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>}
+        #wave.index_exprs<[<"K"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)]>
       ]
     }
          : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>)
@@ -77,7 +77,7 @@ normalform.module [#wave.normal_form<full_types>] {
     %r = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>,
       wave_test.override_operand_index = [
         unit,
-        {N = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>}
+        #wave.index_exprs<[<"N"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)]>
       ]
     }
          : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>)
@@ -105,7 +105,7 @@ normalform.module [#wave.normal_form<full_types>] {
       wave_test.override_operand_index = [
         unit,
         unit,
-        {M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>}
+        #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)]>
       ]
     }
          : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>)
@@ -126,18 +126,22 @@ normalform.module [#wave.normal_form<full_types>] {
       #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
     ]
   } {
-    %add = wave.add %a, %b {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %add = wave.add %a, %b {wave_test.override_result_index = [
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>
+    ]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
 
     // expected-error @below {{conflict when propagating index expressions from result to operand #0}}
     // expected-note @below {{original operand lattice}}
     // expected-note @below {{result #0 lattice}}
-    %mul = wave.mul %add, %c {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %mul = wave.mul %add, %c {wave_test.override_result_index = [
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>
+    ]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
     return %mul : !wave.tensor<[@M, @K] of f16>
   }
 }
@@ -154,19 +158,23 @@ normalform.module [#wave.normal_form<full_types>] attributes { wave_test.disable
       #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
     ]
   } {
-    %add = wave.add %a, %b {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %add = wave.add %a, %b {wave_test.override_result_index = [
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>
+    ]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
 
     // expected-error @below {{conflict when propagating index expressions from operand to result #0}}
     // expected-note @below {{original result lattice}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %mul = wave.mul %add, %c {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %mul = wave.mul %add, %c {wave_test.override_result_index = [
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>
+    ]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
     return %mul : !wave.tensor<[@M, @K] of f16>
   }
 }
@@ -186,13 +194,16 @@ normalform.module [#wave.normal_form<full_types>] attributes { wave_test.disable
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %add = wave.add %a, %b {wave_test.override_operand_index = [{
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }, {
-      M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 44, 1, 1)>,
-      K = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)>
-    }]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+    %add = wave.add %a, %b {wave_test.override_operand_index = [
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 32, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>,
+      #wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0 * 44, 1, 1),
+        <"K"> : [#wave.index_symbol<T1>] -> (T1 * 16, 1, 1)
+      ]>
+    ]}: (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
 
     return %add : !wave.tensor<[@M, @K] of f16>
   }
@@ -235,12 +246,11 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }]}
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -262,12 +272,11 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (<NULL>, 1, 1)>
-    }]}
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (<NULL>, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -289,10 +298,9 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    },
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
        unit  // will default-initialize to bottom.
     ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
@@ -316,12 +324,11 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (0, 1, 1)>
-    }]}
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (0, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -343,11 +350,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40 + 1, 1, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40 + 1, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -369,11 +375,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40 + 2, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40 + 1, 1, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40 + 2, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40 + 1, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -396,11 +401,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 3, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 2, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 3, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 2, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -422,11 +426,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 3)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 3)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -447,12 +450,11 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }]}
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 2)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -473,12 +475,11 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.add
     // CHECK-SAME: index
-    // CHECK-SAME: M : [#wave.index_symbol<T0>] -> (T0 * 40, T0, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, T0, 1)>
-    }]}
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, T0, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, T0, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -500,11 +501,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0, T0, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (T0, WG0, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0, T0, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (T0, WG0, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -528,11 +528,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T1>] -> (T1 * 40, 1, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T1>] -> (T1 * 40, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -555,11 +554,10 @@ normalform.module [#wave.normal_form<full_types>] {
     // expected-error @below {{incompatible operand lattices when propagating from those to result}}
     // expected-note @below {{operand #0 lattice}}
     // expected-note @below {{operand #1 lattice}}
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<WG1>] -> (WG0, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<WG1>] -> (WG1, 1, 1)>
-    }]}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<WG1>] -> (WG0, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<WG1>] -> (WG1, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -581,13 +579,12 @@ normalform.module [#wave.normal_form<full_types>] {
     ]
   } {
     // CHECK: wave.add
-    // CHECK-SAME: index
-    // CHECK-SAME: {M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (T0, 1, 1)>
-    }]}
+    // CHECK-SAME: index =
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (T0, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -608,13 +605,12 @@ normalform.module [#wave.normal_form<full_types>] {
     ]
   } {
     // CHECK: wave.add
-    // CHECK-SAME: index
-    // CHECK-SAME: {M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0 + 2, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<WG0>] -> (WG0 + 2, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 + 2 , 1, 1)>
-    }]}
+    // CHECK-SAME: index =
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0 + 2, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>] -> (WG0 + 2, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0 + 2 , 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -635,13 +631,12 @@ normalform.module [#wave.normal_form<full_types>] {
     ]
   } {
     // CHECK: wave.add
-    // CHECK-SAME: index
-    // CHECK-SAME: {M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0, 1, 1)
-    %result = wave.add %a, %b {wave_test.override_operand_index = [{
-       M = #wave<index_mapping[#wave.index_symbol<WG0>] -> (WG0, 1, 1)>
-    }, {
-       M = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0, 1, 1)>
-    }]}
+    // CHECK-SAME: index =
+    // CHECK-SAME: <"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (WG0 + T0, 1, 1)
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>] -> (WG0, 1, 1)]>,
+       #wave.index_exprs<[<"M"> : [#wave.index_symbol<T0>] -> (T0, 1, 1)]>
+    ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
   }
@@ -666,12 +661,11 @@ normalform.module [#wave.normal_form<full_types>] {
     ^bb0(%a_arg: !wave.tensor<[@M, @K] of f32>):
       // CHECK: wave.add
       // CHECK-SAME: index
-      // CHECK-SAME: M : [#wave.index_symbol<WG0>, #wave.iter<"K">] -> (WG0 + _Iter_K, 1, 1)
-      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [{
-        M = #wave<index_mapping[#wave.index_symbol<WG0>] -> (WG0, 1, 1)>
-      }, {
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K, 1, 1)>
-      }]}
+      // CHECK-SAME: <"M"> : [#wave.index_symbol<WG0>, #wave.iter<"K">] -> (WG0 + _Iter_K, 1, 1)
+      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [
+        #wave.index_exprs<[<"M"> : [#wave.index_symbol<WG0>] -> (WG0, 1, 1)]>,
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K, 1, 1)]>
+      ]}
       : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
 
       wave.yield %partial_result : !wave.tensor<[@M, @K] of f32>
@@ -698,12 +692,11 @@ normalform.module [#wave.normal_form<full_types>] {
     ^bb0(%a_arg: !wave.tensor<[@M, @K] of f32>):
       // CHECK: wave.add
       // CHECK-SAME: index
-      // CHECK-SAME: M : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)
-      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [{
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)>
-      }, {
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)>
-      }]}
+      // CHECK-SAME: <"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)
+      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)]>,
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)]>
+      ]}
       : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
 
       wave.yield %partial_result : !wave.tensor<[@M, @K] of f32>
@@ -740,12 +733,11 @@ normalform.module [#wave.normal_form<full_types>] {
       ^bb1(%a_arg: !wave.tensor<[@M, @K] of f32>):
         // CHECK: wave.add
         // CHECK-SAME: index
-        // CHECK-SAME: M : [#wave.iter<"K">, #wave.iter<"M">] -> (_Iter_K + _Iter_M, 1, 1)
-        %partial_result = wave.add %a_arg, %b_arg {wave_test.override_operand_index = [{
-          M = #wave<index_mapping[#wave.iter<"M">] -> (_Iter_M, 1, 1)>
-        }, {
-          M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K, 1, 1)>
-        }]}
+        // CHECK-SAME: <"M"> : [#wave.iter<"K">, #wave.iter<"M">] -> (_Iter_K + _Iter_M, 1, 1)
+        %partial_result = wave.add %a_arg, %b_arg {wave_test.override_operand_index = [
+          #wave.index_exprs<[<"M"> : [#wave.iter<"M">] -> (_Iter_M, 1, 1)]>,
+          #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K, 1, 1)]>
+        ]}
         : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
 
         wave.yield %partial_result : !wave.tensor<[@M, @K] of f32>
@@ -776,11 +768,10 @@ normalform.module [#wave.normal_form<full_types>] {
       // expected-error @below {{incompatible operand lattices when propagating from those to result}}
       // expected-note @below {{operand #0 lattice}}
       // expected-note @below {{operand #1 lattice}}
-      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [{
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)>
-      }, {
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K * 2, 1, 1)>
-      }]}
+      %partial_result = wave.add %a_arg, %b {wave_test.override_operand_index = [
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)]>,
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K * 2, 1, 1)]>
+      ]}
       : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
 
       wave.yield %partial_result : !wave.tensor<[@M, @K] of f32>
@@ -804,15 +795,15 @@ normalform.module [#wave.normal_form<full_types>] {
     ]
   } {
     // CHECK: wave.read
-    // CHECK-SAME: {M : [] -> (42, 1, 1)
+    // CHECK-SAME: index =
+    // CHECK-SAME: <"M"> : [] -> (42, 1, 1)
     %b_reg = wave.read %b : (!wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
     %result = wave.iterate @K iter_args(%a) {
     ^bb0(%a_arg: !wave.tensor<[@M, @K] of f32>):
-      %partial_result = wave.add %a_arg, %b_reg {wave_test.override_operand_index = [{
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)>
-      }, {
-        M = #wave<index_mapping[#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)>
-      }]}
+      %partial_result = wave.add %a_arg, %b_reg {wave_test.override_operand_index = [
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)]>,
+        #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (_Iter_K + 42, 1, 1)]>
+      ]}
       : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
 
       wave.yield %partial_result : !wave.tensor<[@M, @K] of f32>
@@ -837,15 +828,15 @@ normalform.module [#wave.normal_form<full_types>] {
     ]
   } {
     // CHECK: index
-    // CHECK: M : [] -> (42, 1, <NULL>)
+    // CHECK: <"M"> : [] -> (42, 1, <NULL>)
     wave.write %a, %b {wave_test.override_operand_index = [
-      unit, {
-      M = #wave<index_mapping[#wave.iter<"K">] -> (<NULL>, 1, <NULL>)>
-    }]
+      unit,
+      #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (<NULL>, 1, <NULL>)]>
+    ]
     } : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
-    %c_reg = wave.read %c {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.iter<"K">] -> (42, <NULL>, <NULL>)>
-    }]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+    %c_reg = wave.read %c {wave_test.override_result_index = [
+      #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (42, <NULL>, <NULL>)]>
+    ]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     wave.write %c_reg, %b : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
     return
   }
@@ -869,19 +860,198 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     // CHECK: wave.write
     // CHECK: index
-    // CHECK: M : [] -> (1, <NULL>, <NULL>)
+    // CHECK: <"M"> : [] -> (1, <NULL>, <NULL>)
     wave.write %a, %b {wave_test.override_operand_index = [
-      unit, {
-      M = #wave<index_mapping[#wave.iter<"K">] -> (1, <NULL>, <NULL>)>
-    }]
+      unit,
+      #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (1, <NULL>, <NULL>)]>
+    ]
     } : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
     // CHECK: wave.read
     // CHECK: index
-    // CHECK: M : [] -> (42, <NULL>, <NULL>)
-    %c_reg = wave.read %c {wave_test.override_result_index = [{
-      M = #wave<index_mapping[#wave.iter<"K">] -> (42, <NULL>, <NULL>)>
-    }]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+    // CHECK: <"M"> : [] -> (42, <NULL>, <NULL>)
+    %c_reg = wave.read %c {wave_test.override_result_index = [
+      #wave.index_exprs<[<"M"> : [#wave.iter<"K">] -> (42, <NULL>, <NULL>)]>
+    ]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     wave.write %c_reg, %b : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
     return
+  }
+}
+
+// -----
+
+// Check that dimension ordering is preserved after join() operations.
+// With DictionaryAttr, M and K would be alphabetically sorted to K, M.
+// WaveIndexExprsAttr must preserve the original M, K order.
+
+normalform.module [#wave.normal_form<full_types>] {
+  // CHECK-LABEL: @join_preserves_dimension_order
+  func.func @join_preserves_dimension_order(
+    %a: !wave.tensor<[@M, @K] of f32>,
+    %b: !wave.tensor<[@M, @K] of f32>
+  ) -> !wave.tensor<[@M, @K] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ]
+  } {
+    // Join two lattices with M, K ordering - the result must preserve M before K.
+    // CHECK: wave.add
+    // CHECK-SAME: index
+    // CHECK-SAME: {M : {{.*}}, K : {{.*}}}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>,
+       #wave.index_exprs<[
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>
+    ]}
+    : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
+    return %result : !wave.tensor<[@M, @K] of f32>
+  }
+}
+
+// -----
+
+// Join with three dimensions - verifies ordering is preserved for larger tuples.
+// Both operands have B, M, K order matching the tensor type [@B, @M, @K].
+
+normalform.module [#wave.normal_form<full_types>] {
+  // CHECK-LABEL: @join_preserves_three_dim_order
+  func.func @join_preserves_three_dim_order(
+    %a: !wave.tensor<[@B, @M, @K] of f32>,
+    %b: !wave.tensor<[@B, @M, @K] of f32>
+  ) -> !wave.tensor<[@B, @M, @K] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ]
+  } {
+    // Both operands have B, M, K order. Result must preserve B, M, K order.
+    // With DictionaryAttr this would be sorted to B, K, M (alphabetical).
+    // CHECK: wave.add
+    // CHECK-SAME: index
+    // CHECK-SAME: {B : {{.*}}, M : {{.*}}, K : {{.*}}}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[
+         <"B"> : [#wave.index_symbol<WG2>] -> (WG2, 1, 1),
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>,
+       #wave.index_exprs<[
+         <"B"> : [#wave.index_symbol<WG2>] -> (WG2, 1, 1),
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>
+    ]}
+    : (!wave.tensor<[@B, @M, @K] of f32>, !wave.tensor<[@B, @M, @K] of f32>) -> !wave.tensor<[@B, @M, @K] of f32>
+    return %result : !wave.tensor<[@B, @M, @K] of f32>
+  }
+}
+
+// -----
+
+// Join conflict: operands have same dimensions but in different order with
+// conflicting mappings. The dimension ordering differs (M,K vs K,M) AND the
+// mappings for K conflict, causing the join to reach top.
+
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @join_different_order_conflicting_mappings(
+    %a: !wave.tensor<[@M, @K] of f32>,
+    %b: !wave.tensor<[@M, @K] of f32>
+  ) -> !wave.tensor<[@M, @K] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ]
+  } {
+    // LHS: M, K order with K mapping using T0 floordiv 16
+    // RHS: K, M order with K mapping using T0 floordiv 32 (different!)
+    // The K mappings conflict, causing join to reach top.
+    // expected-error @below {{incompatible operand lattices when propagating from those to result}}
+    // expected-note @below {{operand #0 lattice}}
+    // expected-note @below {{operand #1 lattice}}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>,
+       #wave.index_exprs<[
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 32) * 4, 4, 1),
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+       ]>
+    ]}
+    : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
+    return %result : !wave.tensor<[@M, @K] of f32>
+  }
+}
+
+// -----
+
+// Join conflict: one operand has subset of dimensions with conflicting mapping.
+// LHS has M and K, RHS has only M but with a different mapping.
+
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @join_subset_conflicting_mapping(
+    %a: !wave.tensor<[@M, @K] of f32>,
+    %b: !wave.tensor<[@M, @K] of f32>
+  ) -> !wave.tensor<[@M, @K] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ]
+  } {
+    // LHS: M uses T0 mod 16
+    // RHS: M uses T0 mod 32 (different!)
+    // The M mappings conflict, causing join to reach top.
+    // expected-error @below {{incompatible operand lattices when propagating from those to result}}
+    // expected-note @below {{operand #0 lattice}}
+    // expected-note @below {{operand #1 lattice}}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>,
+       #wave.index_exprs<[
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+       ]>
+    ]}
+    : (!wave.tensor<[@M, @K] of f32>, !wave.tensor<[@M, @K] of f32>) -> !wave.tensor<[@M, @K] of f32>
+    return %result : !wave.tensor<[@M, @K] of f32>
+  }
+}
+
+// -----
+
+// Join conflict: disjoint dimensions with different symbols that conflict
+// when mappings are incompatible.
+
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @join_three_dims_conflicting_shared_dim(
+    %a: !wave.tensor<[@B, @M, @K] of f32>,
+    %b: !wave.tensor<[@B, @M, @K] of f32>
+  ) -> !wave.tensor<[@B, @M, @K] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ]
+  } {
+    // Both have B, M, K but B has conflicting mappings:
+    // LHS: B uses WG2
+    // RHS: B uses WG0 (different workgroup dimension!)
+    // expected-error @below {{incompatible operand lattices when propagating from those to result}}
+    // expected-note @below {{operand #0 lattice}}
+    // expected-note @below {{operand #1 lattice}}
+    %result = wave.add %a, %b {wave_test.override_operand_index = [
+       #wave.index_exprs<[
+         <"B"> : [#wave.index_symbol<WG2>] -> (WG2, 1, 1),
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>,
+       #wave.index_exprs<[
+         <"B"> : [#wave.index_symbol<WG0>] -> (WG0, 1, 1),
+         <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+         <"K"> : [#wave.index_symbol<T0>] -> ((T0 floordiv 16) * 4, 4, 1)
+       ]>
+    ]}
+    : (!wave.tensor<[@B, @M, @K] of f32>, !wave.tensor<[@B, @M, @K] of f32>) -> !wave.tensor<[@B, @M, @K] of f32>
+    return %result : !wave.tensor<[@B, @M, @K] of f32>
   }
 }

--- a/water/test/Dialect/Wave/infer-index-exprs.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs.mlir
@@ -63,21 +63,21 @@ normalform.module [#wave.normal_form<full_types>] {
   ]} {
     // CHECK: wave.mma
     // Left-hand side
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK: }, {
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK: ]>, #wave.index_exprs<[
     // Right-hand side
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
     // Accumulator
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
     // Result (matches the accumulator)
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x16_f16>}
       : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -96,35 +96,35 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.read
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
     %a_read = wave.read %a : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16, <register>>
     // CHECK: wave.read
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
     %b_read = wave.read %b : (!wave.tensor<[@N, @K] of f16>) -> !wave.tensor<[@N, @K] of f16, <register>>
     %cst = arith.constant 0.0 : f32
     // CHECK: wave.register
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %c_reg = wave.register %cst : !wave.tensor<[@M, @N] of f32, <register>>
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %mma = wave.mma %a_read, %b_read, %c_reg {kind = #wave.mma_kind<f32_16x16x16_f16>}
       : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
     // CHECK: wave.write
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     wave.write %mma, %c : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
     return
   }
@@ -148,81 +148,81 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [1, 2, 2]>
   ]} {
     // CHECK: wave.read
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %a_read = wave.read %a
       : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16, <register>>
     // CHECK: wave.read
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %b_read = wave.read %b
       : (!wave.tensor<[@N, @K] of f16>) -> !wave.tensor<[@N, @K] of f16, <register>>
     %cst_0 = arith.constant 0.0 : f32
     // CHECK: wave.register
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %c_reg = wave.register %cst_0
       : !wave.tensor<[@M, @N] of f32, <register>>
     // CHECK: wave.mma
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG: K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %mma1 = wave.mma %a_read, %b_read, %c_reg {kind = #wave.mma_kind<f32_16x16x16_f16>}
       : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // CHECK: wave.cast
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %mma1_casted = wave.cast %mma1
       : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@M, @N] of f16, <register>>
 
     // CHECK: wave.write
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     wave.write %mma1_casted, %storage : !wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@M, @N] of f16>
     // CHECK: wave.read
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
     %reloaded = wave.read %storage : (!wave.tensor<[@M, @N] of f16>) -> !wave.tensor<[@M, @N] of f16, <register>>
 
     // Second read and register
     // CHECK: wave.read
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %d_read = wave.read %d
       : (!wave.tensor<[@P, @N] of f16>) -> !wave.tensor<[@P, @N] of f16, <register>>
     %cst_1 = arith.constant 0.0 : f32
     // CHECK: wave.register
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %c_reg2 = wave.register %cst_1
       : !wave.tensor<[@M, @P] of f32, <register>>
     // CHECK: wave.mma
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK: }, {
-    // CHECK-DAG: N : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"N"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %mma2 = wave.mma %reloaded, %d_read, %c_reg2 {kind = #wave.mma_kind<f32_16x16x16_f16>}
       : (!wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@P, @N] of f16, <register>>, !wave.tensor<[@M, @P] of f32, <register>>) -> !wave.tensor<[@M, @P] of f32, <register>>
 
     // CHECK: wave.write
-    // CHECK-DAG: M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG: P : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG: <"P"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     wave.write %mma2, %c : !wave.tensor<[@M, @P] of f32, <register>>, !wave.tensor<[@M, @P] of f32>
     return
   }
@@ -240,17 +240,17 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 4, 4, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 4, 4, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 4, 4, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 4, 4, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_32x32x8_f16>}
       : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -269,17 +269,17 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 8, 8, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 8, 8, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 8, 8, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 8, 8, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x32_f16>}
       : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -298,17 +298,17 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 16 + ((T0 mod 64) floordiv 16) * 4 + GPR_NUM mod 4, 8, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 16 + ((T0 mod 64) floordiv 16) * 4 + GPR_NUM mod 4, 8, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 16 + ((T0 mod 64) floordiv 16) * 4 + GPR_NUM mod 4, 8, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 16 + ((T0 mod 64) floordiv 16) * 4 + GPR_NUM mod 4, 8, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x32_k4_f8>}
       : (!wave.tensor<[@M, @K] of f8E5M2>, !wave.tensor<[@N, @K] of f8E5M2>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -327,17 +327,17 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_32x32x16_f16>}
       : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -356,17 +356,17 @@ normalform.module [#wave.normal_form<full_types>] {
                               waves_per_block = [2, 3, 4]>
   ]} {
     // CHECK: wave.mma
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 8 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 8, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 8 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 8, 1)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
-    // CHECK: }, {
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 8 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 8, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> ((GPR_NUM floordiv 4) * 8 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 8, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK: ]>, #wave.index_exprs<[
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_32x32x16_k4_f8>}
       : (!wave.tensor<[@M, @K] of f8E5M2>, !wave.tensor<[@N, @K] of f8E5M2>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return
@@ -389,31 +389,31 @@ normalform.module [#wave.normal_form<full_types>] {
     %0 = arith.constant 0.0 : f32
 
     // CHECK:      wave.register
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     %c_reg = wave.register %0 : !wave.tensor<[@M, @N] of f32>
 
     // CHECK:      wave.iterate
     // CHECK-SAME: iter_args
     // CHECK-SAME: index
-    // CHECK-DAG:  M = #wave<index_mapping[#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)>
-    // CHECK-DAG:  N = #wave<index_mapping[#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)>
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     %mma_result = wave.iterate @K iter_args(%c_reg) {
       ^bb0(%acc: !wave.tensor<[@M, @N] of f32>):
 
         // CHECK:      wave.read
-        // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
-        // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+        // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
+        // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
         %a_reg = wave.read %a : (!wave.tensor<[@M, @K] of bf16, <shared>>) -> !wave.tensor<[@M, @K] of bf16>
 
         // CHECK:      wave.read
-        // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
-        // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+        // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
+        // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
         %b_reg = wave.read %b : (!wave.tensor<[@N, @K] of bf16, <shared>>) -> !wave.tensor<[@N, @K] of bf16>
 
         // CHECK:      wave.mma
-        // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
-        // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+        // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 32) * 8, 8, 1)
+        // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
         %inner_acc = wave.mma %a_reg, %b_reg, %acc {kind = #wave.mma_kind<f32_32x32x16_bf16>} :
           (!wave.tensor<[@M, @K] of bf16>, !wave.tensor<[@N, @K] of bf16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
 
@@ -422,8 +422,8 @@ normalform.module [#wave.normal_form<full_types>] {
     } : (!wave.tensor<[@M, @N] of f32>)-> (!wave.tensor<[@M, @N] of f32>)
 
     // CHECK:      wave.write
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>, #wave.index_symbol<GPR_NUM>] -> (((GPR_NUM floordiv 4) * 8) mod 32 + ((T0 mod 64) floordiv 32) * 4 + GPR_NUM mod 4, 16, 32)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 32, 1, 1)
     wave.write %mma_result, %c : !wave.tensor<[@M, @N] of f32> , !wave.tensor<[@M, @N] of f32, <global>>
 
     return
@@ -531,14 +531,14 @@ normalform.module [#wave.normal_form<full_types>] {
   } {
     %cst = arith.constant 1.0 : f16
     // CHECK: wave.register
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
-    // CHECK-DAG:  K : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
     %b_reg = wave.register %cst : !wave.tensor<[@N, @K] of f16, <register>>
     %cst0 = arith.constant 0.0 : f32
     %c_reg = wave.register %cst0 : !wave.tensor<[@M, @N] of f32, <register>>
     // CHECK: wave.allocate
-    // CHECK-DAG:  M : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
-    // CHECK-DAG:  N : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
+    // CHECK-DAG:  <"M"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)
+    // CHECK-DAG:  <"N"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)
     %alloc = wave.allocate {distributed_shape = #wave.expr_list<[] -> (42)>}
       : !wave.tensor<[@M, @N] of f32, <shared>>
     %c = wave.mma %a, %b_reg, %c_reg { kind = #wave.mma_kind<f32_16x16x16_f16> }
@@ -567,17 +567,17 @@ normalform.module [#wave.normal_form<full_types>] {
     wave.iterate @K iter_args() {
       %cst = arith.constant 1.0 : f16
       // CHECK: wave.register
-      // CHECK: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+      // CHECK: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
       %a_reg = wave.register %cst : !wave.tensor<[@M, @K] of f16, <register>>
       %b_reg = wave.register %cst : !wave.tensor<[@N, @K] of f16, <register>>
       // CHECK: wave.register
-      // CHECK: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+      // CHECK: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
       %cst0 = arith.constant 0.0 : f32
       %c_reg = wave.register %cst0 : !wave.tensor<[@M, @N] of f32, <register>>
       %alloc = wave.allocate {distributed_shape = #wave.expr_list<[] -> (42)>}
         : !wave.tensor<[@M, @N] of f32, <shared>>
       // CHECK: wave.mma
-      // CHECK: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+      // CHECK: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
       %c = wave.mma %a_reg, %b_reg, %c_reg { kind = #wave.mma_kind<f32_16x16x16_f16> }
         : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
       wave.write %c, %alloc : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <shared>>
@@ -617,19 +617,19 @@ normalform.module [#wave.normal_form<full_types>] {
       wave.iterate @M iter_args() {
         %cst = arith.constant 1.0 : f16
         // CHECK: wave.register
-        // CHECK-DAG: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
-        // CHECK-DAG: M : [#wave.index_symbol<T0>, #wave.iter<"M">, #wave.symbol<"BLOCK_M">] -> (T0 mod 16 + _Iter_M * BLOCK_M, 1, 1)
+        // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+        // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>, #wave.iter<"M">, #wave.symbol<"BLOCK_M">] -> (T0 mod 16 + _Iter_M * BLOCK_M, 1, 1)
         %a_reg = wave.register %cst : !wave.tensor<[@M, @K] of f16, <register>>
         %b_reg = wave.register %cst : !wave.tensor<[@N, @K] of f16, <register>>
         // CHECK: wave.register
-        // CHECK: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+        // CHECK: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
         %cst0 = arith.constant 0.0 : f32
         %c_reg = wave.register %cst0 : !wave.tensor<[@M, @N] of f32, <register>>
         %alloc = wave.allocate {distributed_shape = #wave.expr_list<[] -> (42)>}
           : !wave.tensor<[@M, @N] of f32, <shared>>
         // CHECK: wave.mma
-        // CHECK-DAG: K : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
-        // CHECK-DAG: M : [#wave.index_symbol<T0>, #wave.iter<"M">, #wave.symbol<"BLOCK_M">] -> (T0 mod 16 + _Iter_M * BLOCK_M, 1, 1)
+        // CHECK-DAG: <"K"> : [#wave.index_symbol<T0>, #wave.iter<"K">, #wave.symbol<"BLOCK_K">] -> (((T0 mod 64) floordiv 16) * 4 + _Iter_K * BLOCK_K, 4, 1
+        // CHECK-DAG: <"M"> : [#wave.index_symbol<T0>, #wave.iter<"M">, #wave.symbol<"BLOCK_M">] -> (T0 mod 16 + _Iter_M * BLOCK_M, 1, 1)
         %c = wave.mma %a_reg, %b_reg, %c_reg { kind = #wave.mma_kind<f32_16x16x16_f16> }
           : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
         wave.write %c, %alloc : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <shared>>

--- a/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir-invalid.mlir
@@ -34,10 +34,10 @@ normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,re
     // WriteOpLoweringPattern requires valid stride expressions (not NULL)
     // expected-error @+1 {{failed to legalize operation 'wave.write' that was explicitly marked illegal}}
     wave.write %reg, %mem
-      index [{
-        M : [#wave.index_symbol<T0>] -> (T0, <NULL>, 1),
-        N : [#wave.index_symbol<T1>] -> (T1, 1, 1)
-      }]
+      {index = [#wave.index_exprs<[
+        <"M"> : [#wave.index_symbol<T0>] -> (T0, <NULL>, 1),
+        <"N"> : [#wave.index_symbol<T1>] -> (T1, 1, 1)
+      ]>]}
       : vector<8xf16>, !wave.tensor<[@M, @N] of f16, <global>>
     return
   }
@@ -52,9 +52,9 @@ normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,re
   func.func @lower_read_non_innermost_dim(%mem: !wave.tensor<[@M, @N] of f16, <global>>)
     attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128, N = 128}>} {
     // expected-error @below {{failed to legalize}}
-    %0 = wave.read %mem index [{
-      M : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 * 8 , <NULL>, 64),
-      N : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)}]
+    %0 = wave.read %mem {index = [#wave.index_exprs<[
+      <"M"> : [#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 * 8 , <NULL>, 64),
+      <"N"> : [#wave.index_symbol<WG1>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 8) * T1, 1, 1)]>]}
       : (!wave.tensor<[@M, @N] of f16, <global>>) -> vector<8xf16>
     return
   }

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -249,7 +249,7 @@ func.func @iterate_result_terminator_address_space_mismatch(%arg0: !wave.tensor<
 // must provide the full triple (start, step, stride)
 func.func @index_attr_wrong_attr_type(%arg0: f32) {
   // expected-error @below {{expected symbol names to be one of WaveSymbolAttr, WaveIndexSymbolAttr or WaveIterSymbolAtt}}
-  wave.register %arg0 index [{X : [#wave.workgroup_dim<x>] -> (WG0)}] : !wave.tensor<[@M] of f32, <register>>
+  wave.register %arg0 {index = [#wave.index_exprs<[<"X"> : [#wave.workgroup_dim<x>] -> (WG0, 1, 1)]>]} : !wave.tensor<[@M] of f32, <register>>
   return
 }
 
@@ -258,8 +258,8 @@ func.func @index_attr_wrong_attr_type(%arg0: f32) {
 // must provide the full triple (start, step, stride)
 func.func @index_attr_missing_step_stride(%arg0: f32) {
   // expected-error @+2 {{expected ','}}
-  // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
-  wave.register %arg0 index [{X : [#wave.index_symbol<WG0>] -> (WG0)}] : !wave.tensor<[@M] of f32, <register>>
+  // expected-error @+1 {{expected three affine expressions for '(start, step, stride)'}}
+  wave.register %arg0 {index = [#wave.index_exprs<[<"X"> : [#wave.index_symbol<WG0>] -> (WG0)]>]} : !wave.tensor<[@M] of f32, <register>>
   return
 }
 
@@ -268,24 +268,24 @@ func.func @index_attr_missing_step_stride(%arg0: f32) {
 // must provide the full triple (start, step, stride)
 func.func @index_attr_missing_stride(%arg0: f32) {
   // expected-error @+2 {{expected ','}}
-  // expected-error @+1 {{custom op 'wave.register' expected three affine expressions for '(start, step, stride)'}}
-  wave.register %arg0 index [{X : [#wave.index_symbol<WG0>] -> (WG0, 1)}] : !wave.tensor<[@M] of f32, <register>>
+  // expected-error @+1 {{expected three affine expressions for '(start, step, stride)'}}
+  wave.register %arg0 {index = [#wave.index_exprs<[<"X"> : [#wave.index_symbol<WG0>] -> (WG0, 1)]>]} : !wave.tensor<[@M] of f32, <register>>
   return
 }
 
 // -----
 
 func.func @index_attr_not_dict(%arg0: f32) {
-  // expected-error @+1 {{'wave.register' op attribute 'index' failed to satisfy constraint: Array of dictionary attributes}}
+  // expected-error @+1 {{'wave.register' op attribute 'index' failed to satisfy constraint: array of WaveIndexExprsAttr}}
   "wave.register"(%arg0) { index = 42 } : (f32) -> !wave.tensor<[@M] of f32, <register>>
   return
 }
 
 // -----
 
-// 'index' array elements must be dictionaries mapping to WaveIndexMappingAttr values.
+// 'index' array elements must be WaveIndexExprsAttr, not dictionaries.
 func.func @index_attr_wrong_value_type(%arg0: f32) {
-  // expected-error @below {{'index' attribute value for key "M" must be WaveIndexMappingAttr, got 42 : i64}}
+  // expected-error @below {{'wave.register' op attribute 'index' failed to satisfy constraint: array of WaveIndexExprsAttr}}
   "wave.register"(%arg0) { index = [{ M = 42 }] } : (f32) -> vector<4xf32>
   return
 }
@@ -294,7 +294,7 @@ func.func @index_attr_wrong_value_type(%arg0: f32) {
 
 func.func @index_attr_iter_not_allowed(%arg0: f32) {
   // expected-error @below {{index expression uses iterator symbol M which is not defined by any parent op}}
-  wave.register %arg0 index [{M : [#wave.iter<"M">] -> (_Iter_M, 1, 1)}] : !wave.tensor<[@M] of f32, <register>>
+  wave.register %arg0 {index = [#wave.index_exprs<[ <"M"> : [#wave.iter<"M">] -> (_Iter_M, 1, 1)]>]} : !wave.tensor<[@M] of f32, <register>>
   return
 }
 
@@ -402,11 +402,11 @@ module attributes { wave.hyperparameters = #wave.hyperparameters<{A = 42, C = 43
 normalform.module [#wave.normal_form<full_types>] {
   func.func @index_key_unspecified(%mem: !wave.tensor<[@M] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 64, BLOCK_N = 64, M = 128}>}  {
-    // expected-error @below {{attribute "index" uses symbolic value "N" not provided as a hyperparameter}}
+    // expected-error @below {{attribute "index" uses symbolic value #wave.symbol<"N"> not provided as a hyperparameter}}
     // expected-note @below {{BLOCK_M, BLOCK_N, M}}
-    %0 = wave.read %mem index [{
-        M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+    %0 = wave.read %mem {index = [#wave.index_exprs<[
+        <"M"> : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+        <"N"> : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)]>]}
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
@@ -419,9 +419,9 @@ normalform.module [#wave.normal_form<full_types>] {
   attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 256}>}  {
     // expected-error @below {{attribute "index" uses symbolic value #wave.symbol<"BLOCK_M"> not provided as a hyperparameter}}
     // expected-note @below {{available symbols: M, N}}
-    %0 = wave.read %mem index [{
-        M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-        N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+    %0 = wave.read %mem {index = [#wave.index_exprs<[
+        <"M"> : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+        <"N"> : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)]>]}
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
@@ -467,10 +467,10 @@ func.func @bounds_wrong_type(%mem: !wave.tensor<[@N] of f32>) {
 func.func @read_index_multi_step(%mem: !wave.tensor<[@M, @N] of f32>) {
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}
-  wave.read %mem index [{
-    M : [#wave.index_symbol<T0>] -> (T0, 2, 1),
-    N : [#wave.index_symbol<T1>] -> (T1, 2, 1)
-  }] : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
+  wave.read %mem {index = [#wave.index_exprs<[
+    <"M"> : [#wave.index_symbol<T0>] -> (T0, 2, 1),
+    <"N"> : [#wave.index_symbol<T1>] -> (T1, 2, 1)
+  ]>]} : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
   return
 }
 
@@ -478,12 +478,10 @@ func.func @read_index_multi_step(%mem: !wave.tensor<[@M, @N] of f32>) {
 
 func.func @read_index_elements_per_thread_mismatch(%mem: !wave.tensor<[@M, @N] of f32>) {
   // expected-error @below {{vectorized dimension step in the index expression with current hyperparameters (2) doesn't match the explicitly specified elements per thread value (4)}}
-  wave.read %mem index [{
-    M : [#wave.index_symbol<T0>] -> (T0, 2, 1),
-    N : [#wave.index_symbol<T1>] -> (T1, 1, 1)
-  }]{
-    elements_per_thread = 4
-  } : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
+  wave.read %mem {index = [#wave.index_exprs<[
+    <"M"> : [#wave.index_symbol<T0>] -> (T0, 2, 1),
+    <"N"> : [#wave.index_symbol<T1>] -> (T1, 1, 1)
+  ]>], elements_per_thread = 4} : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<any of f32, <register>>
   return
 }
 
@@ -492,10 +490,10 @@ func.func @read_index_elements_per_thread_mismatch(%mem: !wave.tensor<[@M, @N] o
 
 func.func @read_index_type_mismatch(%mem: !wave.tensor<[@M, @N] of f32>) {
   // expected-error @below {{vectorized dimension step in the index expression with current hyperparameters (2) doesn't match the vector size (4)}}
-  wave.read %mem index [{
-    M : [#wave.index_symbol<T0>] -> (T0, 2, 1),
-    N : [#wave.index_symbol<T1>] -> (T1, 1, 1)
-  }] : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
+  wave.read %mem {index = [#wave.index_exprs<[
+    <"M"> : [#wave.index_symbol<T0>] -> (T0, 2, 1),
+    <"N"> : [#wave.index_symbol<T1>] -> (T1, 1, 1)
+  ]>]} : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
   return
 }
 
@@ -506,10 +504,10 @@ func.func @read_index_multi_step_eval(%mem: !wave.tensor<[@M, @N] of f32>) attri
 } {
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}
-  wave.read %mem index [{
-    M : [#wave.index_symbol<T0>, #wave.symbol<"X">] -> (T0, 2 * X, 1),
-    N : [#wave.index_symbol<T1>, #wave.symbol<"X">, #wave.symbol<"Y">] -> (T1, X + Y, 1)
-  }] : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
+  wave.read %mem {index = [#wave.index_exprs<[
+    <"M"> : [#wave.index_symbol<T0>, #wave.symbol<"X">] -> (T0, 2 * X, 1),
+    <"N"> : [#wave.index_symbol<T1>, #wave.symbol<"X">, #wave.symbol<"Y">] -> (T1, X + Y, 1)
+  ]>]} : (!wave.tensor<[@M, @N] of f32>) -> vector<4xf32>
   return
 }
 

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -75,7 +75,7 @@ func.func @using_iter_symbol(%arg0: f32) {
   %0 = wave.register %arg0 : !wave.tensor<[@M] of f32, <register>>
   wave.iterate @M iter_args(%0) {
   ^bb0(%arg1: !wave.tensor<[@M] of f32, <register>>):
-    wave.register %arg0 index [{M : [#wave.iter<"M">] -> (0, 1, 1)}] : !wave.tensor<[@M] of f32, <register>>
+    wave.register %arg0 {index = [#wave.index_exprs<[ <"M"> : [#wave.iter<"M">] -> (0, 1, 1)]>]} : !wave.tensor<[@M] of f32, <register>>
     wave.yield %arg1 : !wave.tensor<[@M] of f32, <register>>
   } : (!wave.tensor<[@M] of f32, <register>>) -> !wave.tensor<any of f32>
   return
@@ -94,10 +94,10 @@ func.func @register_with_symbols() {
   %0 = arith.constant 0.0 : f32
   // CHECK: wave.register
   %register = wave.register %0
-    index [{
-      M : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
-      N : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
-    }]
+    {index = [#wave.index_exprs<[
+      <"M"> : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID floordiv BLOCK_SIZE, 1, 1),
+      <"N"> : [#wave.symbol<"THREAD_ID">, #wave.symbol<"BLOCK_SIZE">] -> (THREAD_ID * BLOCK_SIZE + 42, 1, 1)
+    ]>]}
     : !wave.tensor<[@M, @N] of f32, <register>>
   return
 }
@@ -107,11 +107,11 @@ func.func @register_with_symbols_complex_index() {
   %0 = arith.constant 0.0 : f32
   // CHECK: wave.register
   %register = wave.register %0
-    index [{
-      B : [#wave.index_symbol<WG2>, #wave.symbol<"BLOCK_B">] -> (WG2 * (BLOCK_B+BLOCK_B), BLOCK_B * (WG2+WG2), WG2 * BLOCK_B),
-      M : [#wave.index_symbol<WG0>, #wave.symbol<"BLOCK_M">, #wave.index_symbol<T0>] -> (WG0 * BLOCK_M + BLOCK_M * ((T0 floordiv 64) floordiv 2) + T0 mod 32, 1, 1),
-      N : [#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">, #wave.index_symbol<WG1>, #wave.index_symbol<GPR_NUM>, #wave.index_symbol<T0>] -> (T1 * (BLOCK_N floordiv 2) + BLOCK_N * WG1 + GPR_NUM mod 4 + ((GPR_NUM floordiv 4) mod 4) * 8 + ((T0 mod 64) floordiv 32) * 4, 1, 1)
-    }]
+    {index = [#wave.index_exprs<[
+      <"B"> : [#wave.index_symbol<WG2>, #wave.symbol<"BLOCK_B">] -> (WG2 * (BLOCK_B+BLOCK_B), BLOCK_B * (WG2+WG2), WG2 * BLOCK_B),
+      <"M"> : [#wave.index_symbol<WG0>, #wave.symbol<"BLOCK_M">, #wave.index_symbol<T0>] -> (WG0 * BLOCK_M + BLOCK_M * ((T0 floordiv 64) floordiv 2) + T0 mod 32, 1, 1),
+      <"N"> : [#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">, #wave.index_symbol<WG1>, #wave.index_symbol<GPR_NUM>, #wave.index_symbol<T0>] -> (T1 * (BLOCK_N floordiv 2) + BLOCK_N * WG1 + GPR_NUM mod 4 + ((GPR_NUM floordiv 4) mod 4) * 8 + ((T0 mod 64) floordiv 32) * 4, 1, 1)
+    ]>]}
     : !wave.tensor<[@B, @N, @M] of f32, <register>>
   return
 }
@@ -120,7 +120,7 @@ func.func @register_with_symbols_complex_index() {
 func.func @register_with_symbols_empty_symbol_list() {
   %0 = arith.constant 0.0 : f32
   // CHECK: wave.register
-  %register = wave.register %0 index [{B : [] -> (0, 1, 1)}]
+  %register = wave.register %0 {index = [#wave.index_exprs<[<"B"> : [] -> (0, 1, 1)]>]}
     : !wave.tensor<[@B] of f32, <register>>
   return
 }
@@ -311,9 +311,9 @@ attributes {wave.hyperparameters = #wave.hyperparameters<{BLOCK_M = 32, BLOCK_N 
   // CHECK: index
   // CHECK: #wave.index_symbol<WG0>
   // CHECK: #wave.index_symbol<T0>
-  %0 = wave.read %mem index [{
-      M : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
-      N : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)}]
+  %0 = wave.read %mem {index = [#wave.index_exprs<[
+      <"M"> : [#wave.symbol<"BLOCK_M">, #wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (BLOCK_M * WG0 + (BLOCK_M floordiv 2) * (T0 floordiv 64) + T0 mod 64, 1, 64),
+      <"N"> : [#wave.index_symbol<T1>, #wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N + (BLOCK_N floordiv 2) * T1, BLOCK_N ceildiv 2, 1)]>]}
     : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
   return
 }
@@ -357,10 +357,10 @@ func.func @cast_wave_tensor_underspecified(%arg0: !wave.tensor<any of f32>) -> !
 func.func @cast_wave_tensor_with_index(%arg0: !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f16> {
   // CHECK: wave.cast
   // CHECK-SAME: index
-  %0 = wave.cast %arg0 index [{
-    M : [#wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (T0 * BLOCK_M, 1, 1),
-    N : [#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (T1 * BLOCK_N, 1, 1)
-  }] : !wave.tensor<[@M, @N] of f32> to !wave.tensor<[@M, @N] of f16>
+  %0 = wave.cast %arg0 {index = [#wave.index_exprs<[
+    <"M"> : [#wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (T0 * BLOCK_M, 1, 1),
+    <"N"> : [#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (T1 * BLOCK_N, 1, 1)
+  ]>]} : !wave.tensor<[@M, @N] of f32> to !wave.tensor<[@M, @N] of f16>
   return %0 : !wave.tensor<[@M, @N] of f16>
 }
 
@@ -446,5 +446,28 @@ func.func @empty_yield() {
     // CHECK: wave.yield
     wave.yield
   } : () -> ()
+  return
+}
+
+// -----
+
+// This test verifies that WaveIndexExprsAttr preserves dimension ordering
+// during parsing and printing. Unlike DictionaryAttr which alphabetically
+// sorts entries (K before M), WaveIndexExprsAttr maintains insertion order.
+
+// CHECK-LABEL: @index_exprs_preserve_dimension_order
+func.func @index_exprs_preserve_dimension_order() {
+  %0 = arith.constant 0.0 : f16
+  // Dimensions are listed as M, K - this order must be preserved.
+  // With DictionaryAttr, this would be reordered to K, M (alphabetical).
+  // CHECK: wave.register
+  // CHECK-SAME: index =
+  // CHECK-SAME: <"M"> : {{.*}}, <"K"> :
+  %register = wave.register %0
+    {index = [#wave.index_exprs<[
+      <"M"> : [#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1),
+      <"K"> : [#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 1)
+    ]>]}
+    : !wave.tensor<[@M, @K] of f16, <register>>
   return
 }

--- a/water/test/lib/Transforms/TestWaveDialectInferIndexExprs.cpp
+++ b/water/test/lib/Transforms/TestWaveDialectInferIndexExprs.cpp
@@ -42,17 +42,14 @@ overrideInitialization(Operation *top,
         continue;
       }
 
-      auto dict = llvm::dyn_cast<DictionaryAttr>(attr);
-      if (!dict || llvm::any_of(dict.getValue(), [](NamedAttribute attr) {
-            return !llvm::isa<wave::WaveIndexMappingAttr>(attr.getValue());
-          })) {
+      auto indexExprs = llvm::dyn_cast<wave::WaveIndexExprsAttr>(attr);
+      if (!indexExprs) {
         return op->emitError()
                << "expected " << attributeName
-               << " to be an array of "
-                  "dictionaries with WaveIndexMappingAttr or UnitAttr values";
+               << " to be an array of WaveIndexExprsAttr or UnitAttr values";
       }
 
-      setIndexForValue(value, dict);
+      setIndexForValue(value, indexExprs);
     }
     return success();
   };

--- a/wave_lang/kernel/wave/mlir_converter/mlir_to_wave.py
+++ b/wave_lang/kernel/wave/mlir_converter/mlir_to_wave.py
@@ -143,18 +143,18 @@ def _convert_index_mapping_attr_to_sympy(
     return IndexSequence(start, step, stride)
 
 
-def _convert_index_mapping_dict_to_sympy(
-    dict_attr: ir.DictAttr,
+def _convert_index_exprs_to_sympy(
+    index_exprs_attr: wave.WaveIndexExprsAttr,
 ) -> dict[IndexSymbol, IndexSequence]:
-    """Convert a dictionary attribute containing WaveIndexMappingAttr to a dictionary of Wave IndexSequences."""
+    """Convert a WaveIndexExprsAttr to a dictionary of Wave IndexSequences."""
     result = {}
-    for named_attr in dict_attr:
-        key = named_attr.name
-        value = named_attr.attr
+    for entry in index_exprs_attr.entries:
+        key = entry.dimension.name
+        mapping = entry.mapping
         assert isinstance(
-            value, wave.WaveIndexMappingAttr
-        ), f"Unsupported index mapping attribute: {value}"
-        result[index_symbol(key)] = _convert_index_mapping_attr_to_sympy(value)
+            mapping, wave.WaveIndexMappingAttr
+        ), f"Unsupported index mapping attribute: {mapping}"
+        result[index_symbol(key)] = _convert_index_mapping_attr_to_sympy(mapping)
     return result
 
 
@@ -190,15 +190,15 @@ def convert_index_mapping_array_to_sympy(
         assert (
             len(array_attr) == 1
         ), f"Expected exactly one index mapping attribute for non-MMA op: {op}"
-        return _convert_index_mapping_dict_to_sympy(array_attr[0])
+        return _convert_index_exprs_to_sympy(array_attr[0])
 
     assert (
         len(array_attr) == 4
     ), f"Expected exactly four index mapping attributes for MMA op: {op}"
-    lhs_index = _convert_index_mapping_dict_to_sympy(array_attr[0])
-    rhs_index = _convert_index_mapping_dict_to_sympy(array_attr[1])
-    acc_index = _convert_index_mapping_dict_to_sympy(array_attr[2])
-    result_index = _convert_index_mapping_dict_to_sympy(array_attr[3])
+    lhs_index = _convert_index_exprs_to_sympy(array_attr[0])
+    rhs_index = _convert_index_exprs_to_sympy(array_attr[1])
+    acc_index = _convert_index_exprs_to_sympy(array_attr[2])
+    result_index = _convert_index_exprs_to_sympy(array_attr[3])
     mk_symbols = set(lhs_index.keys())
     nk_symbols = set(rhs_index.keys())
     m_symbol = (mk_symbols - nk_symbols).pop()

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -321,22 +321,21 @@ def _symbol_name_to_attribute(name: str) -> ir.Attribute:
         return wave.WaveSymbolAttr.get(name)
 
 
-def _build_index_mapping_dict(
+def _build_index_exprs_attr(
     index: dict[IndexSymbol, IndexSequence], allowed_induction_symbols: set[IndexSymbol]
-) -> ir.DictAttr:
+) -> wave.WaveIndexExprsAttr:
     """
-    Convert a Wave index dictionary into a DictionaryAttr of
-    WaveIndexMappingAttr.
+    Convert a Wave index dictionary into a WaveIndexExprsAttr.
 
-    For MMA, multiple DictAttr objects are assembled into an ArrayAttr (one per
-    operand). For all other nodes a single-element ArrayAttr is used.
+    For MMA, multiple WaveIndexExprsAttr objects are assembled into an ArrayAttr
+    (one per operand). For all other nodes a single-element ArrayAttr is used.
 
     The `allowed_induction_symbols` argument lists induction variable-related
     symbols that are allowed to be present in the expressions. Other symbols
     will be removed and a warning will be generated if it is the case.
     """
 
-    index_mappings: dict[str, ir.Attribute] = {}
+    entries: list[wave.WaveIndexEntryAttr] = []
     for dim, exprs in index.items():
         all_symbols_set = set().union(
             *[
@@ -372,17 +371,17 @@ def _build_index_mapping_dict(
         symbol_attrs = [
             _symbol_name_to_attribute(sym.name) for sym in symbol_mapping.values()
         ]
-        index_mappings[dim.name] = wave.WaveIndexMappingAttr.get(
-            symbol_attrs, start, size, stride
-        )
-    return ir.DictAttr.get(index_mappings)
+        mapping = wave.WaveIndexMappingAttr.get(symbol_attrs, start, size, stride)
+        dim_attr = wave.WaveSymbolAttr.get(dim.name)
+        entries.append(wave.WaveIndexEntryAttr.get(dim_attr, mapping))
+    return wave.WaveIndexExprsAttr.get(entries)
 
 
 def _attach_attributes(
     node: CustomOp, op: ir.Operation, known_ids: set[str] | None = None
 ):
     if getattr(node, "index", None) and isinstance(node.index, dict):
-        dict_attrs: list[ir.DictAttr] = []
+        index_exprs_attrs: list[wave.WaveIndexExprsAttr] = []
 
         # XXX: Collect induction-related symbols that make sense in the current
         # context; the frontend is buggy and may have these symbols outside of
@@ -396,25 +395,25 @@ def _attach_attributes(
                 allowed_induction_symbols.add(induction_symbol)
 
         if isinstance(node, MMA):
-            # Build one index mapping dict per operand for MMA nodes
+            # Build one index exprs attr per operand for MMA nodes
             if lhs_index := getattr(node, "lhs_index", None):
-                dict_attrs.append(
-                    _build_index_mapping_dict(lhs_index, allowed_induction_symbols)
+                index_exprs_attrs.append(
+                    _build_index_exprs_attr(lhs_index, allowed_induction_symbols)
                 )
             if rhs_index := getattr(node, "rhs_index", None):
-                dict_attrs.append(
-                    _build_index_mapping_dict(rhs_index, allowed_induction_symbols)
+                index_exprs_attrs.append(
+                    _build_index_exprs_attr(rhs_index, allowed_induction_symbols)
                 )
             if acc_index := getattr(node, "acc_index", None):
-                dict_attrs.append(
-                    _build_index_mapping_dict(acc_index, allowed_induction_symbols)
+                index_exprs_attrs.append(
+                    _build_index_exprs_attr(acc_index, allowed_induction_symbols)
                 )
         else:
-            dict_attrs.append(
-                _build_index_mapping_dict(node.index, allowed_induction_symbols)
+            index_exprs_attrs.append(
+                _build_index_exprs_attr(node.index, allowed_induction_symbols)
             )
 
-        op.attributes["index"] = ir.ArrayAttr.get(dict_attrs)
+        op.attributes["index"] = ir.ArrayAttr.get(index_exprs_attrs)
 
     if getattr(node, "elements_per_thread", None):
         op.attributes["elements_per_thread"] = ir.IntegerAttr.get(


### PR DESCRIPTION
Index expressions map tensor dimensions to thread/workgroup coordinates for memory access lowering. The dimension order in these expressions must match the tensor type's shape order (e.g., `[@M, @K] -> {M: ..., K: ...}`). However, DictionaryAttr alphabetically sorts its entries, so `{M, K}` becomes `{K, M}`. This causes incorrect lowering when the tensor type is no longer available (e.g., after conversion to memref).

This PR introduces WaveIndexExprsAttr, an ordered attribute that preserves insertion order. It consists of:
  - WaveIndexEntryAttr: A single (dimension, mapping) pair where dimension is a WaveSymbolAttr and mapping is a WaveIndexMappingAttr
  - WaveIndexExprsAttr: An ordered array of WaveIndexEntryAttr entries

  Syntax: `#wave.index_exprs<[@M : <mapping>, @K : <mapping>]>`

The join() operation in lattice analysis uses a LHS-first policy (LHS entries first, then RHS-only entries) as a conventional choice to ensure deterministic output.

Changes:
  - Add WaveIndexEntryAttr and WaveIndexExprsAttr attribute definitions
  - Update IndexExprsLatticeStorage to use WaveIndexExprsAttr and MapVector for order preservation
  - Add C API and Python bindings
  - Update Python emitter/converter