### PR TITLE
[asm] Add MXFP4 scaled MFMA support to Python and C++ backends and fix SGPR…

### DIFF
--- a/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
+++ b/wave_lang/kernel/wave/asm/instruction_defs/common.yaml
@@ -691,6 +691,34 @@ instructions:
   # ===========================================================================
   # LDS Operations
   # ===========================================================================
+  ds_read_u8:
+    mnemonic: ds_read_u8
+    category: lds
+    format: ds
+    defs:
+      - {name: dst, type: vgpr}
+    uses:
+      - {name: addr, type: vgpr}
+      - {name: offset, type: offset, optional: true}
+    latency: 20
+    special:
+      memory: true
+      offset_format: space_separated
+
+  ds_read_u16:
+    mnemonic: ds_read_u16
+    category: lds
+    format: ds
+    defs:
+      - {name: dst, type: vgpr}
+    uses:
+      - {name: addr, type: vgpr}
+      - {name: offset, type: offset, optional: true}
+    latency: 20
+    special:
+      memory: true
+      offset_format: space_separated
+
   ds_read_b32:
     mnemonic: ds_read_b32
     category: lds
@@ -729,6 +757,34 @@ instructions:
       - {name: addr, type: vgpr}
       - {name: offset, type: offset, optional: true}
     latency: 20
+    special:
+      memory: true
+      offset_format: space_separated
+
+  ds_write_b8:
+    mnemonic: ds_write_b8
+    category: lds
+    format: ds
+    defs: []
+    uses:
+      - {name: addr, type: vgpr}
+      - {name: src, type: vgpr}
+      - {name: offset, type: offset, optional: true}
+    latency: 1
+    special:
+      memory: true
+      offset_format: space_separated
+
+  ds_write_b16:
+    mnemonic: ds_write_b16
+    category: lds
+    format: ds
+    defs: []
+    uses:
+      - {name: addr, type: vgpr}
+      - {name: src, type: vgpr}
+      - {name: offset, type: offset, optional: true}
+    latency: 1
     special:
       memory: true
       offset_format: space_separated

--- a/wave_lang/kernel/wave/asm/instruction_formatter.py
+++ b/wave_lang/kernel/wave/asm/instruction_formatter.py
@@ -187,6 +187,7 @@ class InstructionFormatter:
         defs: List[Any] = None,
         uses: List[Any] = None,
         comment: str = None,
+        modifiers: str = None,
     ) -> str:
         """
         Format an instruction to its assembly representation.
@@ -207,10 +208,10 @@ class InstructionFormatter:
         instr_def = self._registry.get(name)
 
         if instr_def:
-            return self._format_with_def(instr_def, defs, uses, comment)
+            return self._format_with_def(instr_def, defs, uses, comment, modifiers)
         else:
             # Fallback for instructions not in registry
-            return self._format_fallback(name, defs, uses, comment)
+            return self._format_fallback(name, defs, uses, comment, modifiers)
 
     def _format_with_def(
         self,
@@ -218,6 +219,7 @@ class InstructionFormatter:
         defs: List[Any],
         uses: List[Any],
         comment: str,
+        modifiers: str = None,
     ) -> str:
         """Format instruction using its definition."""
         # Handle pseudo-ops
@@ -280,6 +282,10 @@ class InstructionFormatter:
                 line = parts[0] + " lds  //" + parts[1]
             else:
                 line = line + " lds"
+
+        # Add extra modifiers (e.g., cbsz:4 blgp:4)
+        if modifiers:
+            line = line + " " + modifiers
 
         # Add comment
         if comment:
@@ -352,6 +358,7 @@ class InstructionFormatter:
         defs: List[Any],
         uses: List[Any],
         comment: str,
+        modifiers: str = None,
     ) -> str:
         """Format instruction not in registry (fallback)."""
         # Use name as mnemonic
@@ -364,6 +371,10 @@ class InstructionFormatter:
             line = f"    {mnemonic}"
         else:
             line = f"    {mnemonic} {', '.join(operands)}"
+
+        # Add extra modifiers (e.g., cbsz:4 blgp:4)
+        if modifiers:
+            line = line + " " + modifiers
 
         if comment:
             line += f"  // {comment}"

--- a/wave_lang/kernel/wave/asm/instruction_registry.py
+++ b/wave_lang/kernel/wave/asm/instruction_registry.py
@@ -437,6 +437,38 @@ def get_instruction_category(
     return instr_def.category
 
 
+def _resolve_instruction(name: str, architecture: str = "common"):
+    """
+    Resolve an instruction definition, trying fallback architectures if needed.
+
+    Args:
+        name: Instruction name (e.g., "s_cbranch_scc0")
+        architecture: Target architecture (default "common")
+
+    Returns:
+        The instruction definition
+
+    Raises:
+        ValueError: If instruction is not found in any registry
+    """
+    registry = get_registry(architecture)
+    instr_def = registry.get(name)
+    if instr_def is None:
+        # Try fallback architectures if not found
+        for fallback_arch in ["gfx950", "gfx942"]:
+            if fallback_arch != architecture:
+                fallback_registry = get_registry(fallback_arch)
+                instr_def = fallback_registry.get(name)
+                if instr_def is not None:
+                    break
+    if instr_def is None:
+        raise ValueError(
+            f"Unknown instruction '{name}' not found in registry for "
+            f"architecture '{architecture}'. Please add it to the YAML definitions."
+        )
+    return instr_def
+
+
 def is_conditional_branch(name: str, architecture: str = "common") -> bool:
     """
     Check if instruction is a conditional branch.
@@ -451,14 +483,7 @@ def is_conditional_branch(name: str, architecture: str = "common") -> bool:
     Raises:
         ValueError: If instruction is not found in registry
     """
-    registry = get_registry(architecture)
-    instr_def = registry.get(name)
-    if instr_def is None:
-        raise ValueError(
-            f"Unknown instruction '{name}' not found in registry for "
-            f"architecture '{architecture}'. Please add it to the YAML definitions."
-        )
-    return instr_def.is_conditional
+    return _resolve_instruction(name, architecture).is_conditional
 
 
 def is_branch_instruction(name: str, architecture: str = "common") -> bool:
@@ -475,14 +500,7 @@ def is_branch_instruction(name: str, architecture: str = "common") -> bool:
     Raises:
         ValueError: If instruction is not found in registry
     """
-    registry = get_registry(architecture)
-    instr_def = registry.get(name)
-    if instr_def is None:
-        raise ValueError(
-            f"Unknown instruction '{name}' not found in registry for "
-            f"architecture '{architecture}'. Please add it to the YAML definitions."
-        )
-    return instr_def.is_branch
+    return _resolve_instruction(name, architecture).is_branch
 
 
 # ==============================================================================

--- a/wave_lang/kernel/wave/asm/kernel_generator.py
+++ b/wave_lang/kernel/wave/asm/kernel_generator.py
@@ -214,7 +214,9 @@ class KernelGenerator:
         defs = [self._resolve_def(d) for d in instr.defs]
         uses = [self._resolve_operand(u) for u in instr.uses]
 
-        return self._formatter.format(name, defs=defs, uses=uses, comment=instr.comment)
+        return self._formatter.format(
+            name, defs=defs, uses=uses, comment=instr.comment, modifiers=instr.modifiers
+        )
 
     def _resolve_def(self, d: KOperand) -> str:
         """Resolve a definition operand."""

--- a/wave_lang/kernel/wave/asm/kernel_ir.py
+++ b/wave_lang/kernel/wave/asm/kernel_ir.py
@@ -301,6 +301,9 @@ class KInstr:
     constraints: KInstrConstraints = field(default_factory=KInstrConstraints)
     comment: Optional[str] = None
     target: Optional[str] = None  # Branch target label (cleaner than using comment)
+    modifiers: Optional[str] = (
+        None  # Extra instruction modifiers (e.g., "cbsz:4 blgp:4")
+    )
 
     def get_virtual_defs(self) -> List[KVirtualReg]:
         """Get all virtual registers defined by this instruction."""

--- a/wave_lang/kernel/wave/asm/kernel_module_compiler.py
+++ b/wave_lang/kernel/wave/asm/kernel_module_compiler.py
@@ -193,6 +193,7 @@ class KernelModuleCompiler:
                     use_kernarg_preloading=use_preloading,
                     num_kernargs=num_args,
                     kernel_name=kernel_name,
+                    architecture=self.targetid,
                 )
 
                 # Emit kernarg loading at the start of kernel IR

--- a/wave_lang/kernel/wave/asm/mlir_walker.py
+++ b/wave_lang/kernel/wave/asm/mlir_walker.py
@@ -130,6 +130,8 @@ class IRWalker:
             self.handlers.handle_vector_store_op(operation, kernel_info)
         elif isinstance(operation, amdgpu_d.MFMAOp):
             self.handlers.handle_mfma_op(operation, kernel_info)
+        elif isinstance(operation, amdgpu_d.ScaledMFMAOp):
+            self.handlers.handle_scaled_mfma_op(operation, kernel_info)
         elif isinstance(operation, amdgpu_d.LDSBarrierOp):
             self.handlers.handle_lds_barrier_op(operation, kernel_info)
         elif isinstance(operation, memref_d.ViewOp):
@@ -146,6 +148,10 @@ class IRWalker:
             self.handlers.handle_scf_for_op(operation, kernel_info)
         elif isinstance(operation, vector_d.ExtractStridedSliceOp):
             self.handlers.handle_vector_extract_strided_slice_op(operation, kernel_info)
+        elif isinstance(operation, vector_d.ExtractOp):
+            self.handlers.handle_vector_extract_op(operation, kernel_info)
+        elif isinstance(operation, vector_d.BitCastOp):
+            self.handlers.handle_vector_bitcast_op(operation, kernel_info)
         # Critical operations for gather_to_lds support
         elif isinstance(operation, amdgpu_d.GatherToLDSOp):
             self.handlers.g2s.handle_gather_to_lds_op(operation, kernel_info)

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
@@ -740,6 +740,30 @@ def WaveASM_V_MFMA_F32_32X32X16_BF8_FP8 : MFMAOp<"v_mfma_f32_32x32x16_bf8_fp8", 
 def WaveASM_V_MFMA_F32_16X16X32_BF8_BF8 : MFMAOp<"v_mfma_f32_16x16x32_bf8_bf8", 4>;
 def WaveASM_V_MFMA_F32_32X32X16_BF8_BF8 : MFMAOp<"v_mfma_f32_32x32x16_bf8_bf8", 16>;
 
+// Scaled MFMA: Matrix multiply with per-group scale factors (gfx950+)
+// These instructions take additional scale operands for MXFP4/FP6/FP8 support
+class ScaledMFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_MFMAOp], traits)> {
+  // Operands: a_data, b_data, acc, a_scale, b_scale
+  let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_VALUSrc:$acc,
+                       WaveASM_VALUSrc:$a_scale, WaveASM_VALUSrc:$b_scale);
+  let results = (outs WaveASM_AnyVGPR:$dst);
+  let assemblyFormat = "$a `,` $b `,` $acc `,` $a_scale `,` $b_scale attr-dict `:` type($a) `,` type($b) `,` type($acc) `,` type($a_scale) `,` type($b_scale) `->` type($dst)";
+
+  // Tied operand: result 0 is tied to operand 2 (accumulator) when acc is VGPR
+  int TiedOperandIndex = 2;
+
+  // Store accumulator size for verification
+  int AccumulatorSize = accSize;
+
+  // Custom verifier for accumulator size matching
+  let hasVerifier = 1;
+}
+
+// MXFP4/FP6/FP8 variants (gfx950+)
+def WaveASM_V_MFMA_SCALE_F32_16X16X128_F8F6F4 : ScaledMFMAOp<"v_mfma_scale_f32_16x16x128_f8f6f4", 4>;
+def WaveASM_V_MFMA_SCALE_F32_32X32X64_F8F6F4 : ScaledMFMAOp<"v_mfma_scale_f32_32x32x64_f8f6f4", 16>;
+
 //===----------------------------------------------------------------------===//
 // VMEM Load Instructions
 //===----------------------------------------------------------------------===//

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
@@ -155,6 +155,10 @@ private:
   /// Emit default instruction format (results then operands)
   std::string emitDefaultFormat(mlir::Operation *op, llvm::StringRef mnemonic);
 
+  /// Emit scaled MFMA instruction with cbsz/blgp format modifiers
+  std::optional<std::string> emitScaledMFMA(mlir::Operation *op,
+                                            llvm::StringRef mnemonic);
+
   ProgramOp program;
   const PhysicalMapping &mapping;
   TargetAttrInterface target;

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/WaveASMOps.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/WaveASMOps.cpp
@@ -43,6 +43,13 @@ static int64_t getMFMAAccumulatorSize(llvm::StringRef mnemonic) {
   if (mnemonic.contains("16x16x4_f64"))
     return 8;
 
+  // Scaled MFMA variants (gfx950+) - check before generic dimension patterns
+  // to avoid false matches (e.g., "16x16x128" should not match "16x16x16")
+  if (mnemonic.contains("16x16x128"))
+    return 4;
+  if (mnemonic.contains("32x32x64"))
+    return 16;
+
   // 4-register accumulators
   if (mnemonic.contains("16x16x16") || mnemonic.contains("16x16x32") ||
       mnemonic.contains("16x16x4_f32") || mnemonic.contains("4x4x4") ||
@@ -243,6 +250,14 @@ LogicalResult V_MFMA_F32_16X16X32_BF8_BF8::verify() {
   return verifyMFMAOp(*this);
 }
 LogicalResult V_MFMA_F32_32X32X16_BF8_BF8::verify() {
+  return verifyMFMAOp(*this);
+}
+
+// Scaled MFMA variants (MXFP4/FP6/FP8 with per-group scales)
+LogicalResult V_MFMA_SCALE_F32_16X16X128_F8F6F4::verify() {
+  return verifyMFMAOp(*this);
+}
+LogicalResult V_MFMA_SCALE_F32_32X32X64_F8F6F4::verify() {
   return verifyMFMAOp(*this);
 }
 

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Target/AMDGCN/InstructionInfo.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Target/AMDGCN/InstructionInfo.cpp
@@ -188,6 +188,48 @@ InstructionRegistry::InstructionRegistry() {
       .incrementsLgkmcnt = true,
   });
 
+  registerInstruction(InstrDesc{
+      .name = "ds_write_b8",
+      .category = InstrCategory::LDS,
+      .defs = {},
+      .uses = {{.name = "vaddr", .type = OperandType::VGPR},
+               {.name = "vdata", .type = OperandType::VGPR}},
+      .latency = 20,
+      .mayStore = true,
+      .incrementsLgkmcnt = true,
+  });
+
+  registerInstruction(InstrDesc{
+      .name = "ds_write_b16",
+      .category = InstrCategory::LDS,
+      .defs = {},
+      .uses = {{.name = "vaddr", .type = OperandType::VGPR},
+               {.name = "vdata", .type = OperandType::VGPR}},
+      .latency = 20,
+      .mayStore = true,
+      .incrementsLgkmcnt = true,
+  });
+
+  registerInstruction(InstrDesc{
+      .name = "ds_read_u8",
+      .category = InstrCategory::LDS,
+      .defs = {{.name = "vdst", .type = OperandType::VGPR, .isDef = true}},
+      .uses = {{.name = "vaddr", .type = OperandType::VGPR}},
+      .latency = 20,
+      .mayLoad = true,
+      .incrementsLgkmcnt = true,
+  });
+
+  registerInstruction(InstrDesc{
+      .name = "ds_read_u16",
+      .category = InstrCategory::LDS,
+      .defs = {{.name = "vdst", .type = OperandType::VGPR, .isDef = true}},
+      .uses = {{.name = "vaddr", .type = OperandType::VGPR}},
+      .latency = 20,
+      .mayLoad = true,
+      .incrementsLgkmcnt = true,
+  });
+
   // MFMA instructions
   registerInstruction(InstrDesc{
       .name = "v_mfma_f32_32x32x8_f16",

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/Handlers.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/Handlers.h
@@ -137,6 +137,8 @@ mlir::LogicalResult handleVectorInsert(mlir::Operation *op,
                                        TranslationContext &ctx);
 mlir::LogicalResult handleVectorShapeCast(mlir::Operation *op,
                                           TranslationContext &ctx);
+mlir::LogicalResult handleVectorBitCast(mlir::Operation *op,
+                                        TranslationContext &ctx);
 mlir::LogicalResult handleVectorFma(mlir::Operation *op,
                                     TranslationContext &ctx);
 mlir::LogicalResult handleVectorReduction(mlir::Operation *op,
@@ -150,6 +152,8 @@ mlir::LogicalResult handleAMDGPULdsBarrier(mlir::Operation *op,
                                            TranslationContext &ctx);
 mlir::LogicalResult handleAMDGPUMfma(mlir::Operation *op,
                                      TranslationContext &ctx);
+mlir::LogicalResult handleAMDGPUScaledMfma(mlir::Operation *op,
+                                           TranslationContext &ctx);
 mlir::LogicalResult handleFatRawBufferCast(mlir::Operation *op,
                                            TranslationContext &ctx);
 mlir::LogicalResult handleGatherToLds(mlir::Operation *op,

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/VectorHandlers.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/VectorHandlers.cpp
@@ -108,6 +108,18 @@ LogicalResult handleVectorShapeCast(Operation *op, TranslationContext &ctx) {
   return success();
 }
 
+LogicalResult handleVectorBitCast(Operation *op, TranslationContext &ctx) {
+  auto castOp = cast<vector::BitCastOp>(op);
+
+  // Bit cast is a no-op at the register level (reinterpret cast)
+  // The data stays in the same registers, just interpreted differently
+  auto src = ctx.getMapper().getMapped(castOp.getSource());
+  if (src) {
+    ctx.getMapper().mapValue(castOp.getResult(), *src);
+  }
+  return success();
+}
+
 LogicalResult handleVectorFma(Operation *op, TranslationContext &ctx) {
   auto fmaOp = cast<vector::FMAOp>(op);
   auto &builder = ctx.getBuilder();

--- a/wave_lang/kernel/wave/asm/wave_asm/test/e2e/test_asm_backend_e2e.py
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/e2e/test_asm_backend_e2e.py
@@ -16,6 +16,7 @@ Tests included:
 3. test_mma_multi_workgroup_single_wave_cpp_backend - Multi-workgroup MMA
 4. test_mma_multi_wave_cpp_backend - Multi-wave MMA
 5. test_gemm_cpp_backend - Full GEMM with K-loop
+6. test_mxfp4_scaled_gemm_cpp_backend - MXFP4 scaled GEMM (gfx950+ only)
 
 Run with:
     # Run all e2e tests with C++ backend (default, requires GPU)
@@ -1106,6 +1107,278 @@ def test_gemm_cpp_backend_with_k_unroll(
     # Validate: C = A @ B^T
     expected = torch.matmul(a.float(), b.float().T)
     assert_close(c, expected, atol=1e-4, rtol=1e-4)
+
+
+# =============================================================================
+# Test: MXFP4 Scaled GEMM
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (64, 64, 512),  # Small MXFP4 GEMM
+        (128, 128, 512),  # Medium MXFP4 GEMM
+    ],
+)
+@pytest.mark.parametrize("use_global_to_shared", _global_to_shared_params())
+def test_mxfp4_scaled_gemm_cpp_backend(
+    shape, use_global_to_shared, compiler, backend, dump_asm
+):
+    """End-to-end test for MXFP4 (4-bit float) scaled GEMM using C++ or Python ASM backend.
+
+    MXFP4 uses:
+    - FP4 (f4E2M1FN) data format - 4 bits per element
+    - E8M0 (f8E8M0FNU) scale factors - 1 byte per scale
+    - Scale group size of 32 elements (hardware-defined)
+    - Scaled MFMA instruction: v_mfma_scale_f32_16x16x128_f8f6f4
+
+    This test requires CDNA4 (gfx950+) architecture with MI350X support.
+
+    Note: This test validates basic functionality (kernel compiles and runs)
+    but does not perform exact numerical validation as that would require:
+    1. Proper FP4 packing implementation (2 elements per byte)
+    2. E8M0 scale factor calculation
+    3. Software reference implementation of scaled MFMA
+    """
+    # Skip if not CDNA4 (gfx950+)
+    if not is_cdna4():
+        pytest.skip("MXFP4 scaled MFMA only supported on gfx950+ (CDNA4/MI350X)")
+
+    skip_if_no_gpu()
+    skip_if_no_wave_lang()
+
+    import torch
+
+    import wave_lang.kernel.lang as tkl
+    import wave_lang.kernel.wave as tkw
+    from wave_lang.kernel.lang.global_symbols import (
+        GLOBAL_ADDRESS_SPACE,
+        SHARED_ADDRESS_SPACE,
+    )
+    from wave_lang.kernel.wave.asm.kernel_module_compiler import KernelModuleCompiler
+    from wave_lang.kernel.wave.compile import WaveCompileOptions
+    from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+    from wave_lang.kernel.wave.utils.torch_utils import (
+        device_randint,
+        device_zeros,
+    )
+
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    BLOCK_M_SYM = tkl.sym.BLOCK_M
+    BLOCK_N_SYM = tkl.sym.BLOCK_N
+    BLOCK_K_SYM = tkl.sym.BLOCK_K
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    ADDRESS_SPACE_0 = tkl.sym.ADDRESS_SPACE_0
+
+    # MXFP4 configuration
+    SCALE_GROUP_SIZE = 32  # Hardware-defined for MXFP4
+    BLOCK_M = 32
+    BLOCK_N = 32
+    BLOCK_K = 128
+    WAVE_M = 16
+    WAVE_N = 16
+    wave_size = 64
+
+    constraints = [
+        tkw.WorkgroupConstraint(M, BLOCK_M_SYM, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N_SYM, 1),
+        tkw.TilingConstraint(K, BLOCK_K_SYM),
+        tkw.WaveConstraint(M, WAVE_M),
+        tkw.WaveConstraint(N, WAVE_N),
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            mma_type=tkw.ScaledMMAType.F32_16x16x128_F8F6F4,
+        ),
+    ]
+
+    @tkw.wave(constraints)
+    def mxfp4_gemm_kernel(
+        a: tkl.Memory[
+            M, K / 2, ADDRESS_SPACE, tkl.i8
+        ],  # Packed FP4 data (2 elements per byte)
+        a_scale: tkl.Memory[
+            M, K / SCALE_GROUP_SIZE, ADDRESS_SPACE, tkl.i8
+        ],  # E8M0 scales
+        b: tkl.Memory[N, K / 2, ADDRESS_SPACE, tkl.i8],  # Packed FP4 data
+        b_scale: tkl.Memory[
+            N, K / SCALE_GROUP_SIZE, ADDRESS_SPACE, tkl.i8
+        ],  # E8M0 scales
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            # Load packed FP4 data
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            # Bitcast i8 -> f4e2m1fn
+            a_reg = tkw.bitcast(a_reg, tkl.f4e2m1fn)
+            b_reg = tkw.bitcast(b_reg, tkl.f4e2m1fn)
+
+            # Load scale factors
+            a_scale_reg = tkw.read(a_scale)
+            b_scale_reg = tkw.read(b_scale)
+            # Bitcast i8 -> f8e8m0fnu
+            a_scale_reg = tkw.bitcast(a_scale_reg, tkl.f8e8m0fnu)
+            b_scale_reg = tkw.bitcast(b_scale_reg, tkl.f8e8m0fnu)
+
+            # Scaled MMA: C += (A * scaleA) @ (B * scaleB)^T
+            acc = tkw.scaled_mma(a_reg, a_scale_reg, b_reg, b_scale_reg, acc)
+            return acc
+
+        tkw.write(repeat, c)
+
+    m, n, k = shape
+
+    # Create input tensors
+    # Note: These are placeholder values - proper FP4 packing would be needed for real validation
+    a = device_randint(-128, 127, (m, k // 2), dtype=torch.int8)  # Packed FP4
+    a_scale = device_randint(
+        -128, 127, (m, k // SCALE_GROUP_SIZE), dtype=torch.int8
+    )  # E8M0 scales
+    b = device_randint(-128, 127, (n, k // 2), dtype=torch.int8)  # Packed FP4
+    b_scale = device_randint(
+        -128, 127, (n, k // SCALE_GROUP_SIZE), dtype=torch.int8
+    )  # E8M0 scales
+    c = device_zeros((m, n), dtype=torch.float32)
+
+    # Calculate grid dimensions
+    grid_x = m // BLOCK_M
+    grid_y = n // BLOCK_N
+
+    options = WaveCompileOptions(
+        subs={
+            M: m,
+            N: n,
+            K: k,
+            BLOCK_M_SYM: BLOCK_M,
+            BLOCK_N_SYM: BLOCK_N,
+            BLOCK_K_SYM: BLOCK_K,
+            SCALE_GROUP_SIZE: SCALE_GROUP_SIZE,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        backend="asm",
+        wave_runtime=True,
+        compile_to_mlir=False,
+        use_global_to_shared=use_global_to_shared,
+    )
+    options = set_default_run_config(options)
+
+    # Capture MLIR and kernel info
+    kernel_info = capture_wave_kernel_info(options, mxfp4_gemm_kernel)
+
+    # Verify MLIR contains scaled_mfma operation
+    assert (
+        "amdgpu.scaled_mfma" in kernel_info.mlir_text
+    ), "Expected amdgpu.scaled_mfma operation in MLIR"
+
+    # Test ID for file naming
+    g2s_str = "g2s" if use_global_to_shared else "no_g2s"
+    test_id = f"mxfp4_gemm_{m}x{n}x{k}_{g2s_str}"
+
+    # Compile with C++ backend if requested
+    cpp_result = None
+    cpp_asm = None
+    if backend in ("cpp", "both"):
+        cpp_result = compiler.compile_full(
+            kernel_info.mlir_text, kernel_info.workgroup_size
+        )
+        if not cpp_result.success:
+            pytest.fail(f"C++ compilation failed: {cpp_result.error_message}")
+        cpp_asm = cpp_result.asm_text
+
+        # Verify assembly contains scaled MFMA instruction
+        assert (
+            "v_mfma_scale_f32_16x16x128_f8f6f4" in cpp_asm
+        ), "Expected v_mfma_scale_f32_16x16x128_f8f6f4 instruction in assembly"
+
+    # Compile with Python backend if requested
+    python_asm = None
+    python_binary_path = None
+    if backend in ("python", "both"):
+        try:
+            python_compiler = KernelModuleCompiler(
+                targetid=get_target_arch(), codeobj="5"
+            )
+            python_asm = python_compiler.compile_mlir_string(kernel_info.mlir_text)
+
+            # Verify assembly contains scaled MFMA instruction
+            assert (
+                "v_mfma_scale_f32_16x16x128_f8f6f4" in python_asm
+            ), "Expected v_mfma_scale_f32_16x16x128_f8f6f4 instruction in assembly"
+
+            # Also assemble to binary for execution using the same assembler as C++ backend
+            if backend == "python":
+                success, binary_path, error = compiler.assemble_to_binary(python_asm)
+                if not success:
+                    pytest.fail(f"Python ASM->Binary failed: {error}")
+                python_binary_path = binary_path
+        except Exception as e:
+            if backend == "python":
+                pytest.fail(f"Python compilation failed: {e}")
+            else:
+                # Log warning if Python backend fails in "both" mode
+                import warnings
+
+                warnings.warn(f"Python backend compilation failed: {e}")
+
+    # Dump assemblies if requested
+    if dump_asm:
+        with open(f"/tmp/{test_id}_mlir.txt", "w") as f:
+            f.write(kernel_info.mlir_text)
+        if cpp_asm:
+            with open(f"/tmp/{test_id}_cpp.s", "w") as f:
+                f.write(cpp_asm)
+        if python_asm:
+            with open(f"/tmp/{test_id}_python.s", "w") as f:
+                f.write(python_asm)
+
+    # Determine which binary to execute
+    if backend == "python":
+        if python_binary_path is None:
+            pytest.fail("Python backend did not produce a binary")
+        binary_path = python_binary_path
+        kernel_name = kernel_info.kernel_name
+    else:
+        # Use C++ backend (for both "cpp" and "both" modes)
+        binary_path = cpp_result.binary_path
+        kernel_name = cpp_result.get_kernel_name() or kernel_info.kernel_name
+
+    # Use Wave compiler's launch info
+    block = kernel_info.workgroup_size
+    lds_size = kernel_info.lds_size
+    grid = (
+        kernel_info.grid_size
+        if kernel_info.grid_size != (1, 1, 1)
+        else (grid_x, grid_y, 1)
+    )
+
+    # Execute on GPU
+    run_with_wave_runtime(
+        binary_path=binary_path,
+        inputs=[a, a_scale, b, b_scale],
+        outputs=[c],
+        grid=grid,
+        block=block,
+        shared_memory_bytes=lds_size,
+        func_name=kernel_name,
+    )
+
+    # Basic sanity checks (not exact numerical validation)
+    # We can't compute expected result without proper FP4 packing/unpacking
+    assert c.shape == (m, n), f"Output shape mismatch: expected {(m, n)}, got {c.shape}"
+
+    # Check that kernel ran and produced non-zero output (sanity check)
+    # Note: This is a weak test but validates the execution pipeline
+    assert not torch.all(
+        c == 0
+    ), "Output is all zeros - kernel may not have executed correctly"
 
 
 # =============================================================================


### PR DESCRIPTION
… conflict

Add end-to-end support for MXFP4 scaled MFMA (v_mfma_scale_f32_16x16x128_f8f6f4) in both the Python and C++ wave_asm backends, and fix a critical SGPR register conflict that caused GPU memory access faults for kernels with 4+ arguments.

C++ backend (wave_asm):
- AMDGPUHandlers.cpp: Add getScaledMFMAFormatCode() to map MLIR float types (Float4E2M1FN, Float6E2M3FN, etc.) to cbsz/blgp hardware format codes, and attach them as attributes on the generated V_MFMA_SCALE op.
- AssemblyEmitter.cpp: Add .Case handlers for V_MFMA_SCALE_F32_16X16X128 and V_MFMA_SCALE_F32_32X32X64 that emit cbsz/blgp modifiers. Add handlers for DS_WRITE_B8, DS_WRITE_B16, DS_READ_U8, DS_READ_U16.
- TranslateFromMLIR.cpp: Fix LDS stores to use DS_WRITE_B8 for 1-byte and DS_WRITE_B16 for 2-byte stores (previously fell through to DS_WRITE_B32, corrupting adjacent LDS memory for scale factors).
- InstructionInfo.cpp: Add InstrDesc entries for ds_write_b8/b16, ds_read_u8/u16.
- SCFHandlers.cpp: Fix critical SGPR conflict - loop counters were hardcoded to s32, which overlaps with SRDs when kernels have 5+ arguments (e.g., MXFP4 with a, a_scale, b, b_scale, c). Now dynamically computes loop counter base from getFirstFreeSgprAfterSRDs().
- TranslateFromMLIR.h: Add getFirstFreeSgprAfterSRDs() that accounts for both regular and cache-swizzle SRDs to prevent register conflicts.

Python backend:
- kernel_mfma.py: Add cbsz:4 blgp:4 modifiers to scaled MFMA instructions.
- kernel_ir.py: Add modifiers field to KInstr.
- instruction_formatter.py: Support emitting instruction modifiers.
- kernel_generator.py: Pass modifiers through to formatter.
- handlers_memory.py: Add ds_read_b32 support for sub-4-byte LDS loads.
- kernel_compilation_context.py: Add emit_lds_read_b32 helper.

Tests:
- test_asm_backend_e2e.py: Fix device_randn -> device_randint for int8 tensors.
- asm_backend_test.py: Same device_randn fix for Python backend tests.