### PR TITLE
undo wrong dataflow from c3ca6ea1f0a7bb1cb26293c8e10399aa234a3852

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -214,7 +214,7 @@ def MmaOp : WaveOp<"mma",
 def IterateOp : Op<WaveDialect, "iterate", [
     AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<RegionBranchOpInterface,
-        ["areTypesCompatible", "getEntrySuccessorOperands", "getSuccessorInputs"]>,
+        ["areTypesCompatible", "getEntrySuccessorOperands"]>,
     DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>]> {
   let summary = "Executes the body repeatedly";
   let description = [{

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -322,7 +322,7 @@ public:
       for (auto &&[terminatorOperand, iterArg, lattice] : llvm::zip_equal(
                yieldOp.getOperands(), iterateOp.getIterArgs(),
                lattices.take_front(iterateOp.getIterArgs().size()))) {
-        // Fetch the lattice and create a dependecy to re-visit the program
+        // Fetch the lattice and create a dependency to re-visit the program
         // point at the start of the loop body block when the lattice changes
         // since we know we are processing a branch into the loop body. Taking
         // the program point before the block / first operation will call

--- a/water/test/Dialect/Wave/infer-types.mlir
+++ b/water/test/Dialect/Wave/infer-types.mlir
@@ -238,8 +238,7 @@ normalform.module [] {
 normalform.module [#wave.normal_form<full_func_boundary>] {
   func.func @iterate_mismatching_results(%arg0: !wave.tensor<[@A] of f32>, %arg1: !wave.tensor<[@B] of f32>) {
     %read = wave.read %arg1 : (!wave.tensor<[@B] of f32>) -> !wave.tensor<any of f32>
-    // expected-error @below {{along control flow edge from parent to Region #0: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@B] of f32>'}}
-    // expected-note @below {{region branch point}}
+    // expected-error @below {{expected iter arg #0 dimension #0 (#wave.symbol<"A">) to match block iter arg #0 dimension #0 (#wave.symbol<"B">)}}
     wave.iterate @I iter_args(%arg0, %read) {
     ^bb0(%arg2: !wave.tensor<[@B] of f32>, %arg3: !wave.tensor<any of f32>):
       wave.yield %arg2, %arg3 : !wave.tensor<[@B] of f32>, !wave.tensor<any of f32>

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -107,8 +107,7 @@ func.func @iterate_iter_args_block_iter_args_mismatch(%arg0: !wave.tensor<any of
 // -----
 
 func.func @iterate_iter_arg_block_arg_element_type_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A] of bf16>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{expected iter arg #0 and block iter arg #0 elemental types to match, got 'f32', 'bf16'}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A] of bf16>):
     wave.yield %arg1 : !wave.tensor<[@A] of bf16>
@@ -118,8 +117,7 @@ func.func @iterate_iter_arg_block_arg_element_type_mismatch(%arg0: !wave.tensor<
 // -----
 
 func.func @iterate_iter_arg_block_arg_rank_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A, @B] of f32>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{rank mismatch between iter arg #0 and block iter arg #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A, @B] of f32>):
     wave.yield %arg1 : !wave.tensor<[@A, @B] of f32>
@@ -139,8 +137,7 @@ func.func @iterate_iter_arg_block_arg_shape_mismatch(%arg0: !wave.tensor<[@A] of
 // -----
 
 func.func @iterate_iter_arg_block_arg_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <register>>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32, <register>>' should match successor input type #0 '!wave.tensor<[@A] of f32, <shared>>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{address space mismatch between iter arg #0 and block iter arg #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A] of f32, <shared>>):
     wave.yield %arg1 : !wave.tensor<[@A] of f32, <shared>>
@@ -150,8 +147,7 @@ func.func @iterate_iter_arg_block_arg_address_space_mismatch(%arg0: !wave.tensor
 // -----
 
 func.func @iterate_iter_arg_result_element_type_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A] of bf16>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{expected result #0 and terminator operand #0 elemental types to match, got 'bf16', 'f32'}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A] of f32>):
     wave.yield %arg1 : !wave.tensor<[@A] of f32>
@@ -161,8 +157,7 @@ func.func @iterate_iter_arg_result_element_type_mismatch(%arg0: !wave.tensor<[@A
 // -----
 
 func.func @iterate_iter_arg_result_rank_mismatch(%arg0: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A, @B] of f32>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{rank mismatch between result #0 and terminator operand #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A] of f32>):
     wave.yield %arg1 : !wave.tensor<[@A] of f32>
@@ -182,8 +177,7 @@ func.func @iterate_iter_arg_result_shape_mismatch(%arg0: !wave.tensor<[@A] of f3
 // -----
 
 func.func @iterate_iter_arg_result_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <register>>) {
-  // expected-error @below {{along control flow edge from parent to parent: successor operand type #0 '!wave.tensor<[@A] of f32, <register>>' should match successor input type #0 '!wave.tensor<[@A] of f32, <shared>>'}}
-  // expected-note @below {{region branch point}}
+  // expected-error @below {{address space mismatch between result #0 and terminator operand #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg1: !wave.tensor<[@A] of f32, <register>>):
     wave.yield %arg1 : !wave.tensor<[@A] of f32, <register>>
@@ -203,10 +197,9 @@ func.func @iterate_capture_type_mismatch(%arg0: !wave.tensor<[@A] of f32>, %capt
 // -----
 
 func.func @iterate_results_terminator_operands_mismatch(%arg0: !wave.tensor<any of f32>, %arg1: !wave.tensor<any of f32>) {
-  // expected-error @below {{along control flow edge from Operation wave.yield to parent: region branch point has 2 operands, but region successor needs 1 inputs}}
+  // expected-error @below {{expects the same number of results (1) and terminator operands (2)}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg2: !wave.tensor<any of f32>):
-    // expected-note @below {{region branch point}}
     wave.yield %arg2, %arg1 : !wave.tensor<any of f32>, !wave.tensor<any of f32>
   } : (!wave.tensor<any of f32>) -> !wave.tensor<any of f32>
 }
@@ -214,10 +207,9 @@ func.func @iterate_results_terminator_operands_mismatch(%arg0: !wave.tensor<any 
 // -----
 
 func.func @iterate_result_terminator_element_type_mismatch(%arg0: !wave.tensor<[@A] of bf16>, %arg1: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from Operation wave.yield to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A] of bf16>'}}
+  // expected-error @below {{expected result #0 and terminator operand #0 elemental types to match, got 'bf16', 'f32'}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg2: !wave.tensor<[@A] of bf16>):
-    // expected-note @below {{region branch point}}
     wave.yield %arg1 : !wave.tensor<[@A] of f32>
   } : (!wave.tensor<[@A] of bf16>) -> !wave.tensor<[@A] of bf16>
 }
@@ -225,10 +217,9 @@ func.func @iterate_result_terminator_element_type_mismatch(%arg0: !wave.tensor<[
 // -----
 
 func.func @iterate_result_terminator_rank_mismatch(%arg0: !wave.tensor<[@A, @B] of f32>, %arg1: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from Operation wave.yield to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@A, @B] of f32>'}}
+  // expected-error @below {{rank mismatch between result #0 and terminator operand #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg2: !wave.tensor<[@A, @B] of f32>):
-    // expected-note @below {{region branch point}}
     wave.yield %arg1 : !wave.tensor<[@A] of f32>
   } : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@A, @B] of f32>
 }
@@ -236,10 +227,9 @@ func.func @iterate_result_terminator_rank_mismatch(%arg0: !wave.tensor<[@A, @B] 
 // -----
 
 func.func @iterate_result_terminator_shape_mismatch(%arg0: !wave.tensor<[@B] of f32>, %arg1: !wave.tensor<[@A] of f32>) {
-  // expected-error @below {{along control flow edge from Operation wave.yield to parent: successor operand type #0 '!wave.tensor<[@A] of f32>' should match successor input type #0 '!wave.tensor<[@B] of f32>'}}
+  // expected-error @below {{expected result #0 dimension #0 (#wave.symbol<"B">) to match terminator operand #0 dimension #0 (#wave.symbol<"A">)}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg2: !wave.tensor<[@B] of f32>):
-    // expected-note @below {{region branch point}}
     wave.yield %arg1 : !wave.tensor<[@A] of f32>
   } : (!wave.tensor<[@B] of f32>) -> !wave.tensor<[@B] of f32>
 }
@@ -247,10 +237,9 @@ func.func @iterate_result_terminator_shape_mismatch(%arg0: !wave.tensor<[@B] of 
 // -----
 
 func.func @iterate_result_terminator_address_space_mismatch(%arg0: !wave.tensor<[@A] of f32, <shared>>, %arg1: !wave.tensor<[@A] of f32, <register>>) {
-  // expected-error @below {{along control flow edge from Operation wave.yield to parent: successor operand type #0 '!wave.tensor<[@A] of f32, <register>>' should match successor input type #0 '!wave.tensor<[@A] of f32, <shared>>'}}
+  // expected-error @below {{address space mismatch between result #0 and terminator operand #0}}
   wave.iterate @I iter_args(%arg0) {
   ^bb0(%arg2: !wave.tensor<[@A] of f32, <shared>>):
-    // expected-note @below {{region branch point}}
     wave.yield %arg1 : !wave.tensor<[@A] of f32, <register>>
   } : (!wave.tensor<[@A] of f32, <shared>>) -> !wave.tensor<[@A] of f32, <shared>>
 }


### PR DESCRIPTION
The changes to dataflow modeling of the iterate operation indicating made in that (integration) commit are wrong. They are the exact opposite of the modeling that drops the induction variable implemented in f5d2beda4d743e51aa2edabcced1c200e7c73a5d. They also replace customized error messages with default ones and don't provide alternative checks.