### PR TITLE
Change tags from str to set[str]

### DIFF
--- a/examples/python/6.3_schedule.py
+++ b/examples/python/6.3_schedule.py
@@ -107,7 +107,7 @@ def test_gfx1250_tbuf_gemm(is_debug=False):
         global_to_shared_b = tkw.filter_nodes(all_read_b, node_type=tkw.TensorLoadToLDS)
         shared_load_b = tkw.filter_nodes(all_read_b, node_type=tkw.Read)
 
-        global_to_shared_fused = tkw.get_node_by_tag("read_a,read_b")
+        global_to_shared_fused = tkw.get_node_by_tag({"read_a", "read_b"})
 
         if len(global_to_shared_fused) == 0:
             global_to_shared_fused.extend(global_to_shared_a)

--- a/lit_tests/kernel/wave/tag.py
+++ b/lit_tests/kernel/wave/tag.py
@@ -26,7 +26,9 @@ def print_tags(trace):
     for node in graph.nodes:
         tag = getattr(node, "tag", None)
         if tag is not None:
-            print(f"  {node.name}: tag={tag}")
+            # Format set as comma-separated string for readable output
+            tag_str = ",".join(sorted(tag)) if isinstance(tag, set) else str(tag)
+            print(f"  {node.name}: tag={tag_str}")
 
 
 @run_test

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -637,10 +637,11 @@ def tag(expr: fx.Proxy, tag_name: str) -> fx.Proxy:
     Returns:
         The same fx.Proxy, allowing chained expressions
     """
+    tag_set = {tag_name} if isinstance(tag_name, str) else tag_name
     if isinstance(expr, fx.Proxy):
-        expr.node.tag = tag_name
+        expr.node.tag = tag_set
     elif isinstance(expr, fx.Node):
-        expr.tag = tag_name
+        expr.tag = tag_set
     else:
         raise ValueError(
             f"tkw.tag expects an fx.Proxy or fx.Node, got {type(expr)}. "
@@ -676,8 +677,20 @@ class CustomOp(ABC):
             setattr(self.fx_node, "location", value)
 
     @property
-    def tag(self) -> Optional[str]:
-        return getattr(self.fx_node, "tag", None)
+    def tag(self) -> Optional[set[str]]:
+        tag = getattr(self.fx_node, "tag", None)
+        # Normalize legacy string tags to sets
+        if isinstance(tag, str):
+            return {tag}
+        return tag
+
+    @tag.setter
+    def tag(self, value: Optional[str | set[str]]):
+        if value is None:
+            return
+        if isinstance(value, str):
+            value = {value}
+        setattr(self.fx_node, "tag", value)
 
     @property
     def unroll_iteration(self) -> Optional[int]:

--- a/wave_lang/kernel/wave/fuse_tensor_loads.py
+++ b/wave_lang/kernel/wave/fuse_tensor_loads.py
@@ -414,14 +414,14 @@ def fuse_tensor_loads(
         if hasattr(load1_node, "pre_expansion_id"):
             fused_load.pre_expansion_id = load1_node.pre_expansion_id
 
-        # Add tags to the fused load
-        tags = []
-        if hasattr(load1_node, "tag"):
-            tags.append(load1_node.tag)
-        if hasattr(load2_node, "tag"):
-            tags.append(load2_node.tag)
+        # Add tags to the fused load (merge tag sets)
+        tags: set[str] = set()
+        for node in (load1_node, load2_node):
+            tag = getattr(node, "tag", None)
+            if tag:
+                tags |= tag if isinstance(tag, set) else {tag}
         if tags:
-            fused_load.tag = ",".join(tags)
+            fused_load.tag = tags
 
         logger.debug(f"Created fused load: {fused_load.name}")
 

--- a/wave_lang/kernel/wave/schedules/gemm_triple_buffer.py
+++ b/wave_lang/kernel/wave/schedules/gemm_triple_buffer.py
@@ -190,7 +190,7 @@ def get_gfx1250_tbuf_gemm_schedule():
         global_to_shared_b = tkw.filter_nodes(all_read_b, node_type=tkw.TensorLoadToLDS)
         shared_load_b = tkw.filter_nodes(all_read_b, node_type=tkw.Read)
 
-        global_to_shared_fused = tkw.get_node_by_tag("read_a,read_b")
+        global_to_shared_fused = tkw.get_node_by_tag({"read_a", "read_b"})
 
         if len(global_to_shared_fused) == 0:
             global_to_shared_fused.extend(global_to_shared_a)

--- a/wave_lang/kernel/wave/utils/tag_utils.py
+++ b/wave_lang/kernel/wave/utils/tag_utils.py
@@ -41,7 +41,7 @@ def propagate_tag(source_node: fx.Node, target_node: fx.Node) -> None:
         target_node.tag = tag
 
 
-def set_tag(node: fx.Node, tag: Optional[str]) -> None:
+def set_tag(node: fx.Node, tag: Optional[str | set[str]]) -> None:
     """
     Set tag on node if tag is provided.
 
@@ -50,7 +50,10 @@ def set_tag(node: fx.Node, tag: Optional[str]) -> None:
 
     Args:
         node: The node to set the tag on
-        tag: The tag string, or None to skip setting
+        tag: The tag string or set of strings, or None to skip setting.
+            If a string is provided, it will be converted to a single-element set.
     """
     if tag is not None and node is not None:
+        if isinstance(tag, str):
+            tag = {tag}
         node.tag = tag


### PR DESCRIPTION
- Update the tag system from single strings to `set[str]` for better representation of fused operations
- When operations are fused (e.g.,` read_a` and `read_b`), their tags are now stored as a set `{"read_a", "read_b"}` instead of a comma-separated string `"read_a,read_b"`
- `get_node_by_tag` now supports two modes:
  - Single string query: matches nodes where the tag is in the node's tag set
  - Set query: matches nodes where the tag set equals exactly