### PR TITLE
[water] tighten verification of element types

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -128,25 +128,25 @@ public:
   }
 };
 
-// Verify that element types of Wave tensors match between LHS and RHS. Emit
-// diagnostic errors and return a failure when it is not the case.
+// Verify that element types of Wave tensors or vectors match between LHS and
+// RHS. Emit diagnostic errors and return a failure when it is not the case.
 namespace detail {
 llvm::LogicalResult verifyElementTypesMatch(std::optional<mlir::Location> loc,
                                             llvm::StringRef lhsName,
-                                            wave::WaveTensorType lhs,
+                                            mlir::Type lhs,
                                             llvm::StringRef rhsName,
-                                            wave::WaveTensorType rhs);
+                                            mlir::Type rhs);
 
-// Verify if two types are compatible:
-//   - their symbolic shapes are either equal or at least one of them is
+// Verify if two Wave tensor or vector types are compatible:
+//   - their element types are equal;
+//   - tensor symbolic shapes are either equal or at least one of them is
 //     underspecified;
-//   - their address spaces are either equal or at least one of them is
-//     underspecified.
+//   - tensor address spaces are either equal or at least one of them is
+//     underspecified;
 // When it is not the case, return failure and optionally report an error if a
 // location is provided.
 llvm::LogicalResult verifyTypesCompatible(
-    wave::WaveTensorType lhs, wave::WaveTensorType rhs,
-    bool includeAddressSpace,
+    mlir::Type lhs, mlir::Type rhs, bool includeAddressSpace,
     std::optional<mlir::Location> errorLocation = std::nullopt,
     llvm::StringRef lhsName = "", llvm::StringRef rhsName = "");
 

--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -1529,7 +1529,13 @@ static LogicalResult verifyReadWriteOp(Operation *op, ArrayAttr indexAttr,
                                        Type memoryType, Type valueType,
                                        WaveReadWriteBoundsAttr bounds,
                                        ArrayAttr orderedSyms) {
-  // Skip verification if memory is already resolved to MemRefType.
+
+  if (failed(wave::detail::verifyElementTypesMatch(
+          op->getLoc(), "memory", memoryType, "register", valueType)))
+    return failure();
+
+  // Skip the rest of the verification if memory is already resolved to
+  // MemRefType.
   auto tensorType = dyn_cast<WaveTensorType>(memoryType);
   if (!tensorType)
     return success();

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -318,6 +318,13 @@ func.func @mismatch_shape_binary(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wav
 
 // -----
 
+func.func @mismatch_element_type_tensor_vector(%lhs: !wave.tensor<[@A, @B] of f32>, %rhs: !wave.tensor<[@A, @B] of f32>) {
+  // expected-error @below {{expected result #0 and operand #0 elemental types to match, got 'f64', 'f32'}}
+  wave.add %lhs, %rhs : (!wave.tensor<[@A, @B] of f32>, !wave.tensor<[@A, @B] of f32>) -> vector<4xf64>
+}
+
+// -----
+
 func.func @mismatch_shape_unary(%lhs: !wave.tensor<[@A, @B] of f32>) {
   // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match operand #0 dimension #0 (#wave.symbol<"A">)}}
   wave.exp2 %lhs : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@B, @C] of f32>
@@ -421,6 +428,14 @@ normalform.module [#wave.normal_form<full_types>] {
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
+}
+
+// -----
+
+func.func @read_element_type_mismatch(%mem: memref<64x64xf16, #gpu.address_space<workgroup>>) {
+  // expected-error @below {{expected result #0 and operand #0 elemental types to match, got 'f32', 'f16'}}
+  %0 = wave.read %mem : (memref<64x64xf16, #gpu.address_space<workgroup>>) -> vector<8xf32>
+  return
 }
 
 // -----


### PR DESCRIPTION
Add verification of matching element types on partially-lowered Wave dialect
IR, i.e., between Wave tensors, vectors and memrefs. There is no reason we
should allow type mismatches in this case.

Signed-off-by: Alex Zinenko <git@ozinenko.com>