### PR TITLE
Fix lit test timeouts on CI (#838)

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -245,7 +245,7 @@ jobs:
           # TODO: can't sudo to install dwarfdump on rdna4
           echo "WAVE_TEST_WATER=$WAVE_TEST_WATER"
           echo "WAVE_TEST_DWARFDUMP=$WAVE_TEST_DWARFDUMP"
-          lit lit_tests/ -v
+          lit lit_tests/ -v --timeout 600 -j 4
 
       - name: MyPy Type Checking
         run: |

--- a/.github/workflows/ci-happy.yml
+++ b/.github/workflows/ci-happy.yml
@@ -219,7 +219,7 @@ jobs:
               export PYTHONPATH=${ROOT_VENV}
 
               echo "Lit tests"
-              WAVE_TEST_DWARFDUMP=1 lit lit_tests/ -v
+              WAVE_TEST_DWARFDUMP=1 lit lit_tests/ -v --timeout 600 -j 4
             '
 
       # 8. final cleanup container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run LIT tests
         run: |
-          WAVE_TEST_DWARFDUMP=1 lit lit_tests/ -v
+          WAVE_TEST_DWARFDUMP=1 lit lit_tests/ -v --timeout 600 -j 4
 
       - name: MyPy Type Checking
         run: |

--- a/lit_tests/lit.cfg.py
+++ b/lit_tests/lit.cfg.py
@@ -73,3 +73,7 @@ project_root = os.path.dirname(os.path.dirname(__file__))
 lit.llvm.llvm_config.with_environment("PYTHONPATH", project_root, append_path=True)
 config.environment["FILECHECK_OPTS"] = "--dump-input=fail"
 config.environment["WAVE_CACHE_ON"] = "0"
+
+# Pin hash seed for deterministic test behavior (scheduling algorithms
+# use data structures whose iteration order depends on hash randomization).
+config.environment["PYTHONHASHSEED"] = "0"


### PR DESCRIPTION
CI jobs on linux-mi35x-1gpu-ossci-iree-org are repeatedly timing out at the 60-minute job limit during the lit test step. Three compounding factors cause this:

1. No per-test timeout: a single pathological compilation can run indefinitely until the job-level limit kills everything.
2. No parallelism: lit runs all 49 test files serially, unlike pytest which already uses `-n 4`.
3. Non-deterministic scheduling: PYTHONHASHSEED is not pinned, so set iteration order in the modulo scheduling code varies across runs, occasionally producing pathologically slow orderings.

Add `--timeout 600` (10 min per test) and `-j 4` (parallel workers) to all three CI workflow lit invocations (ci.yaml, ci-gpu.yaml, ci-happy.yml). Pin `PYTHONHASHSEED=0` in lit.cfg.py to eliminate hash-randomization non-determinism in scheduling set iteration order.