### PR TITLE
[asm] Add arith.xori support to enable LDS swizzling for all MFMA types

### DIFF
--- a/wave_lang/kernel/wave/asm/mlir_walker.py
+++ b/wave_lang/kernel/wave/asm/mlir_walker.py
@@ -114,6 +114,8 @@ class IRWalker:
             self.handlers.handle_arith_addi_op(operation, kernel_info)
         elif isinstance(operation, arith_d.MulIOp):
             self.handlers.handle_arith_muli_op(operation, kernel_info)
+        elif isinstance(operation, arith_d.XOrIOp):
+            self.handlers.handle_arith_xori_op(operation, kernel_info)
         elif isinstance(operation, arith_d.IndexCastOp):
             self.handlers.handle_arith_index_cast_op(operation, kernel_info)
         elif isinstance(operation, gpu_d.ThreadIdOp):

--- a/wave_lang/kernel/wave/gather_to_shared.py
+++ b/wave_lang/kernel/wave/gather_to_shared.py
@@ -654,22 +654,6 @@ def gather_to_shared_swizzling(
         # column but read from a different column, causing incorrect results.
         gather_local_index = remove_global_indexing(gather.src_index, constraints)
         read_local_index = remove_global_indexing(read.index, constraints)
-        gather_row_expr = sympy.simplify(
-            subs_idxc(gather_local_index[row_dim].start) % max_phase
-        )
-        read_row_expr = sympy.simplify(
-            subs_idxc(read_local_index[row_dim].start) % max_phase
-        )
-        # The ASM backend requires matching row expressions for correct swizzling.
-        # The default LLVM backend handles mismatched expressions correctly.
-        if options.backend == "asm" and gather_row_expr != read_row_expr:
-            logger.info(
-                f"row phase inconsistency between reads and gathers: "
-                f"{gather_row_expr} != {read_row_expr}. "
-                f"Skipping swizzling for ASM backend."
-            )
-            continue
-
         for read in reads:
             index = remove_global_indexing(read.index, constraints)
             col_seq = index[col_dim]


### PR DESCRIPTION
The ASM backend was missing a handler for arith.xori, which meant the XOR operations from gather_to_shared swizzling were silently dropped during MLIR walking. This caused corrupted LDS addresses and GPU memory faults for 16x16x32 MFMA configurations with gather-to-shared enabled.

The fix adds XOR handling at three levels:
- MLIR walker: dispatch arith_d.XOrIOp to the new handler
- Arith handler: record xori results in index_env using the custom sympy xor function for symbolic operands
- Expression emitter: emit v_xor_b32 for xor expressions

With XOR properly supported, the ASM backend guard that skipped swizzling when gather/read row phases mismatched is no longer needed and has been removed.