### PR TITLE
[water] Add design doc for elements-per-thread handling

### DIFF
--- a/water/docs/design/elements-per-thread.md
+++ b/water/docs/design/elements-per-thread.md
@@ -184,6 +184,20 @@ Atomic/Scatter count: 1 (only process first element)
 
 ---
 
+## Code Simplification from Removing PropagateElementsPerThread
+
+If lowering patterns convert WaveTensorType to VectorType during lowering (using the type converter), instead of expecting pre-converted types, we can simplify:
+
+| Component | Current State | After Change |
+|-----------|---------------|--------------|
+| `ReadOpLoweringPattern` | Expects VectorType result, fails if WaveTensorType | Use type converter to get vector width from `index.size` |
+| `WriteOpLoweringPattern` | Expects VectorType operand, fails if WaveTensorType | Use type converter to get vector width from `index.size` |
+| `WaveIterableType` constraint | Accepts both WaveTensorType and VectorType | Only WaveTensorType needed |
+| `wave.iterate` type constraints | Dual-type support for iter_args/captures/results | Only WaveTensorType needed |
+| `VectorsInRegisters` normal form | Verifies register tensors converted to vectors (not yet merged) | Remove |
+
+---
+
 ## Example
 
 **Current:**


### PR DESCRIPTION
This document analyzes how elements_per_thread (EPT) is used in PyWave and proposes that Water use index.size instead of separate EPT attributes.

TL;DR:
- EPT is redundant for most ops (Read, Write, MMA, Reduce, Broadcast) since it's already encoded in index.size
- Only Atomic and Scatter need special attributes (atomic_count, scatter_count) since they may process fewer elements than vector size
- PropagateElementsPerThread pass can be simplified/removed

Please let me know if my understanding is not correct.