### PR TITLE
Enable kernel argument preloading in ASM backend

### DIFF
--- a/tests/kernel/wave/test_cfg_liveness.py
+++ b/tests/kernel/wave/test_cfg_liveness.py
@@ -74,7 +74,7 @@ class TestCFGConstruction:
 
         # v0 = 1; branch target; v0 = 2; target: v0 = 3
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
-        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="target"))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), target="target"))
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(2),)))
         program.emit(KInstr(Instruction._LABEL, (), (), comment="target"))
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(3),)))
@@ -92,7 +92,7 @@ class TestCFGConstruction:
         v0 = program.alloc_vreg()
 
         # cbranch target; v0 = 1; target: v0 = 2
-        program.emit(KInstr(Instruction.S_CBRANCH_SCC1, (), (), comment="target"))
+        program.emit(KInstr(Instruction.S_CBRANCH_SCC1, (), (), target="target"))
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
         program.emit(KInstr(Instruction._LABEL, (), (), comment="target"))
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(2),)))
@@ -110,7 +110,7 @@ class TestCFGConstruction:
         # loop_header: v0 = 1; branch loop_header
         program.emit(KInstr(Instruction._LABEL, (), (), comment="loop_header"))
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
-        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), target="loop_header"))
 
         cfg = build_cfg(program)
 
@@ -191,7 +191,7 @@ class TestCFGLiveness:
         # Block 0: v0 = 1; branch block1
         # Block 1: v1 = v0 + 1
         program.emit(KInstr(Instruction.V_MOV_B32, (v0,), (KImm(1),)))
-        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="block1"))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), target="block1"))
         program.emit(KInstr(Instruction._LABEL, (), (), comment="block1"))
         program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))
 
@@ -219,7 +219,7 @@ class TestCFGLiveness:
         program.emit(KInstr(Instruction.V_ADD_U32, (v2,), (v0, v1)))
 
         # Loop latch: branch back
-        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop_header"))
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), target="loop_header"))
 
         cfg = build_cfg(program)
         compute_cfg_liveness(cfg, program.instructions)
@@ -271,7 +271,7 @@ class TestLiveRangeExtension:
 
         # branch loop_header (back-edge)
         program.emit(
-            KInstr(Instruction.S_BRANCH, (), (), comment="loop_header")
+            KInstr(Instruction.S_BRANCH, (), (), target="loop_header")
         )  # idx 3
 
         info = compute_liveness(program, use_cfg=True)
@@ -298,7 +298,7 @@ class TestLiveRangeExtension:
         program.emit(KInstr(Instruction.V_ADD_U32, (v1,), (v0, KImm(1))))  # idx 2
 
         # branch loop
-        program.emit(KInstr(Instruction.S_BRANCH, (), (), comment="loop"))  # idx 3
+        program.emit(KInstr(Instruction.S_BRANCH, (), (), target="loop"))  # idx 3
 
         # Compare CFG-based vs linear liveness
         info_cfg = compute_liveness(program, use_cfg=True)
@@ -335,7 +335,7 @@ class TestIntegration:
         # Compare and conditional branch
         program.emit(KInstr(Instruction.S_CMP_LT_U32, (), (counter, bound)))  # idx 4
         program.emit(
-            KInstr(Instruction.S_CBRANCH_SCC0, (), (), comment="loop_exit")
+            KInstr(Instruction.S_CBRANCH_SCC0, (), (), target="loop_exit")
         )  # idx 5
 
         # Loop body: use tid (loop-invariant)
@@ -349,7 +349,7 @@ class TestIntegration:
 
         # Branch back
         program.emit(
-            KInstr(Instruction.S_BRANCH, (), (), comment="loop_header")
+            KInstr(Instruction.S_BRANCH, (), (), target="loop_header")
         )  # idx 8
 
         # loop_exit:

--- a/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
+++ b/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
@@ -1098,6 +1098,14 @@ instructions:
     uses: []
     latency: 0
 
+  _srd_copy_base:
+    mnemonic: ""
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+
   _srd_fill_size:
     mnemonic: ""
     category: pseudo
@@ -1164,3 +1172,14 @@ instructions:
     defs: []
     uses: []
     latency: 0
+
+  # Kernel argument preloading entry point pattern (s_branch to aligned label)
+  _preload_branch:
+    mnemonic: "s_branch"
+    category: pseudo
+    format: pseudo
+    defs: []
+    uses: []
+    latency: 0
+    special:
+      branch: true

--- a/wave_lang/kernel/wave/asm/kernel_liveness.py
+++ b/wave_lang/kernel/wave/asm/kernel_liveness.py
@@ -207,7 +207,7 @@ def _is_conditional_branch(instr: KInstr) -> bool:
 def _get_branch_target(instr: KInstr) -> Optional[str]:
     """Get the target label of a branch instruction."""
     if _is_branch_instruction(instr):
-        return instr.comment  # Branch target is stored in comment
+        return instr.target
     return None
 
 

--- a/wave_lang/kernel/wave/asm/kernel_loops.py
+++ b/wave_lang/kernel/wave/asm/kernel_loops.py
@@ -102,12 +102,12 @@ class _LoopSupport:
 
         # Branch to body if SCC=1
         self.program.emit(
-            KInstr(Instruction.S_CBRANCH_SCC1, (), (), comment=f"loop_{loop_id}_body")
+            KInstr(Instruction.S_CBRANCH_SCC1, (), (), target=f"loop_{loop_id}_body")
         )
 
         # Branch to exit if not taken
         self.program.emit(
-            KInstr(Instruction.S_BRANCH, (), (), comment=f"loop_{loop_id}_exit")
+            KInstr(Instruction.S_BRANCH, (), (), target=f"loop_{loop_id}_exit")
         )
 
         # Body label
@@ -141,7 +141,7 @@ class _LoopSupport:
 
         # Branch back to header
         self.program.emit(
-            KInstr(Instruction.S_BRANCH, (), (), comment=f"loop_{loop_id}_header")
+            KInstr(Instruction.S_BRANCH, (), (), target=f"loop_{loop_id}_header")
         )
 
     def end_loop(self):

--- a/wave_lang/kernel/wave/asm/kernel_passes.py
+++ b/wave_lang/kernel/wave/asm/kernel_passes.py
@@ -100,6 +100,7 @@ class _CompilationPasses:
             self.program,
             reserved_vgprs=reserved_vgprs,
             reserved_sgprs=reserved_sgprs,
+            precolored_sregs=self._precolored_sregs if self._precolored_sregs else None,
         )
 
         # Render


### PR DESCRIPTION
Implement kernel argument preloading for gfx950/MI350X following LLVM's pattern:

1. Emit s_load into preload locations (s[2:3], s[4:5], etc.) BEFORE branch
2. s_waitcnt lgkmcnt(0)
3. s_branch to 256-byte aligned entry point
4. .p2align 8 for alignment
5. Copy from preload locations to SRD ranges (s_mov_b64)
6. Continue with kernel code

This ensures compatibility:
- If hardware preloading works: s_load is idempotent, values already there
- If hardware preloading fails: s_load provides the values

Changes:
- kernel_compilation_context.py: Restructured _emit_srd_prologue() to emit s_load into preload locations before branch, then copy to SRD ranges after. Added KERNARG_PTR_SGPRS constant and _emit_wgid_prologue() helper (DRY).
- kernel_generator.py: Added handler for _preload_branch pseudo-instruction
- kernel_ir.py: Updated is_branch to handle _preload_branch
- kernel_module_compiler.py: Gate preloading by target (gfx95*) and COv5+. Added MAX_PRELOAD_SGPRS limit (16 SGPRs = 8 pointer args).
- metadata_emitter.py: Added preloading AMDHSA metadata fields, guarded by COv5+
- kernel_expr_emitter.py: Added _handle_wgid() helper (DRY)
- instruction_defs/common.yaml: Added _preload_branch pseudo instruction
- docs/wave/asm_backend.rst: Added Kernel Argument Preloading documentation
- docs/wave/register_allocation.rst: Updated ABI docs with preloading SGPR layout

Expected benefit: ~12-25% speedup for small kernels by eliminating ~100 cycle s_load latency at kernel startup.

All 56 ASM backend tests passing.