### PR TITLE
[water] add wave.permute op

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -604,4 +604,40 @@ def BroadcastOp : WaveOp<"broadcast", [
   }];
 }
 
+def PermuteOp : WaveOp<"permute", [
+    DeclareOpInterfaceMethods<WaveInferTypeOpInterface>,
+    WaveElementsPerThreadOpInterface, IdentityElementsPerThreadOpTrait,
+    DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>]> {
+  let summary = "Permute the dimensions of a register-resident tensor";
+  let description = [{
+    Reorders the symbolic dimensions of a register-resident tensor according
+    to the result type shape. This operation is primarily a semantic marker
+    that affects how index expressions are transformed during compilation.
+    At lowering time, the operation is a pass-through since the actual data
+    layout in registers remains unchanged - only the interpretation of which
+    dimension each element belongs to changes.
+
+    For example, permuting a tensor with shape [B, M, N] to [M, N, B] swaps
+    the strides associated with the symbolic dimensions in the index
+    expressions.
+
+    The result type, when fully-specified, must be a permutation of the input
+    shape (same symbols in a different order). If the result type is not
+    fully-specified, its shape will be inferred from the input type during
+    type inference.
+  }];
+  let arguments = !con((ins
+    Arg<WaveTensorInRegister, "Value to permute">:$value
+  ), commonArguments);
+  let results = (outs
+    Res<WaveTensorInRegister, "Permuted value">:$result
+  );
+
+  let assemblyFormat =
+    "$value " # commonArgumentsSyntax # " attr-dict `:`"
+    "qualified(type($value)) `to` qualified(type($result))";
+
+  let hasVerifier = 1;
+}
+
 #endif // WATER_DIALECT_WAVE_WAVEOPS

--- a/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerWaveToMLIR.cpp
@@ -80,8 +80,8 @@ struct LowerWaveToMLIRPass
         wave::AddOp, wave::SubOp, wave::AllocateOp, wave::CastOp, wave::DivOp,
         wave::ReciprocalOp, wave::Exp2Op, wave::ExtractOp, wave::ExtractSliceOp,
         wave::IterateOp, wave::MaxElementOp, wave::MmaOp, wave::MulOp,
-        wave::ReadOp, wave::RegisterOp, wave::ShuffleOp, wave::SumOp,
-        wave::WriteOp, wave::YieldOp>();
+        wave::PermuteOp, wave::ReadOp, wave::RegisterOp, wave::ShuffleOp,
+        wave::SumOp, wave::WriteOp, wave::YieldOp>();
 
     // Mark functions as illegal if they have Wave tensor types in their
     // signature.

--- a/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -543,6 +543,29 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// PermuteOp
+//===----------------------------------------------------------------------===//
+
+/// Lowers `wave.permute` by replacing it with its operand.
+/// The permute operation is a semantic marker that affects index expression
+/// transformation during compilation. At lowering time, the underlying data
+/// representation remains unchanged.
+class PermuteOpLoweringPattern : public OpConversionPattern<wave::PermuteOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(wave::PermuteOp op, wave::PermuteOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Permute is a pass-through operation at lowering time.
+    // The index expression transformation is handled separately during
+    // the index inference pass.
+    rewriter.replaceOp(op, adaptor.getValue());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // IterateOp
 //===----------------------------------------------------------------------===//
 
@@ -761,8 +784,8 @@ void wave::populateWaveMiscellaneousOpsLoweringPatterns(
     WaveTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<CastOpLoweringPattern, ExtractOpLoweringPattern,
                ExtractSliceOpLoweringPattern, IterateOpLoweringPattern,
-               RegisterOpLoweringPattern, ShuffleOpLoweringPattern>(
-      typeConverter, patterns.getContext());
+               PermuteOpLoweringPattern, RegisterOpLoweringPattern,
+               ShuffleOpLoweringPattern>(typeConverter, patterns.getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -820,3 +820,66 @@ func.func @broadcast_element_type_mismatch(%arg0: !wave.tensor<[@M, @N] of f32, 
   wave.broadcast %arg0 : (!wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N, @K] of f16, <register>>
   return
 }
+
+// -----
+
+// Test that permute result shape must not be empty
+func.func @permute_empty_result_shape(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input shape rank (2) does not match target shape rank (0)}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[] of f32, <register>>
+  return
+}
+
+// -----
+
+// Test that permute input and result element types must match
+func.func @permute_element_type_mismatch(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{expected input and result elemental types to match, got 'f32', 'f16'}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@N, @M] of f16, <register>>
+  return
+}
+
+// -----
+
+// Test that permute result shape dimensions must exist in input shape
+func.func @permute_unknown_dimension(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input dimension 'M' is not present in result shape}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@P, @Q] of f32, <register>>
+  return
+}
+
+// -----
+
+// Test that permute result shape with one unknown dimension fails
+func.func @permute_partial_unknown_dimension(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input dimension 'M' is not present in result shape}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@N, @B] of f32, <register>>
+  return
+}
+
+// -----
+
+// Test that permute result shape with extra dimension not in input fails
+func.func @permute_extra_dimension(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input shape rank (2) does not match target shape rank (3)}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@N, @M, @K] of f32, <register>>
+  return
+}
+
+// -----
+
+// Test that permute result shape rank must match input shape rank
+func.func @permute_result_rank_mismatch(%arg0: !wave.tensor<[@M, @N, @K] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input shape rank (3) does not match target shape rank (2)}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N, @K] of f32, <register>> to !wave.tensor<[@N, @M] of f32, <register>>
+  return
+}
+
+// -----
+
+// Test that permute result shape must be a permutation of input shape
+func.func @permute_result_not_permutation(%arg0: !wave.tensor<[@M, @N] of f32, <register>>) {
+  // expected-error @below {{'wave.permute' op input dimension 'M' is not present in result shape}}
+  wave.permute %arg0 : !wave.tensor<[@M, @N] of f32, <register>> to !wave.tensor<[@N, @K] of f32, <register>>
+  return
+}

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -432,6 +432,25 @@ func.func @cast_mixed_specified(%arg0: !wave.tensor<[@M, @N] of f32>) -> !wave.t
   return %0 : !wave.tensor<any of bf16>
 }
 
+// CHECK-LABEL: @permute
+func.func @permute(%arg0: !wave.tensor<[@B, @M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N, @B] of f32, <register>> {
+  // CHECK: wave.permute
+  // CHECK-SAME: !wave.tensor<[@B, @M, @N] of f32, <register>> to !wave.tensor<[@M, @N, @B] of f32, <register>>
+  %0 = wave.permute %arg0 : !wave.tensor<[@B, @M, @N] of f32, <register>> to !wave.tensor<[@M, @N, @B] of f32, <register>>
+  return %0 : !wave.tensor<[@M, @N, @B] of f32, <register>>
+}
+
+// CHECK-LABEL: @permute_with_index
+func.func @permute_with_index(%arg0: !wave.tensor<[@M, @N] of f16, <register>>) -> !wave.tensor<[@N, @M] of f16, <register>> {
+  // CHECK: wave.permute
+  // CHECK-SAME: index
+  %0 = wave.permute %arg0 index [{
+    M : <[#wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (T0 * BLOCK_M, 1, 1)>,
+    N : <[#wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (T1 * BLOCK_N, 1, 1)>
+  }] : !wave.tensor<[@M, @N] of f16, <register>> to !wave.tensor<[@N, @M] of f16, <register>>
+  return %0 : !wave.tensor<[@N, @M] of f16, <register>>
+}
+
 // -----
 // Test wave.iterate and wave.yield with vector types
 

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -104,6 +104,7 @@ try:
         SumOp,
         WriteOp,
         YieldOp,
+        PermuteOp,
         DeviceConstraintAttr,
         HardwareConstraintAttr,
         TilingConstraintAttr,
@@ -145,6 +146,7 @@ WAVE_OP_CONSTRUCTORS = {
     "iterate": IterateOp,
     "output": YieldOp,
     "write": WriteOp,
+    "permute": PermuteOp,
     "max_element": MaxElementOp,
     "sum": SumOp,
     # TODO: Add more or find a good way of avoiding needing a mapping


### PR DESCRIPTION
Add `wave.permute` op that permutes dimensions of a `WaveTensorInRegister`.
Lowers to a no-op, but modifies propagation of index expressions by permuting the strides according to `target_shape`.