### PR TITLE
[water] Add missing fields to hardware constraint

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -191,7 +191,9 @@ def HardwareConstraintAttr : AttrDef<WaveDialect, "HardwareConstraint"> {
                               waves_per_block = [1, 1, 1],
                               mma_type = #wave.mma_kind<f32_16x16x16_f16>,
                               vector_shapes = {M = 1, N = 1, K = 64},
-                              max_bits_per_load = 128>
+                              max_bits_per_load = 128,
+                              workgroups_per_cluster = [4, 4, 1],
+                              n_service_waves = 1>
     ```
 
     specifies that the hardware supports N `threads_per_wave`
@@ -211,19 +213,46 @@ def HardwareConstraintAttr : AttrDef<WaveDialect, "HardwareConstraint"> {
 
     `max_bits_per_load` specifies the maximum number of bits that can
     be loaded with a single load instruction.
+
+    `workgroups_per_cluster` (optional) specifies the cluster dimensions
+    (X, Y, Z) for GPU cluster-based multicast operations. When specified,
+    enables multicast optimization where tensor loads can be shared across
+    multiple workgroups within a cluster. This is a hardware-specific feature
+    (e.g., gfx1250+) that reduces memory bandwidth by broadcasting data.
+    Example: [4, 4, 1] creates a 4x4x1 cluster of 16 workgroups total.
+
+    `n_service_waves` (default 0) specifies the number of dedicated "service
+    waves" for asynchronous loading in wave specialization. When non-zero,
+    the kernel is specialized to partition operations into load and compute
+    waves, where service waves handle asynchronous data loading while compute
+    waves perform computation. This enables better latency hiding through
+    wave-level parallelism. The actual thread block size becomes:
+    threads_per_block = (waves_per_block[0] * threads_per_wave,
+                         waves_per_block[1] + n_service_waves,
+                         waves_per_block[2])
+
+    Note: The `workgroups_per_cluster` and `n_service_waves` attributes are
+    included for compatibility with the Python-based compilation infrastructure
+    and kernel configuration. The corresponding optimization passes (multicast
+    operation generation and wave specialization) are currently implemented in
+    Python and have not yet been ported to MLIR C++.
   }];
   let parameters = (ins "unsigned":$threads_per_wave,
                         OptionalArrayRefParameter<"unsigned">:$waves_per_block,
                         OptionalParameter<"::wave::WaveMmaKindAttr">:$mma_type,
                         OptionalParameter<"::mlir::DictionaryAttr">:$vector_shapes,
-                        DefaultValuedParameter<"unsigned", "128">:$max_bits_per_load);
+                        DefaultValuedParameter<"unsigned", "128">:$max_bits_per_load,
+                        OptionalArrayRefParameter<"unsigned">:$workgroups_per_cluster,
+                        DefaultValuedParameter<"unsigned", "0">:$n_service_waves);
 
   let assemblyFormat = [{
     `<` `threads_per_wave` `=` $threads_per_wave
     (`,` `waves_per_block` `=` `[` $waves_per_block^ `]`)?
     (`,` `mma_type` `=` $mma_type^)?
     (`,` `vector_shapes` `=` $vector_shapes^)?
-    (`,` `max_bits_per_load` `=` $max_bits_per_load^)? `>`
+    (`,` `max_bits_per_load` `=` $max_bits_per_load^)?
+    (`,` `workgroups_per_cluster` `=` `[` $workgroups_per_cluster^ `]`)?
+    (`,` `n_service_waves` `=` $n_service_waves^)? `>`
   }];
 
   let genVerifyDecl = 1;

--- a/water/include/water/c/Dialects.h
+++ b/water/include/water/c/Dialects.h
@@ -391,7 +391,8 @@ mlirAttributeIsAHardwareConstraintAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute mlirHardwareConstraintAttrGet(
     MlirContext mlirCtx, unsigned threadsPerWave, size_t wavesPerBlockSize,
     unsigned *wavesPerBlock, MlirAttribute mmaType, MlirAttribute vectorShapes,
-    unsigned maxBitsPerLoad);
+    unsigned maxBitsPerLoad, size_t workgroupsPerClusterSize,
+    unsigned *workgroupsPerCluster, unsigned nServiceWaves);
 
 /// Returns the typeID of a HardwareConstraintAttr.
 MLIR_CAPI_EXPORTED MlirTypeID mlirWHardwareConstraintAttrGetTypeID();
@@ -409,6 +410,13 @@ MLIR_CAPI_EXPORTED MlirAttribute
 mlirHardwareConstraintAttrGetVectorShapes(MlirAttribute attr);
 MLIR_CAPI_EXPORTED unsigned
 mlirHardwareConstraintAttrGetMaxBitsPerLoad(MlirAttribute attr);
+MLIR_CAPI_EXPORTED intptr_t
+mlirHardwareConstraintAttrGetNumWorkgroupsPerCluster(MlirAttribute attr);
+MLIR_CAPI_EXPORTED unsigned
+mlirHardwareConstraintAttrGetWorkgroupsPerClusterElem(MlirAttribute attr,
+                                                      intptr_t i);
+MLIR_CAPI_EXPORTED unsigned
+mlirHardwareConstraintAttrGetNServiceWaves(MlirAttribute attr);
 
 //===---------------------------------------------------------------------===//
 // DeviceConstraintAttr

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -423,11 +423,11 @@ bool mlirAttributeIsAHardwareConstraintAttr(MlirAttribute attr) {
   return llvm::isa<wave::HardwareConstraintAttr>(unwrap(attr));
 }
 
-MlirAttribute
-mlirHardwareConstraintAttrGet(MlirContext mlirCtx, unsigned threadsPerWave,
-                              size_t wavesPerBlockSize, unsigned *wavesPerBlock,
-                              MlirAttribute mmaType, MlirAttribute vectorShapes,
-                              unsigned maxBitsPerLoad) {
+MlirAttribute mlirHardwareConstraintAttrGet(
+    MlirContext mlirCtx, unsigned threadsPerWave, size_t wavesPerBlockSize,
+    unsigned *wavesPerBlock, MlirAttribute mmaType, MlirAttribute vectorShapes,
+    unsigned maxBitsPerLoad, size_t workgroupsPerClusterSize,
+    unsigned *workgroupsPerCluster, unsigned nServiceWaves) {
   MLIRContext *ctx = unwrap(mlirCtx);
   auto mmaTypeAttr =
       llvm::cast_if_present<wave::WaveMmaKindAttr>(unwrap(mmaType));
@@ -436,7 +436,9 @@ mlirHardwareConstraintAttrGet(MlirContext mlirCtx, unsigned threadsPerWave,
 
   return wrap(wave::HardwareConstraintAttr::get(
       ctx, threadsPerWave, llvm::ArrayRef(wavesPerBlock, wavesPerBlockSize),
-      mmaTypeAttr, vectorShapesAttr, maxBitsPerLoad));
+      mmaTypeAttr, vectorShapesAttr, maxBitsPerLoad,
+      llvm::ArrayRef(workgroupsPerCluster, workgroupsPerClusterSize),
+      nServiceWaves));
 }
 
 MlirTypeID mlirWHardwareConstraintAttrGetTypeID() {
@@ -468,6 +470,22 @@ MlirAttribute mlirHardwareConstraintAttrGetVectorShapes(MlirAttribute attr) {
 unsigned mlirHardwareConstraintAttrGetMaxBitsPerLoad(MlirAttribute attr) {
   return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
       .getMaxBitsPerLoad();
+}
+intptr_t
+mlirHardwareConstraintAttrGetNumWorkgroupsPerCluster(MlirAttribute attr) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getWorkgroupsPerCluster()
+      .size();
+}
+unsigned
+mlirHardwareConstraintAttrGetWorkgroupsPerClusterElem(MlirAttribute attr,
+                                                      intptr_t i) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getWorkgroupsPerCluster()[i];
+}
+unsigned mlirHardwareConstraintAttrGetNServiceWaves(MlirAttribute attr) {
+  return llvm::cast<wave::HardwareConstraintAttr>(unwrap(attr))
+      .getNServiceWaves();
 }
 
 //===---------------------------------------------------------------------===//

--- a/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -621,10 +621,15 @@ WaveExprListAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 LogicalResult HardwareConstraintAttr::verify(
     function_ref<InFlightDiagnostic()> emitError, unsigned threadsPerWave,
     ArrayRef<unsigned> wavesPerBlock, WaveMmaKindAttr mmaType,
-    DictionaryAttr vectorShapes, unsigned maxBitsPerLoad) {
+    DictionaryAttr vectorShapes, unsigned maxBitsPerLoad,
+    ArrayRef<unsigned> workgroupsPerCluster, unsigned nServiceWaves) {
 
   if (!(wavesPerBlock.empty() || wavesPerBlock.size() == 3))
     return emitError() << "waves_per_block (" << wavesPerBlock
+                       << ") should have 3 elements";
+
+  if (!workgroupsPerCluster.empty() && workgroupsPerCluster.size() != 3)
+    return emitError() << "workgroups_per_cluster (" << workgroupsPerCluster
                        << ") should have 3 elements";
 
   if (vectorShapes) {

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -316,6 +316,25 @@ with ir.Context() as ctx:
     print(hardware_constr_3)
     # CHECK: [2, 2, 1]
     print(hardware_constr_3.waves_per_block)
+    # CHECK: []
+    print(hardware_constr_3.workgroups_per_cluster)
+    # CHECK: 0
+    print(hardware_constr_3.n_service_waves)
+
+    # CHECK: #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [2, 2, 1], vector_shapes = {M = 512 : i64, N = 512 : i64}, workgroups_per_cluster = [4, 4, 1], n_service_waves = 2>
+    hardware_constr_4 = wave.HardwareConstraintAttr.get(
+        threads_per_wave=64,
+        waves_per_block=[2, 2, 1],
+        vector_shapes=shape_dict,
+        max_bits_per_load=128,
+        workgroups_per_cluster=[4, 4, 1],
+        n_service_waves=2,
+    )
+    print(hardware_constr_4)
+    # CHECK: [4, 4, 1]
+    print(hardware_constr_4.workgroups_per_cluster)
+    # CHECK: 2
+    print(hardware_constr_4.n_service_waves)
 
     # CHECK: #wave.device_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, device_dim = 0>
     device_constr = wave.DeviceConstraintAttr.get(


### PR DESCRIPTION
This adds the fields `workgroups_per_cluster` and `n_service_waves` to wave.hardware_constraint and corresponding Python bindings.
The transformations triggered by these are currently not implemented in water, but their presence simplifies round-trip tests and eases potential porting.