### PR TITLE
Add fx trace equivalence checking utility

### DIFF
--- a/wave_lang/kernel/_support/dtype.py
+++ b/wave_lang/kernel/_support/dtype.py
@@ -56,6 +56,14 @@ class DataType:
     def __repr__(self):
         return f"DataType({self._ir_type_asm})"
 
+    def __eq__(self, other):
+        if not isinstance(other, DataType):
+            return False
+        return self.ir_type_asm() == other.ir_type_asm()
+
+    def __hash__(self):
+        return hash(self.ir_type_asm())
+
     def is_int_asm(self):
         return self._name in _INT_TYPES
 


### PR DESCRIPTION
Adds a structural trace equivalence checking utility for comparing two fx graphs.

The equivalence checker handles symbolic dimensions, nested structures, and provides failure reasons for debugging.
This utility will be used to validate the MLIR-to-fx conversion pipeline by enabling round-trip-tests.