### PR TITLE
[water] add wave.sub op

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -109,6 +109,11 @@ def AddOp : BinaryWaveOp<"add"> {
   let description = baseDescription;
 }
 
+def SubOp : BinaryWaveOp<"sub"> {
+  let summary = "Subtract two values";
+  let description = baseDescription;
+}
+
 def MulOp : BinaryWaveOp<"mul"> {
   let summary = "Multiply two values";
   let description = baseDescription;

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -75,10 +75,11 @@ struct LowerWaveToMLIRPass
       vector::VectorDialect
         // clang-format on
         >();
-    target.addIllegalOp<wave::AddOp, wave::AllocateOp, wave::CastOp,
-                        wave::DivOp, wave::Exp2Op, wave::ExtractSliceOp,
-                        wave::IterateOp, wave::MmaOp, wave::MulOp, wave::ReadOp,
-                        wave::RegisterOp, wave::WriteOp, wave::YieldOp>();
+    target
+        .addIllegalOp<wave::AddOp, wave::SubOp, wave::AllocateOp, wave::CastOp,
+                      wave::DivOp, wave::Exp2Op, wave::ExtractSliceOp,
+                      wave::IterateOp, wave::MmaOp, wave::MulOp, wave::ReadOp,
+                      wave::RegisterOp, wave::WriteOp, wave::YieldOp>();
 
     // Mark functions as illegal if they have Wave tensor types in their
     // signature.

--- a/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -113,6 +113,7 @@ void wave::populateWaveBinaryOpLoweringPatterns(
     WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns
       .add<BinaryOpLoweringPattern<wave::AddOp, arith::AddFOp, arith::AddIOp>,
+           BinaryOpLoweringPattern<wave::SubOp, arith::SubFOp, arith::SubIOp>,
            BinaryOpLoweringPattern<wave::MulOp, arith::MulFOp, arith::MulIOp>,
            BinaryOpLoweringPattern<wave::DivOp, arith::DivFOp, arith::DivSIOp>>(
           typeConverter, patterns.getContext());

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -271,6 +271,34 @@ normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,re
 // -----
 
 normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,resolved_allocations>] {
+  // CHECK-LABEL: func.func @lower_sub
+  func.func @lower_sub() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
+    // CHECK-NOT: wave.sub
+    // CHECK:     %[[LHS:.*]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+    // CHECK:     %[[RHS:.*]] = arith.constant dense<2.000000e+00> : vector<4xf32>
+    // CHECK:     arith.subf %[[LHS]], %[[RHS]] : vector<4xf32>
+    %cst = arith.constant 1.0 : f32
+    %lhs = wave.register %cst : vector<4xf32>
+    %cst1 = arith.constant 2.0 : f32
+    %rhs = wave.register %cst1 : vector<4xf32>
+    %subf = wave.sub %lhs, %rhs : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
+    // CHECK:     %[[LHSI:.*]] = arith.constant dense<5> : vector<2xi32>
+    // CHECK:     %[[RHSI:.*]] = arith.constant dense<3> : vector<2xi32>
+    // CHECK:     arith.subi %[[LHSI]], %[[RHSI]] : vector<2xi32>
+    %cst2 = arith.constant 5 : i32
+    %lhsi = wave.register %cst2 : vector<2xi32>
+    %cst3 = arith.constant 3 : i32
+    %rhsi = wave.register %cst3 : vector<2xi32>
+    %subi = wave.sub %lhsi, %rhsi : (vector<2xi32>, vector<2xi32>) -> vector<2xi32>
+
+    return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,resolved_allocations>] {
   // CHECK-LABEL: func.func @lower_mul
   func.func @lower_mul() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
     // CHECK-NOT: wave.mul

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -36,7 +36,9 @@ func.func @binary(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<any o
   %1 = wave.mul %0, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
   // CHECK: wave.div
   %2 = wave.div %1, %lhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
-  return %2 : !wave.tensor<[@A, @B] of bf16>
+  // CHECK: wave.sub
+  %3 = wave.sub %2, %rhs : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %3 : !wave.tensor<[@A, @B] of bf16>
 }
 
 // CHECK-LABEL: @memory

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -84,6 +84,7 @@ try:
     from water_mlir.water_mlir import ir
     from water_mlir.water_mlir.dialects.wave import (
         AddOp,
+        SubOp,
         AllocateOp,
         CastOp,
         DivOp,
@@ -121,6 +122,7 @@ except Exception as e:
 # Mapping from tkw_op_name to actual op constructors
 WAVE_OP_CONSTRUCTORS = {
     "add": AddOp,
+    "sub": SubOp,
     "allocate": AllocateOp,
     "cast": CastOp,
     "extract_slice": ExtractSliceOp,


### PR DESCRIPTION
`wave.sub` subtracts two `WaveTensorInRegister` values and is lowered to `arith.sub` / `arith.subf`.

Signed-off-by: Tim Gymnich <tim@gymni.ch>
