### PR TITLE
Propagate tags through compilation pipeline for manual scheduling

### DIFF
--- a/examples/python/6.4_schedule.py
+++ b/examples/python/6.4_schedule.py
@@ -1,0 +1,204 @@
+"""
+Attention Scheduling: Custom 4-Cluster Ping-Pong Schedule
+
+This example demonstrates how to use a custom wave schedule for attention that
+implements a 4-cluster ping-pong pattern matching create_attention_clusters
+from schedule_reordering.py.
+
+The schedule and tagged kernel template are defined in:
+- wave_lang.kernel.wave.templates.tagged_attention - BSHD attention kernel with tags
+- wave_lang.kernel.wave.schedules.attention_prefetch - 4-cluster ping-pong schedule
+
+The schedule uses 4 clusters with workgroup barriers for synchronization:
+
+- Cluster 0: QK computation + softmax1
+  - SetWavePrio(1), MMA0 (QK), SetWavePrio(0)
+  - softmax1 operations (sub_x, exp, mul_init, sum, cast, scale)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 1: K data movement + V shared load
+  - GatherToLDS K (global -> shared)
+  - Shared load V (from previous iteration's prefetch)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 2: PV computation + softmax0
+  - SetWavePrio(1), MMA1 (PV), SetWavePrio(0)
+  - softmax0 operations (max, sub_delta, exp_delta, masking)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 3: V data movement + K shared load
+  - GatherToLDS V (global -> shared)
+  - Shared load K (from current iteration's prefetch)
+  - WorkgroupBarrier, SchedulingBarrier
+
+The stagger() call enables ping-pong execution where wave groups alternate
+between clusters, allowing one group to compute while another prefetches.
+
+IMPORTANT: This schedule requires 8 waves (num_waves=8) to work correctly
+since it is a ping-pong schedule using multi-buffering with wave staggering.
+"""
+
+import math
+import torch
+
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.lang.wave_types import *
+from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
+from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from wave_lang.kernel.wave.utils.general_utils import get_default_scheduling_params
+
+# Import templates and schedules
+from wave_lang.kernel.wave.templates.attention_common import AttentionShape
+from wave_lang.kernel.wave.templates.tagged_attention import (
+    get_tagged_bshd_attention_kernel,
+)
+from wave_lang.kernel.wave.schedules.attention_prefetch import (
+    get_attention_prefetch_schedule,
+)
+
+from utils import parse_args, list_tests, run_test
+
+
+def test_attention_manual_schedule(is_debug=False):
+    """
+    Attention with custom 4-cluster ping-pong schedule.
+
+    This demonstrates using the tagged attention kernel template with the
+    4-cluster ping-pong schedule from attention_prefetch.py. The kernel uses
+    BSHD layout:
+    - Q: [B, N_Q, H, D_Q] - Query tensor (Batch, QuerySeq, Heads, HeadDim)
+    - K: [B, N_KV, H_KV, D_Q] - Key tensor
+    - V: [B, N_KV, H_KV, D_KV] - Value tensor
+    - C: [B, N_Q, H, D_KV] - Output tensor
+
+    The 4-cluster schedule pattern:
+    - Cluster 0: QK MMA + softmax1 (compute on K data)
+    - Cluster 1: GatherToLDS K + shared_load V (K prefetch, V consume)
+    - Cluster 2: PV MMA + softmax0 (compute on V data)
+    - Cluster 3: GatherToLDS V + shared_load K (V prefetch, K consume)
+
+    Wave staggering enables ping-pong execution between wave groups, allowing
+    one group to compute while another prefetches data.
+    """
+    shape = AttentionShape(
+        num_query_heads=64,
+        num_kv_heads=64,
+        query_seq_len=128,
+        head_size_kv=64,
+        head_size=64,
+        kv_seq_len=256,
+    )
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16,) * 2
+
+    # Get the tagged BSHD attention kernel
+    tagged_attention, hyperparams, _ = get_tagged_bshd_attention_kernel(
+        shape,
+        mfma_variant,
+        dynamic_dims=False,
+        is_causal=False,
+        num_waves=8,  # 8 waves for ping-pong scheduling
+    )
+    hyperparams.update(get_default_scheduling_params())
+
+    # Get the prefetch schedule
+    attention_prefetch_schedule = get_attention_prefetch_schedule()
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        schedule=SchedulingType.MANUAL,
+        use_global_to_shared=True,  # Enable GatherToLDS
+        print_ir_after="all" if is_debug else [],
+    )
+
+    options = set_default_run_config(options)
+
+    # Compile with the custom schedule
+    compiled_attention = wave_compile(
+        options, tagged_attention, attention_prefetch_schedule
+    )
+
+    if is_debug:
+        with open("attention_manual_schedule.asm", "w") as f:
+            f.write(compiled_attention.asm)
+        print("=== MANUAL ATTENTION SCHEDULE (GatherToLDS) ===")
+        print(compiled_attention.asm)
+
+    # Create test data - BSHD layout: [Batch, Seq, Heads, Dim]
+    # For the tagged kernel, B=1, H=num_query_heads, H_KV=num_kv_heads
+    batch = 1
+    num_query_heads = shape.num_query_heads
+    num_kv_heads = shape.num_kv_heads
+    seq_q = shape.query_seq_len
+    seq_kv = shape.kv_seq_len
+    head_size = shape.head_size
+    head_size_kv = shape.head_size_kv
+
+    q = torch.randn(
+        batch, seq_q, num_query_heads, head_size, dtype=torch.float16, device="cuda"
+    )
+    k = torch.randn(
+        batch, seq_kv, num_kv_heads, head_size, dtype=torch.float16, device="cuda"
+    )
+    v = torch.randn(
+        batch, seq_kv, num_kv_heads, head_size_kv, dtype=torch.float16, device="cuda"
+    )
+    c = torch.zeros(
+        batch, seq_q, num_query_heads, head_size_kv, dtype=torch.float32, device="cuda"
+    )
+
+    # Run the kernel
+    compiled_attention(q, k, v, c)
+
+    # Compute reference using PyTorch
+    # Reshape for standard attention computation
+    log2e = 1.44269504089
+    dk_sqrt = math.sqrt(1.0 / head_size)
+    scale = dk_sqrt * log2e
+
+    q_f32 = q.float()
+    k_f32 = k.float()
+    v_f32 = v.float()
+
+    # Transpose for attention: [B, H, S, D]
+    q_t = q_f32.permute(0, 2, 1, 3)  # [B, H, N_Q, D_Q]
+    k_t = k_f32.permute(0, 2, 1, 3)  # [B, H_KV, N_KV, D_Q]
+    v_t = v_f32.permute(0, 2, 1, 3)  # [B, H_KV, N_KV, D_KV]
+
+    # For GQA, repeat K/V heads to match Q heads
+    head_ratio = num_query_heads // num_kv_heads
+    if head_ratio > 1:
+        k_t = k_t.repeat_interleave(head_ratio, dim=1)  # [B, H, N_KV, D_Q]
+        v_t = v_t.repeat_interleave(head_ratio, dim=1)  # [B, H, N_KV, D_KV]
+
+    # Attention: Q @ K^T
+    attn_scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale
+    # Our kernel uses exp2, so adjust softmax
+    attn_probs = torch.softmax(attn_scores * math.log(2), dim=-1)
+    # Output: attn @ V
+    output = torch.matmul(attn_probs, v_t)  # [B, H, N_Q, D_KV]
+
+    # Transpose back to BSHD: [B, N_Q, H, D_KV]
+    expected = output.permute(0, 2, 1, 3)
+
+    assert torch.allclose(c.cpu(), expected.cpu(), rtol=1e-3, atol=1e-3)
+
+    print("Attention manual schedule test passed!")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    if args.list_tests:
+        list_tests(globals())
+        exit(0)
+
+    if not args.test:
+        print("Error: --test argument is required")
+        print("Use --list_tests to see available tests")
+        exit(1)
+
+    success = run_test(args.test, globals(), args.debug, args.repeat)
+    exit(0 if success else 1)

--- a/lit_tests/kernel/wave/attention/custom_attention_schedule.py
+++ b/lit_tests/kernel/wave/attention/custom_attention_schedule.py
@@ -1,0 +1,109 @@
+# RUN: python %s | FileCheck %s
+
+"""
+Lit test for tagged attention kernel with manual prefetch schedule.
+
+This test verifies that the tagged attention kernel template from
+templates.tagged_attention compiles correctly with the manual
+attention prefetch schedule from schedules.attention_prefetch.
+
+The tagged attention kernel provides operation tags for custom scheduling:
+- "n_kv_loop": Main iteration loop over KV sequence
+- "read_q": Q read from global memory (hoisted outside loop)
+- "read_k": K read (GatherToLDS + shared read)
+- "read_v": V read (GatherToLDS + shared read)
+- "mma_qk": QK MMA operation (GEMM0)
+- "mma_pv": PV MMA operation (GEMM1)
+- "softmax0_*": First group of softmax ops (max, exp2, sum)
+- "softmax1_*": Second group of softmax ops (delta_max scaling)
+"""
+
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from wave_lang.kernel.wave.templates.attention_common import AttentionShape
+from wave_lang.kernel.wave.templates.tagged_attention import (
+    get_tagged_bshd_attention_kernel,
+)
+from wave_lang.kernel.wave.schedules.attention_prefetch import (
+    get_attention_prefetch_schedule,
+)
+from wave_lang.kernel.wave.utils.general_utils import (
+    get_default_scheduling_params,
+    run_test,
+)
+
+
+@run_test
+def test_tagged_attention_kernel():
+    """
+    Test that the tagged BSHD attention kernel compiles with manual schedule.
+
+    This verifies:
+    1. The tagged_attention kernel from templates module can be created
+    2. The attention_prefetch_schedule from schedules module works
+    3. The kernel + schedule compiles successfully with GatherToLDS and hardware transpose
+    """
+    # Configuration from manual_scheduled_attention_test.py
+    shape = AttentionShape(
+        num_query_heads=4,
+        num_kv_heads=4,
+        query_seq_len=256,
+        kv_seq_len=256,
+        head_size=64,
+        head_size_kv=64,
+    )
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16, tkw.MMAType.F32_16x16x16_F16)
+
+    # Get the tagged BSHD attention kernel from the templates module
+    tagged_attention, hyperparams, _ = get_tagged_bshd_attention_kernel(
+        shape,
+        mfma_variant,
+        dynamic_dims=False,
+        is_causal=False,
+        num_waves=8,
+    )
+    hyperparams.update(get_default_scheduling_params())
+
+    # Get the manual attention prefetch schedule
+    attention_schedule = get_attention_prefetch_schedule()
+
+    # Compile with manual scheduling using GatherToLDS
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=False,
+        schedule=SchedulingType.MANUAL,
+        use_scheduling_barriers=False,
+        use_global_to_shared=True,
+        compile_to_mlir=True,
+        target="gfx950",
+    )
+
+    kernel = wave_compile(options, tagged_attention, attention_schedule)
+
+    # Print the MLIR for FileCheck
+    print("=== TAGGED ATTENTION KERNEL WITH MANUAL SCHEDULE ===")
+    print(kernel.asm)
+
+    # CHECK-LABEL: === TAGGED ATTENTION KERNEL WITH MANUAL SCHEDULE ===
+    # CHECK: func.func @tagged_attention
+
+    # Verify GatherToLDS operations for K and V matrices (global -> shared memory)
+    # CHECK: amdgpu.gather_to_lds
+    # CHECK: amdgpu.gather_to_lds
+
+    # Verify hardware transpose loads for V matrix (transposed read from shared memory)
+    # CHECK: amdgpu.transpose_load
+    # CHECK: amdgpu.transpose_load
+
+    # Verify MMA operations are present (QK and PV GEMMs)
+    # CHECK: amdgpu.mfma
+
+    # Verify softmax operations (shuffle for reductions)
+    # CHECK: gpu.shuffle
+
+
+if __name__ == "__main__":
+    pass

--- a/lit_tests/kernel/wave/tag.py
+++ b/lit_tests/kernel/wave/tag.py
@@ -1,0 +1,372 @@
+# RUN: python %s | FileCheck %s
+
+"""
+Tests for tkw.tag() function.
+
+This module tests that tkw.tag() correctly assigns tags to Python arithmetic
+operators in the FX graph. Tags enable custom wave schedules to identify and
+manipulate specific operations.
+"""
+
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.wave.utils.general_utils import run_test
+from wave_lang.kernel.wave.utils.print_utils import print_trace
+
+M = tkl.sym.M
+N = tkl.sym.N
+K = tkl.sym.K
+ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+
+def print_tags(trace):
+    """Print tags associated with FX nodes in the trace."""
+    print("Tags in FX graph:")
+    graph = trace.get_root_graph()
+    for node in graph.nodes:
+        tag = getattr(node, "tag", None)
+        if tag is not None:
+            print(f"  {node.name}: tag={tag}")
+
+
+@run_test
+def test_tag_multiply():
+    """Test tagging a multiplication operation."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Tag the multiplication
+        result = tkw.tag(a * b, "multiply_ab")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: mul(lhs=read, rhs=read_1)
+    # CHECK-NEXT: write(register_=mul
+    # CHECK-NEXT: output
+
+    # Verify tag is present
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: mul: tag=multiply_ab
+
+
+@run_test
+def test_tag_add():
+    """Test tagging an addition operation."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Tag the addition
+        result = tkw.tag(a + b, "add_ab")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %add
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: add(lhs=read, rhs=read_1)
+    # CHECK-NEXT: write(register_=add
+    # CHECK-NEXT: output
+
+    # Verify tag is present
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: add: tag=add_ab
+
+
+@run_test
+def test_tag_subtract():
+    """Test tagging a subtraction operation."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Tag the subtraction
+        result = tkw.tag(a - b, "sub_ab")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %sub
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: sub(lhs=read, rhs=read_1)
+    # CHECK-NEXT: write(register_=sub
+    # CHECK-NEXT: output
+
+    # Verify tag is present
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: sub: tag=sub_ab
+
+
+@run_test
+def test_tag_divide():
+    """Test tagging a division operation."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Tag the division
+        result = tkw.tag(a / b, "div_ab")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %truediv
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: truediv(lhs=read, rhs=read_1)
+    # CHECK-NEXT: write(register_=truediv
+    # CHECK-NEXT: output
+
+    # Verify tag is present
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: truediv: tag=div_ab
+
+
+@run_test
+def test_tag_multiple_operations():
+    """Test tagging multiple different operations."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Tag multiple operations
+        sum_result = tkw.tag(a + b, "sum_op")
+        diff_result = tkw.tag(a - b, "diff_op")
+        prod_result = tkw.tag(sum_result * diff_result, "prod_op")
+        tkw.write(prod_result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %add
+    # CHECK-NEXT: %sub
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: add(lhs=read, rhs=read_1)
+    # CHECK-NEXT: sub(lhs=read, rhs=read_1)
+    # CHECK-NEXT: mul(lhs=add, rhs=sub)
+    # CHECK-NEXT: write(register_=mul
+    # CHECK-NEXT: output
+
+    # Verify all tags are present
+    # CHECK: Tags in FX graph:
+    # CHECK-DAG: add: tag=sum_op
+    # CHECK-DAG: sub: tag=diff_op
+    # CHECK-DAG: mul: tag=prod_op
+
+
+@run_test
+def test_tag_with_scalar():
+    """Test tagging operations with scalar values."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        scale = tkl.Register[M, N, tkl.f16](0.5)
+        # Tag multiplication with scalar
+        result = tkw.tag(a * scale, "scaled")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: register
+    # CHECK-NEXT: mul(lhs=read, rhs=register)
+    # CHECK-NEXT: write(register_=mul
+    # CHECK-NEXT: output
+
+    # Verify tag is present
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: mul: tag=scaled
+
+
+@run_test
+def test_tag_chained_operations():
+    """Test tagging in a chain of operations, only tagging final result."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Chain operations but only tag the final result
+        intermediate = a + b
+        result = tkw.tag(intermediate * a, "final_result")
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %add
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: add(lhs=read, rhs=read_1)
+    # CHECK-NEXT: mul(lhs=add, rhs=read)
+    # CHECK-NEXT: write(register_=mul
+    # CHECK-NEXT: output
+
+    # Verify only final operation has tag
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: mul: tag=final_result
+
+
+@run_test
+def test_tag_returns_same_proxy():
+    """Test that tkw.tag returns the same proxy for chaining."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        a = tkw.read(A)
+        b = tkw.read(A)
+        # Verify the returned value can be used in further operations
+        tagged = tkw.tag(a * b, "product")
+        # Use the tagged result in another operation
+        result = tagged + a
+        tkw.write(result, A, elements_per_thread=4)
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %add
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: mul(lhs=read, rhs=read_1)
+    # CHECK-NEXT: add(lhs=mul, rhs=read)
+    # CHECK-NEXT: write(register_=add
+    # CHECK-NEXT: output
+
+    # Verify tag is on mul, and add uses mul as input
+    # CHECK: Tags in FX graph:
+    # CHECK-NEXT: mul: tag=product
+
+
+@run_test
+def test_tag_with_tkw_operations():
+    """Test that tkw.tag works alongside native tkw operations with tags."""
+
+    @tkw.wave_trace_only()
+    def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        # Native tkw operation with tag
+        a = tkw.read(A, tag="read_a")
+        b = tkw.read(A, tag="read_b")
+        # Python operation with tkw.tag
+        result = tkw.tag(a * b, "multiply")
+        tkw.write(result, A, elements_per_thread=4, tag="write_out")
+
+    trace = test()
+    print_trace(trace)
+    print_tags(trace)
+
+    # CHECK: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %mul
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
+
+    # CHECK: Custom format:
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: mul(lhs=read, rhs=read_1)
+    # CHECK-NEXT: write(register_=mul
+    # CHECK-NEXT: output
+
+    # Verify all tags are present
+    # CHECK: Tags in FX graph:
+    # CHECK-DAG: read: tag=read_a
+    # CHECK-DAG: read_1: tag=read_b
+    # CHECK-DAG: mul: tag=multiply
+    # CHECK-DAG: write: tag=write_out

--- a/tests/kernel/attention/manual_scheduled_attention_test.py
+++ b/tests/kernel/attention/manual_scheduled_attention_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+E2E tests for manually scheduled attention kernels.
+
+These tests verify that the tagged attention kernel with manual scheduling
+produces correct results and can be successfully compiled and executed
+on CDNA4 (gfx95*) hardware.
+"""
+
+import pytest
+import torch
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.wave.utils.general_utils import get_default_scheduling_params
+from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+from wave_lang.kernel.wave.utils.torch_utils import device_randn, device_zeros
+from wave_lang.kernel.wave.compile import WaveCompileOptions, wave_compile
+from wave_lang.kernel.wave.constraints import MMAType
+from wave_lang.kernel.wave.templates.tagged_attention import (
+    get_tagged_bshd_attention_kernel,
+)
+from wave_lang.kernel.wave.templates.attention_common import AttentionShape
+from wave_lang.kernel.wave.schedules.attention_prefetch import (
+    get_attention_prefetch_schedule,
+)
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from torch.testing import assert_close
+from ..common.utils import require_e2e, require_cdna4
+
+
+def reference_attention(q, k, v, is_causal=False):
+    """Reference attention using PyTorch scaled_dot_product_attention."""
+    return torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=None, is_causal=is_causal
+    )
+
+
+# Test configurations: (num_query_heads, num_kv_heads, query_seq_len, kv_seq_len, head_size, head_size_kv, num_waves, schedule_type)
+# BLOCK_N_Q = 128 * (num_waves // 4), so:
+#   - num_waves=4: BLOCK_N_Q=128, requires query_seq_len >= 128
+#   - num_waves=8: BLOCK_N_Q=256, requires query_seq_len >= 256
+test_configs = [
+    # No scheduling (baseline) - smaller config with num_waves=4
+    (1, 1, 128, 128, 64, 64, 4, SchedulingType.NONE),
+    # Manual scheduling with various shapes
+    (1, 1, 256, 256, 64, 64, 8, SchedulingType.MANUAL),
+    (4, 4, 256, 256, 64, 64, 8, SchedulingType.MANUAL),
+    (8, 2, 256, 256, 64, 64, 8, SchedulingType.MANUAL),  # GQA
+    # Larger sequence to test pipelining
+    (4, 4, 512, 512, 64, 64, 8, SchedulingType.MANUAL),
+]
+
+# MMA variants: (mma_qk, mma_pv)
+mma_variants = [
+    (MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16),
+    (MMAType.F32_16x16x32_F16, MMAType.F32_16x16x16_F16),
+]
+
+
+@require_e2e
+@require_cdna4
+@pytest.mark.parametrize("config", test_configs)
+@pytest.mark.parametrize("mma_variant", mma_variants)
+@pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_tagged_attention(
+    config: tuple,
+    mma_variant: tuple[MMAType, MMAType],
+    is_causal: bool,
+    dtype: torch.dtype,
+    run_bench,
+    perf_filename_tk,
+):
+    """
+    Test the tagged attention kernel with various configurations.
+
+    Tests both unscheduled (NONE) and manually scheduled (MANUAL) variants
+    with different shapes, sequence lengths, causal modes, and MMA types.
+    """
+    (
+        num_query_heads,
+        num_kv_heads,
+        query_seq_len,
+        kv_seq_len,
+        head_size,
+        head_size_kv,
+        num_waves,
+        schedule_type,
+    ) = config
+
+    attention_shape = AttentionShape(
+        num_query_heads=num_query_heads,
+        num_kv_heads=num_kv_heads,
+        query_seq_len=query_seq_len,
+        kv_seq_len=kv_seq_len,
+        head_size=head_size,
+        head_size_kv=head_size_kv,
+    )
+
+    mfma_variant = mma_variant
+
+    tagged_attention, hyperparams, _ = get_tagged_bshd_attention_kernel(
+        attention_shape,
+        mfma_variant,
+        dynamic_dims=False,
+        is_causal=is_causal,
+        num_waves=num_waves,
+    )
+    hyperparams.update(get_default_scheduling_params())
+
+    # Get schedule if using manual scheduling
+    attention_schedule = (
+        get_attention_prefetch_schedule()
+        if schedule_type == SchedulingType.MANUAL
+        else None
+    )
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=schedule_type,
+        use_scheduling_barriers=False,
+        use_global_to_shared=True,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=perf_filename_tk,
+    )
+
+    options = set_default_run_config(options)
+    compiled_attention = (
+        wave_compile(options, tagged_attention, attention_schedule)
+        if attention_schedule
+        else wave_compile(options, tagged_attention)
+    )
+
+    # Create input tensors - BSHD layout: [B, N, H, D]
+    B = 1
+    q = device_randn((B, query_seq_len, num_query_heads, head_size), dtype=dtype)
+    k = device_randn((B, kv_seq_len, num_kv_heads, head_size), dtype=dtype)
+    v = device_randn((B, kv_seq_len, num_kv_heads, head_size_kv), dtype=dtype)
+    output = device_zeros(
+        (B, query_seq_len, num_query_heads, head_size_kv), dtype=torch.float32
+    )
+
+    compiled_attention(q, k, v, output)
+
+    # Compute reference - PyTorch expects BHND layout
+    q_ref = q.permute(0, 2, 1, 3)
+    k_ref = k.permute(0, 2, 1, 3)
+    v_ref = v.permute(0, 2, 1, 3)
+
+    # Handle GQA by repeating KV heads for reference
+    if num_query_heads != num_kv_heads:
+        repeat_factor = num_query_heads // num_kv_heads
+        k_ref = k_ref.repeat_interleave(repeat_factor, dim=1)
+        v_ref = v_ref.repeat_interleave(repeat_factor, dim=1)
+
+    ref_output = reference_attention(q_ref, k_ref, v_ref, is_causal=is_causal)
+    ref_output = ref_output.permute(0, 2, 1, 3)
+
+    assert_close(output, ref_output, check_dtype=False, atol=1e-3, rtol=1e-3)

--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -51,6 +51,7 @@ from ...ops.wave_ops import (
     Write,
     get_custom,
 )
+from ..utils.tag_utils import propagate_tag
 from ..constraints import (
     Constraint,
     DistributionConstraint,
@@ -1105,6 +1106,7 @@ def create_broadcast(
             to_broadcast.fx_node, target_node.type.symbolic_shape
         ).add_to_graph(op.graph, loc=op.location)
         broadcasted.location = op.location
+        propagate_tag(op.fx_node, broadcasted)
         custom = get_custom(broadcasted)
         custom.vector_shapes = op.vector_shapes
         custom.index = deepcopy(target_node.index)

--- a/wave_lang/kernel/wave/analysis/partition_strided_operators.py
+++ b/wave_lang/kernel/wave/analysis/partition_strided_operators.py
@@ -26,9 +26,8 @@ from ...ops.wave_ops import (
     Write,
     get_custom,
 )
-from ..constraints import (
-    Constraint,
-)
+from ..constraints import Constraint
+from ..utils.tag_utils import propagate_tag
 from ..utils.general_utils import (
     all_equal,
     get_fastest_index,
@@ -383,6 +382,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 )
                 reshape.expanded_dims = custom.expanded_dims
                 reshape.vector_shapes = custom.vector_shapes
+                propagate_tag(custom.fx_node, reshape)
 
                 # Save the original index on the reshape op so later we can
                 # detect if op was part of `gpr_offset` partition.
@@ -500,6 +500,7 @@ def partition_gather_like_ops(
                 )
                 reshape.expanded_dims = custom.expanded_dims
                 reshape.vector_shapes = custom.vector_shapes
+                propagate_tag(custom.fx_node, reshape)
 
                 reshape.index = index
                 custom.replace_all_uses_with(reshape)

--- a/wave_lang/kernel/wave/decompose_vmma_ops.py
+++ b/wave_lang/kernel/wave/decompose_vmma_ops.py
@@ -21,6 +21,7 @@ from ..wave.constraints import (
     MMAOperand,
     MMAType,
 )
+from ..wave.utils.tag_utils import propagate_tag
 
 VMMA_TO_NATIVE_MAP = {
     MMAType.F32_16x16x32_K8_F16: MMAType.F32_16x16x16_F16,
@@ -138,6 +139,8 @@ def decompose_vmma_ops(
                 slice_rhs = Reshape([mma_op.rhs], virtual_vector_shapes).add_to_graph(
                     mma_op.graph, loc=mma_op.location
                 )
+                propagate_tag(mma_op.fx_node, slice_lhs)
+                propagate_tag(mma_op.fx_node, slice_rhs)
 
             # Setting vector_shapes for num_partitions
             slice_lhs.vector_shapes = native_vector_shapes

--- a/wave_lang/kernel/wave/in_thread_transpose.py
+++ b/wave_lang/kernel/wave/in_thread_transpose.py
@@ -17,6 +17,7 @@ from .._support.tracing import CapturedTrace
 from ..lang.global_symbols import *
 from ..lang.wave_types import IndexMapping
 from ..ops.wave_ops import Extract, Read, Reshape, Write, get_custom
+from ..wave.utils.tag_utils import propagate_tag
 from ..wave.constraints import (
     Constraint,
     TilingConstraint,
@@ -313,11 +314,13 @@ def create_transpose_writes(
                 value = Extract(new_reads[j], [i]).add_to_graph(
                     write.graph, loc=write.location
                 )
+                propagate_tag(write.fx_node, value)
                 values.append(value)
 
             value = Reshape(values, store_elems_per_thread).add_to_graph(
                 write.graph, loc=write.location
             )
+            propagate_tag(write.fx_node, value)
             repacked.append(value)
 
     new_writes = defaultdict(list)

--- a/wave_lang/kernel/wave/schedules/__init__.py
+++ b/wave_lang/kernel/wave/schedules/__init__.py
@@ -3,3 +3,21 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .gemm_triple_buffer import (
+    get_async_two_cluster_triple_buffer,
+    get_gfx1250_tbuf_gemm_schedule,
+)
+from .gemm_two_pp_cluster import (
+    get_two_pp_cluster_schedule,
+    get_async_two_pp_clusters,
+)
+from .attention_prefetch import get_attention_prefetch_schedule
+
+__all__ = [
+    "get_async_two_cluster_triple_buffer",
+    "get_gfx1250_tbuf_gemm_schedule",
+    "get_two_pp_cluster_schedule",
+    "get_async_two_pp_clusters",
+    "get_attention_prefetch_schedule",
+]

--- a/wave_lang/kernel/wave/schedules/attention_prefetch.py
+++ b/wave_lang/kernel/wave/schedules/attention_prefetch.py
@@ -1,0 +1,290 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Attention Prefetch Schedule
+
+This module provides a custom wave schedule for attention that implements
+a 4-cluster ping-pong pattern matching create_attention_clusters from
+schedule_reordering.py.
+
+IMPORTANT: This schedule requires 8 waves (num_waves=8) to work correctly
+since it is a ping-pong schedule using multi-buffering with wave staggering.
+
+The schedule uses 4 clusters with workgroup barriers for synchronization:
+
+- Cluster 0: QK computation + softmax1
+  - SetWavePrio(1), MMA0 (QK), SetWavePrio(0)
+  - softmax1 operations (sub_x, exp, mul_init, sum, cast, scale)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 1: K data movement + V shared load
+  - GatherToLDS K (global -> shared)
+  - Shared load V (from previous iteration's prefetch)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 2: PV computation + softmax0
+  - SetWavePrio(1), MMA1 (PV), SetWavePrio(0)
+  - softmax0 operations (max, sub_delta, exp_delta, masking)
+  - WorkgroupBarrier, SchedulingBarrier
+
+- Cluster 3: V data movement + K shared load
+  - GatherToLDS V (global -> shared)
+  - Shared load K (from current iteration's prefetch)
+  - WorkgroupBarrier, SchedulingBarrier
+
+The stagger() call enables ping-pong execution where wave groups alternate
+between clusters, allowing one group to compute while another prefetches.
+
+This schedule expects a kernel with the following tags:
+- "n_kv_loop": The main iteration loop over KV sequence
+- "read_k": K read - uses GatherToLDS (global->shared) + Read (shared load)
+- "read_v": V read - uses GatherToLDS (global->shared) + Read (shared load)
+- "mma_qk", "mma_qk_init": QK MMA operations (GEMM0)
+- "mma_pv": PV MMA operation (GEMM1)
+- "softmax0_*": Softmax0 ops (permute, masking, scale, max, sub_delta, exp_delta)
+- "softmax1_*": Softmax1 ops (sub_x, exp, mul_init, sum, cast, scale)
+- Requires use_global_to_shared=True in WaveCompileOptions
+- Requires num_waves=8 in the kernel creation
+"""
+
+import wave_lang.kernel.wave as tkw
+import wave_lang.kernel.wave.wave_schedule as wave_schedule
+from wave_lang.kernel.lang.global_symbols import *
+
+
+def _get_node_by_tag_optional(tag: str):
+    """
+    Get nodes by tag, returning None if no nodes found.
+    This allows handling optional operations like causal masking.
+    """
+    result = tkw.get_node_by_tag(tag)
+    # get_node_by_tag returns empty list if no nodes found
+    if result is None or (isinstance(result, (list, tuple)) and len(result) == 0):
+        return None
+    return result
+
+
+def get_attention_prefetch_schedule():
+    """
+    Returns a schedule function that implements the prefetch attention pattern
+    with 4-stage pipelining (8 cycles, II=2) using GatherToLDS.
+
+    Returns:
+        A wave_schedule decorated function
+    """
+
+    @wave_schedule.wave_schedule()
+    def attention_prefetch_schedule():
+        """
+        Custom schedule implementing 4-cluster ping-pong attention pattern.
+
+        Cluster ordering matches create_attention_clusters from schedule_reordering.py:
+        - Cluster 0: QK MMA + softmax1 (compute on K data)
+        - Cluster 1: GatherToLDS K + shared_load V (K prefetch, V consume)
+        - Cluster 2: PV MMA + softmax0 (compute on V data)
+        - Cluster 3: GatherToLDS V + shared_load K (V prefetch, K consume)
+
+        Wave staggering enables ping-pong execution between wave groups.
+        """
+        # Get the main iteration loop
+        n_kv_loop = tkw.get_node_by_tag("n_kv_loop")
+
+        # ==================== Get K read operations (GEMM0) ====================
+        all_read_k = tkw.get_node_by_tag("read_k")
+        global_to_shared_k = tkw.filter_nodes(all_read_k, node_type=tkw.GatherToLDS)
+        shared_load_k = tkw.filter_nodes(all_read_k, node_type=tkw.Read)
+
+        # ==================== Get V read operations (GEMM1) ====================
+        all_read_v = tkw.get_node_by_tag("read_v")
+        global_to_shared_v = tkw.filter_nodes(all_read_v, node_type=tkw.GatherToLDS)
+        shared_load_v = tkw.filter_nodes(all_read_v, node_type=tkw.Read)
+
+        # ==================== Get MMA operations ====================
+        mma_qk_init = tkw.get_node_by_tag("mma_qk_init")
+        mma_qk = tkw.get_node_by_tag("mma_qk")
+        mma_pv = tkw.get_node_by_tag("mma_pv")
+
+        # ==================== Get softmax0 operations (before last sub) ====================
+        # Includes masking operations which are grouped with softmax0
+        softmax0_permute = tkw.get_node_by_tag("softmax0_permute")
+        softmax0_self_index_kv = tkw.get_node_by_tag("softmax0_self_index_kv")
+        softmax0_apply_expr = tkw.get_node_by_tag("softmax0_apply_expr")
+        softmax0_broadcast_mask = tkw.get_node_by_tag("softmax0_broadcast_mask")
+        # Causal operations are optional (only present when is_causal=True)
+        softmax0_self_index_q = _get_node_by_tag_optional("softmax0_self_index_q")
+        softmax0_broadcast_q = _get_node_by_tag_optional("softmax0_broadcast_q")
+        softmax0_causal_cmp = _get_node_by_tag_optional("softmax0_causal_cmp")
+        softmax0_causal_and = _get_node_by_tag_optional("softmax0_causal_and")
+        softmax0_cast_mask = tkw.get_node_by_tag("softmax0_cast_mask")
+        softmax0_select_bias = tkw.get_node_by_tag("softmax0_select_bias")
+        softmax0_add_bias = tkw.get_node_by_tag("softmax0_add_bias")
+        softmax0_scale = tkw.get_node_by_tag("softmax0_scale")
+        softmax0_max = tkw.get_node_by_tag("softmax0_max")
+        softmax0_sub_delta = tkw.get_node_by_tag("softmax0_sub_delta")
+        softmax0_exp_delta = tkw.get_node_by_tag("softmax0_exp_delta")
+
+        # ==================== Get softmax1 operations (from last sub onward) ====================
+        softmax1_sub_x = tkw.get_node_by_tag("softmax1_sub_x")
+        softmax1_exp = tkw.get_node_by_tag("softmax1_exp")
+        softmax1_mul_init = tkw.get_node_by_tag("softmax1_mul_init")
+        softmax1_sum = tkw.get_node_by_tag("softmax1_sum")
+        softmax1_cast = tkw.get_node_by_tag("softmax1_cast")
+        softmax1_scale = tkw.get_node_by_tag("softmax1_scale")
+
+        # ==================== Create 4-stage pipeline ====================
+        # Matches PrefetchAttentionScheduler's 8-cycle, II=2 structure
+        # Use simple stage assignments without barriers (barriers are added later via reorder_graph)
+        pipeline_loop = tkw.pipeline(n_kv_loop)
+
+        # Build softmax0 ops list (excluding None for non-causal)
+        softmax0_ops = [
+            softmax0_permute,
+            softmax0_self_index_kv,
+            softmax0_apply_expr,
+            softmax0_broadcast_mask,
+            softmax0_self_index_q,
+            softmax0_broadcast_q,
+            softmax0_causal_cmp,
+            softmax0_causal_and,
+            softmax0_cast_mask,
+            softmax0_select_bias,
+            softmax0_add_bias,
+            softmax0_scale,
+            softmax0_max,
+            softmax0_sub_delta,
+            softmax0_exp_delta,
+        ]
+        softmax0_ops = [op for op in softmax0_ops if op is not None and op]
+
+        # Build softmax1 ops list
+        softmax1_ops = [
+            softmax1_sub_x,
+            softmax1_exp,
+            softmax1_mul_init,
+            softmax1_sum,
+            softmax1_cast,
+            softmax1_scale,
+        ]
+
+        with pipeline_loop as pl:
+            # Stage 0 (cycles 0-1): GatherToLDS K
+            pl.set_stage(
+                [
+                    (global_to_shared_k,),  # cycle 0: K global->shared
+                    (),  # cycle 1
+                ],
+            )
+            # Stage 1 (cycles 2-3): shared_load K + GatherToLDS V
+            pl.set_stage(
+                [
+                    (shared_load_k,),  # cycle 0: K shared load
+                    (global_to_shared_v,),  # cycle 1: V global->shared
+                ],
+            )
+            # Stage 2 (cycles 4-5): MMA0, softmax0 (including masking ops)
+            pl.set_stage(
+                [
+                    (mma_qk_init, mma_qk),  # cycle 0: MMA0 (QK)
+                    tuple(softmax0_ops),  # cycle 1: softmax0
+                ],
+            )
+            # Stage 3 (cycles 6-7): softmax1, shared_load V, MMA1
+            pl.set_stage(
+                [
+                    tuple(softmax1_ops),  # cycle 0: softmax1
+                    (shared_load_v, mma_pv),  # cycle 1: V shared read + MMA1 (PV)
+                ],
+            )
+
+        # ==================== Apply ping-pong cluster ordering and staggering ====================
+        # Filter nodes for the KERNEL stage only
+        global_to_shared_k_kernel = tkw.filter_nodes(
+            global_to_shared_k, subgraph=pipeline_loop.KERNEL
+        )
+        shared_load_k_kernel = tkw.filter_nodes(
+            shared_load_k, subgraph=pipeline_loop.KERNEL
+        )
+        global_to_shared_v_kernel = tkw.filter_nodes(
+            global_to_shared_v, subgraph=pipeline_loop.KERNEL
+        )
+        shared_load_v_kernel = tkw.filter_nodes(
+            shared_load_v, subgraph=pipeline_loop.KERNEL
+        )
+        mma_qk_init_kernel = tkw.filter_nodes(
+            mma_qk_init, subgraph=pipeline_loop.KERNEL
+        )
+        mma_qk_kernel = tkw.filter_nodes(mma_qk, subgraph=pipeline_loop.KERNEL)
+        mma_pv_kernel = tkw.filter_nodes(mma_pv, subgraph=pipeline_loop.KERNEL)
+        softmax0_ops_kernel = [
+            tkw.filter_nodes(op, subgraph=pipeline_loop.KERNEL) for op in softmax0_ops
+        ]
+        softmax1_ops_kernel = [
+            tkw.filter_nodes(op, subgraph=pipeline_loop.KERNEL) for op in softmax1_ops
+        ]
+
+        # Filter out empty lists from softmax ops (some ops may not be in KERNEL stage)
+        # Note: Empty softmax ops lists are valid - some operations may be scheduled
+        # in PROLOGUE or EPILOGUE stages depending on the pipeline structure.
+        # Empty clusters with only barriers are allowed and handled correctly.
+        softmax0_ops_kernel = [op for op in softmax0_ops_kernel if op]
+        softmax1_ops_kernel = [op for op in softmax1_ops_kernel if op]
+
+        # Create cluster ordering matching create_attention_clusters from schedule_reordering.py
+        # This is the ping-pong pattern with 4 clusters:
+        # - Cluster 0: QK computation + softmax1
+        # - Cluster 1: K data movement + local load V
+        # - Cluster 2: PV computation + softmax0
+        # - Cluster 3: V data movement + local load K
+        clusters = [
+            # Cluster 0: QK computation and softmax1
+            tkw.cluster(
+                [
+                    tkw.SetWavePrio(1),
+                    mma_qk_init_kernel,
+                    mma_qk_kernel,
+                    tkw.SetWavePrio(0),
+                    *softmax1_ops_kernel,
+                    tkw.WorkgroupBarrier(),
+                    tkw.SchedulingBarrier([]),
+                ],
+            ),
+            # Cluster 1: K data movement (global_to_shared_k) + local load V
+            tkw.cluster(
+                [
+                    global_to_shared_k_kernel,
+                    shared_load_v_kernel,
+                    tkw.WorkgroupBarrier(),
+                    tkw.SchedulingBarrier([]),
+                ],
+            ),
+            # Cluster 2: PV computation and softmax0
+            tkw.cluster(
+                [
+                    tkw.SetWavePrio(1),
+                    mma_pv_kernel,
+                    tkw.SetWavePrio(0),
+                    *softmax0_ops_kernel,
+                    tkw.WorkgroupBarrier(),
+                    tkw.SchedulingBarrier([]),
+                ],
+            ),
+            # Cluster 3: V data movement (global_to_shared_v) + local load K
+            tkw.cluster(
+                [
+                    global_to_shared_v_kernel,
+                    shared_load_k_kernel,
+                    tkw.WorkgroupBarrier(),
+                    tkw.SchedulingBarrier([]),
+                ],
+            ),
+        ]
+
+        # Apply the cluster-based reordering to the KERNEL stage
+        tkw.reorder_graph(pipeline_loop.KERNEL, clusters)
+        tkw.stagger(pipeline_loop.KERNEL)
+
+    return attention_prefetch_schedule

--- a/wave_lang/kernel/wave/templates/__init__.py
+++ b/wave_lang/kernel/wave/templates/__init__.py
@@ -3,3 +3,11 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .attention_common import AttentionShape
+from .tagged_attention import get_tagged_bshd_attention_kernel
+
+__all__ = [
+    "AttentionShape",
+    "get_tagged_bshd_attention_kernel",
+]

--- a/wave_lang/kernel/wave/templates/tagged_attention.py
+++ b/wave_lang/kernel/wave/templates/tagged_attention.py
@@ -1,0 +1,239 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tagged Attention Kernel for use with custom wave schedules.
+
+Memory Layout: BSHD - Q[B,N_Q,H,D_Q], K[B,N_KV,H_KV,D_Q], V[B,N_KV,H_KV,D_KV], C[B,N_Q,H,D_KV]
+
+Tags enable schedulers to identify operations:
+- read_q/read_k/read_v, mma_qk/mma_pv, write_output
+- softmax0_*: ops before last sub (max, exp_delta)
+- softmax1_*: ops from last sub onward (sub_x, exp, sum, cast, scale)
+"""
+
+import math
+
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.wave.constraints import MMAType
+
+from .attention_common import AttentionShape
+
+
+def get_tagged_bshd_attention_kernel(
+    shape: AttentionShape,
+    mfma_variant: list[MMAType],
+    dynamic_dims: bool,
+    is_causal: bool = False,
+    num_waves: int = 8,
+):
+    """
+    Create a tagged BSHD attention kernel for use with custom schedules.
+
+    Args:
+        shape: AttentionShape containing dimension sizes
+        mfma_variant: Tuple of MMA types for QK and PV GEMMs
+        dynamic_dims: Whether to use dynamic dimensions
+        is_causal: Whether to apply causal masking
+        num_waves: Number of waves (default 8 for ping-pong scheduling)
+
+    Returns:
+        Tuple of (kernel_function, hyperparams, dynamic_symbols)
+    """
+    B = tkl.sym.B
+    N_Q = tkl.sym.N_Q
+    N_KV = tkl.sym.N_KV
+    D_Q = tkl.sym.D_Q
+    D_KV = tkl.sym.D_KV
+    H = tkl.sym.H
+    H_KV = tkl.sym.H_KV
+
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_N_Q = tkl.sym.BLOCK_N_Q
+    BLOCK_N_KV = tkl.sym.BLOCK_N_KV
+    BLOCK_D_KV = tkl.sym.BLOCK_D_KV
+    BLOCK_H = tkl.sym.BLOCK_H
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(N_Q, BLOCK_N_Q, 0)]
+    constraints += [tkw.WorkgroupConstraint(D_KV, BLOCK_D_KV, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 3)]
+    constraints += [tkw.WorkgroupConstraint(H_KV, BLOCK_H, 3, primary=False)]
+    constraints += [tkw.TilingConstraint(N_KV, BLOCK_N_KV)]
+    constraints += [tkw.WaveConstraint(N_Q, BLOCK_N_Q / num_waves)]
+    constraints += [tkw.WaveConstraint(D_KV, BLOCK_D_KV / 1)]
+
+    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
+        Mvec, Nvec, TPW = 16, 16, 64
+    elif mfma_variant[1] == MMAType.F32_16x16x32_F16:
+        Mvec, Nvec, TPW = 16, 16, 64
+    elif mfma_variant[1] == MMAType.F32_32x32x8_F16:
+        Mvec, Nvec, TPW = 32, 32, 64
+    elif mfma_variant[1] == MMAType.RDNA4_WAVE32_F32_16x16x16_F16:
+        Mvec, Nvec, TPW = 16, 16, 32
+    else:
+        raise ValueError(f"Unsupported MMA variant: {mfma_variant[1]}")
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=TPW,
+            mma_type=mfma_variant[1],
+            vector_shapes={B: 0, H: 0, H_KV: 0, N_Q: Mvec, D_KV: Nvec},
+        )
+    ]
+
+    if dynamic_dims:
+        constraints += [tkw.Assumption(N_KV > BLOCK_N_KV * 4)]
+
+    log2e = 1.44269504089
+    dk_sqrt = math.sqrt(1.0 / shape.head_size)
+    scale = dk_sqrt * log2e
+
+    # GQA validation: num_query_heads must be divisible by num_kv_heads
+    if shape.num_kv_heads <= 0:
+        raise ValueError(f"num_kv_heads must be positive, got {shape.num_kv_heads}")
+    if shape.num_query_heads % shape.num_kv_heads != 0:
+        raise ValueError(
+            f"num_query_heads ({shape.num_query_heads}) must be divisible by "
+            f"num_kv_heads ({shape.num_kv_heads}) for GQA"
+        )
+    head_ratio = shape.num_query_heads // shape.num_kv_heads
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+
+    output_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H: j, D_KV: k, N_Q: l},
+        outputs={B: i, N_Q: l, H: j, D_KV: k},
+    )
+    q_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H: j, N_Q: k, D_Q: l},
+        outputs={B: i, H: j, N_Q: k, D_Q: l},
+    )
+    # GQA: K/V use j // head_ratio to map query head to KV head
+    k_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H_KV: j // head_ratio, N_KV: k, D_Q: l},
+        outputs={B: i, H_KV: j, N_KV: k, D_Q: l},
+    )
+    v_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H_KV: j // head_ratio, D_KV: k, N_KV: l},
+        outputs={B: i, H_KV: j, D_KV: k, N_KV: l},
+    )
+
+    @tkw.wave(constraints)
+    def tagged_attention(
+        q: tkl.Memory[B, N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, N_KV, H_KV, D_Q, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N_KV, H_KV, D_KV, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, H, D_KV, N_Q, tkl.f32](0.0)
+        init_sum = tkl.Register[B, H, N_Q, tkl.f32](0.0)
+        init_max = tkl.Register[B, H, N_Q, tkl.f32](-1e6)
+        qkv_scaling = tkl.Register[B, H, N_Q, D_Q, tkl.f16](scale)
+        ZEROF = tkl.Register[N_Q, N_KV, tkl.f32](0.0)
+        MIN_INF = tkl.Register[N_Q, N_KV, tkl.f32](-1e6)
+
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg], tag="n_kv_loop")
+        def repeat(
+            partial_max: tkl.Register[B, H, N_Q, tkl.f32],
+            partial_sum: tkl.Register[B, H, N_Q, tkl.f32],
+            acc: tkl.Register[B, H, D_KV, N_Q, tkl.f32],
+        ):
+            # GEMM0: Q @ K^T
+            imm_reg = tkw.register((B, H, N_KV, N_Q), tkl.f32, 0.0, tag="mma_qk_init")
+            q_reg = tkw.read(q, mapping=q_mapping, tag="read_q")
+            q_reg = tkw.tag(q_reg * qkv_scaling, "softmax0_scale")
+            k_reg = tkw.read(k, mapping=k_mapping, tag="read_k")
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0], tag="mma_qk")
+            x_j = tkw.permute(
+                inner_acc, target_shape=[B, H, N_Q, N_KV], tag="softmax0_permute"
+            )
+
+            # Masking
+            n_kv_index = tkw.self_index(N_KV, tkl.i32, tag="softmax0_self_index_kv")
+            mask = tkw.apply_expr(
+                n_kv_index, lambda x: x < N_KV, tag="softmax0_apply_expr"
+            )
+            mask = tkw.broadcast(
+                mask, target_shape=[N_Q, N_KV], tag="softmax0_broadcast_mask"
+            )
+            if is_causal:
+                n_q_index = tkw.self_index(N_Q, tkl.i32, tag="softmax0_self_index_q")
+                n_q_index = tkw.broadcast(
+                    n_q_index, target_shape=[N_Q, N_KV], tag="softmax0_broadcast_q"
+                )
+                mask = tkw.tag(n_q_index >= n_kv_index, "softmax0_causal_cmp")
+                mask = tkw.tag(mask & mask, "softmax0_causal_and")
+            mask = tkw.cast(mask, tkw.i1, tag="softmax0_cast_mask")
+            bias = tkw.select(mask, ZEROF, MIN_INF, tag="softmax0_select_bias")
+            x_j = tkw.tag(x_j + bias, "softmax0_add_bias")
+
+            # Softmax0: ops before last sub
+            m_j = tkw.max(x_j, partial_max, dim=N_KV, tag="softmax0_max")
+            delta_max_sub = tkw.tag(partial_max - m_j, "softmax0_sub_delta")
+            e_delta_max = tkw.exp2(delta_max_sub, tag="softmax0_exp_delta")
+
+            # Softmax1: from last sub onward
+            x_sub = tkw.tag(x_j - m_j, "softmax1_sub_x")
+            e_delta = tkw.exp2(x_sub, tag="softmax1_exp")
+            e_init = tkw.tag(partial_sum * e_delta_max, "softmax1_mul_init")
+            d_j = tkw.sum(e_delta, e_init, dim=N_KV, tag="softmax1_sum")
+            imm_f16 = tkw.cast(e_delta, tkl.f16, tag="softmax1_cast")
+            new_acc = tkw.tag(acc * e_delta_max, "softmax1_scale")
+
+            # GEMM1: softmax(QK) @ V
+            v_reg = tkw.read(v, mapping=v_mapping, tag="read_v")
+            acc = tkw.mma(v_reg, imm_f16, new_acc, mfma_variant[1], tag="mma_pv")
+            return m_j, d_j, acc
+
+        res_max, res_sum, res_mm = repeat
+        reciprocal_sum = tkw.reciprocal(res_sum, tag="epilog_reciprocal")
+        res = tkw.tag(res_mm * reciprocal_sum, "epilog_normalize")
+        tkw.write(res, c, mapping=output_mapping, tag="write_output")
+
+    # BLOCK_N_Q scales with num_waves: BASE_BLOCK_N_Q elements per WAVES_PER_BLOCK_FACTOR waves
+    # For 4 waves: BLOCK_N_Q=128, for 8 waves: BLOCK_N_Q=256
+    WAVES_PER_BLOCK_FACTOR = 4
+    BASE_BLOCK_N_Q = 128
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_B: 1,
+        BLOCK_H: 1,
+        BLOCK_N_Q: BASE_BLOCK_N_Q * (num_waves // WAVES_PER_BLOCK_FACTOR),
+        BLOCK_D_KV: shape.head_size_kv,
+        BLOCK_N_KV: 64,
+        B: 1,
+        H: shape.num_query_heads,
+        H_KV: shape.num_kv_heads,
+        N_Q: shape.query_seq_len,
+        D_KV: shape.head_size_kv,
+        D_Q: shape.head_size,
+        N_KV: shape.kv_seq_len,
+    }
+
+    dynamic_symbols = []
+    if dynamic_dims:
+        dynamic_symbols.append(N_Q)
+        dynamic_symbols.append(D_KV)
+        dynamic_symbols.append(B)
+        dynamic_symbols.append(N_KV)
+        del hyperparams[N_Q]
+        del hyperparams[D_KV]
+        del hyperparams[B]
+        del hyperparams[N_KV]
+
+    return tagged_attention, hyperparams, dynamic_symbols

--- a/wave_lang/kernel/wave/utils/mma_utils.py
+++ b/wave_lang/kernel/wave/utils/mma_utils.py
@@ -26,6 +26,7 @@ from ..constraints import (
 )
 from .graph_utils import capture_backward_slice
 from .symbol_utils import subs_idxc
+from .tag_utils import propagate_tag
 
 
 def is_reshape_needed(
@@ -163,6 +164,7 @@ def get_mma_dimensional_mapping(
                 )
                 custom_reshape = get_custom(reshape)
                 custom_reshape.vector_shapes = mma.vector_shapes
+                propagate_tag(mma.fx_node, reshape)
                 mma.update_arg(arg_index, reshape)
 
     def find_mma_in_slice(node: CustomOp) -> Optional[MMABase]:

--- a/wave_lang/kernel/wave/utils/tag_utils.py
+++ b/wave_lang/kernel/wave/utils/tag_utils.py
@@ -1,0 +1,56 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Tag Propagation Utilities
+
+This module provides helper functions for propagating operation tags
+through the Wave compilation pipeline. Tags are used by custom schedulers
+to identify and organize operations.
+
+Usage:
+    from wave_lang.kernel.wave.utils.tag_utils import propagate_tag, set_tag
+
+    # Propagate tag from source node to target node
+    propagate_tag(source_node, target_node)
+
+    # Set tag on node if tag is provided
+    set_tag(node, "my_tag")
+"""
+
+from typing import Optional
+import torch.fx as fx
+
+
+def propagate_tag(source_node: fx.Node, target_node: fx.Node) -> None:
+    """
+    Propagate tag from source node to target node if present.
+
+    This is the primary mechanism for preserving tags through compilation
+    passes that decompose, reshape, or broadcast operations.
+
+    Args:
+        source_node: The node to copy the tag from
+        target_node: The node to copy the tag to
+    """
+    tag = getattr(source_node, "tag", None)
+    if tag is not None:
+        target_node.tag = tag
+
+
+def set_tag(node: fx.Node, tag: Optional[str]) -> None:
+    """
+    Set tag on node if tag is provided.
+
+    This is useful when creating new nodes that should inherit a tag
+    from a variable rather than another node.
+
+    Args:
+        node: The node to set the tag on
+        tag: The tag string, or None to skip setting
+    """
+    if tag is not None and node is not None:
+        node.tag = tag


### PR DESCRIPTION
This change ensures that operation tags assigned in the kernel definition are preserved when operations are decomposed, expanded, or transformed during compilation. This enables manual scheduling to correctly identify and schedule all operations.

Key changes:
- decompose_reduce_ops.py: Propagate tags to Extract, binary ops, ShuffleOp, Allocate, Write, Read, NewScalar, and Eq nodes during ReduceOp decomposition
- mma_utils.py: Propagate tags from MMA to Reshape nodes
- partition_strided_operators.py: Propagate tags from Read/SelfIndex to Reshape
- decompose_vmma_ops.py: Propagate tags from MMA to Reshape nodes
- hardware_transpose.py: Propagate tags from Read to Reshape/concat nodes
- in_thread_transpose.py: Propagate tags from Write to Extract/Reshape nodes
- index_sequence_analysis.py: Propagate tags to Broadcast nodes for shape matching

Also adds:
- Tagged BSHD attention kernel template (tagged_attention.py)
- Manual attention prefetch schedule (attention_prefetch.py)
- Example and lit tests for tagged attention with manual scheduling
- tkw.tag() function for tagging Python arithmetic operators