### PR TITLE
[water] harden reduction op verification

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -1377,6 +1377,20 @@ LogicalResult wave::detail::verifyReductionOperation(Operation *op,
     }
   }
 
+  if (initType && initType.getFullySpecified()) {
+    if (axisAttr && llvm::is_contained(initType.getShape(), axisAttr)) {
+      return op->emitOpError()
+             << "init tensor shape must not contain the reduced axis";
+    }
+  }
+
+  if (resultType && resultType.getFullySpecified()) {
+    if (axisAttr && llvm::is_contained(resultType.getShape(), axisAttr)) {
+      return op->emitOpError()
+             << "result tensor shape must not contain the reduced axis";
+    }
+  }
+
   return success();
 }
 

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -766,3 +766,30 @@ func.func @underspecified_reduction(%input: !wave.tensor<any of f32>, %init: !wa
   %result = wave.sum %input init(%init) <warp> : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<any of f32>
   return %result : !wave.tensor<any of f32>
 }
+
+// -----
+
+func.func @reduction_init_contains_axis_explicit(%input: !wave.tensor<any of f32>, %init: !wave.tensor<[@N, @M] of f32>) -> !wave.tensor<any of f32> {
+  // Reducing along axis @M, but init tensor shape contains @M.
+  // expected-error @below {{init tensor shape must not contain the reduced axis}}
+  %result = wave.sum %input init(%init) along @M <warp> : (!wave.tensor<any of f32>, !wave.tensor<[@N, @M] of f32>) -> !wave.tensor<any of f32>
+  return %result : !wave.tensor<any of f32>
+}
+
+// -----
+
+func.func @reduction_result_contains_axis_explicit(%input: !wave.tensor<any of f32>, %init: !wave.tensor<any of f32>) -> !wave.tensor<[@N, @M] of f32> {
+  // Reducing along axis @M, but result tensor shape contains @M.
+  // expected-error @below {{result tensor shape must not contain the reduced axis}}
+  %result = wave.sum %input init(%init) along @M <warp> : (!wave.tensor<any of f32>, !wave.tensor<any of f32>) -> !wave.tensor<[@N, @M] of f32>
+  return %result : !wave.tensor<[@N, @M] of f32>
+}
+
+// -----
+
+func.func @reduction_init_and_result_contain_axis(%input: !wave.tensor<any of f32>, %init: !wave.tensor<[@K] of f32>) -> !wave.tensor<[@K] of f32> {
+  // Reducing along axis @K, but both init and result shapes contain @K.
+  // expected-error @below {{init tensor shape must not contain the reduced axis}}
+  %result = wave.max_element %input init(%init) along @K <warp> : (!wave.tensor<any of f32>, !wave.tensor<[@K] of f32>) -> !wave.tensor<[@K] of f32>
+  return %result : !wave.tensor<[@K] of f32>
+}


### PR DESCRIPTION
Check that the reduction axis, when provided, is not present in init and result types, which is true given that dimensions are required to be unique.