### PR TITLE
[asm] Add region-based control flow and remove labels mode

### DIFF
--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMControlFlowOps.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMControlFlowOps.td
@@ -1,0 +1,155 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef WAVEASM_DIALECT_WAVEASMCONTROLFLOWOPS
+#define WAVEASM_DIALECT_WAVEASMCONTROLFLOWOPS
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/LoopLikeInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "waveasm/Dialect/WaveASMDialect.td"
+include "waveasm/Dialect/WaveASMTypes.td"
+
+//===----------------------------------------------------------------------===//
+// Structured Control Flow Operations
+//===----------------------------------------------------------------------===//
+
+def WaveASM_LoopOp : WAVEASMOp<"loop", [
+    DeclareOpInterfaceMethods<RegionBranchOpInterface, ["getSuccessorInputs", "getEntrySuccessorOperands"]>,
+    DeclareOpInterfaceMethods<LoopLikeOpInterface, ["getInitsMutable", "getRegionIterArgs", "getYieldedValuesMutable"]>,
+    RecursiveMemoryEffects,
+    SingleBlockImplicitTerminator<"ConditionOp">
+  ]> {
+  let summary = "Structured loop with trailing condition (do-while semantics)";
+  let description = [{
+    Executes the body region at least once, then re-enters if the trailing
+    waveasm.condition evaluates to true.  This is a do-while style loop:
+    the condition is checked after the body, not before.
+    Uses block arguments for loop-carried values (SSA φ-nodes).
+
+    The body region must terminate with a waveasm.condition operation
+    that computes the loop condition and yields updated values.
+
+    See test/Dialect/region-control-flow.mlir for round-trip examples
+    (simple loops, multi-iter_arg loops, MFMA accumulation, nesting).
+  }];
+
+  let arguments = (ins Variadic<WaveASM_AnyReg>:$initArgs);
+  let results = (outs Variadic<WaveASM_AnyReg>:$results);
+  let regions = (region SizedRegion<1>:$body);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::ValueRange":$initArgs)>
+  ];
+
+  let extraClassDeclaration = [{
+    // Get the loop body block
+    ::mlir::Block &getBodyBlock();
+
+    // Get the number of loop-carried values
+    unsigned getNumRegionIterArgs();
+
+    // RegionBranchOpInterface will be implemented in .cpp
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+def WaveASM_IfOp : WAVEASMOp<"if", [
+    DeclareOpInterfaceMethods<RegionBranchOpInterface, ["getSuccessorInputs"]>,
+    RecursiveMemoryEffects,
+    SingleBlockImplicitTerminator<"YieldOp">
+  ]> {
+  let summary = "Conditional execution (if-then-else)";
+  let description = [{
+    Conditionally executes then or else region based on condition.
+    Both regions must terminate with waveasm.yield.
+
+    See test/Dialect/region-control-flow.mlir for round-trip examples
+    (simple if, if-then-else, multi-result if, if nested in loop).
+  }];
+
+  let arguments = (ins WaveASM_AnySGPR:$condition);
+  let results = (outs Variadic<WaveASM_AnyReg>:$results);
+  let regions = (region SizedRegion<1>:$thenRegion,
+                        AnyRegion:$elseRegion);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "::mlir::Value":$condition, "bool":$withElseRegion)>,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::mlir::Value":$condition,
+                   "bool":$withElseRegion)>
+  ];
+
+  let extraClassDeclaration = [{
+    // Get blocks
+    ::mlir::Block &getThenBlock();
+    ::mlir::Block *getElseBlock();
+
+    // Check if else region exists
+    bool hasElse();
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+def WaveASM_ConditionOp : WAVEASMOp<"condition", [
+    Terminator,
+    HasParent<"LoopOp">,
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+      ["getSuccessorRegions"]>
+  ]> {
+  let summary = "Loop condition terminator";
+  let description = [{
+    Terminates a loop body with a condition check and updated
+    loop-carried values. If condition is true, loops back to the start.
+    Otherwise, exits the loop with the final values.
+
+    TODO: Model this potentially using side effects.
+    IMPORTANT: The condition value must be produced by an s_cmp instruction
+    that sets the SCC flag. The assembly emitter emits `s_cbranch_scc1` to
+    implement the loop back-edge. No SCC-clobbering instructions (s_add,
+    s_and, s_or, etc.) may be inserted between the s_cmp and this operation.
+    The waitcnt and hazard mitigation passes must respect this constraint
+    (s_waitcnt and s_nop do not clobber SCC and are safe).
+
+    See test/Dialect/region-control-flow.mlir for usage examples.
+  }];
+
+  let arguments = (ins WaveASM_AnySGPR:$condition,
+                       Variadic<WaveASM_AnyReg>:$iterArgs);
+
+  let assemblyFormat = [{
+    $condition `:` type($condition)
+    (`iter_args` `(` $iterArgs `)` `:` type($iterArgs)^)?
+    attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def WaveASM_YieldOp : WAVEASMOp<"yield", [
+    Pure,
+    ReturnLike,
+    Terminator,
+    ParentOneOf<["IfOp", "ProgramOp"]>
+  ]> {
+  let summary = "Yield values from a region";
+  let description = [{
+    Yields values from a region (if/then/else) back to the parent operation.
+
+    See test/Dialect/region-control-flow.mlir for usage examples.
+  }];
+
+  let arguments = (ins Variadic<WaveASM_AnyReg>:$results);
+  let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
+}
+
+#endif // WAVEASM_DIALECT_WAVEASMCONTROLFLOWOPS

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "waveasm/Dialect/WaveASMAttrs.h"

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
@@ -98,12 +98,20 @@ class SALUBinaryOp<string mnemonic, list<Trait> traits = []>
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($dst)";
 }
 
-// SALU Compare: sets scc, no explicit result
+// SALU Compare: returns condition in SCC.
+// NOTE: On hardware, s_cmp sets the implicit SCC flag with no destination
+// register. We model SCC as an explicit sreg result so that ConditionOp
+// (the while-loop terminator) can reference it as an SSA Value. The
+// assembly emitter special-cases all S_CMP ops to emit only the two
+// source operands (no destination). The register allocator treats the
+// result as a regular sreg; this wastes one SGPR slot but is harmless
+// since the live range is very short (s_cmp -> condition terminator).
+// TODO: Consider a dedicated SCCType to avoid the wasted register slot.
 class SALUCmpOp<string mnemonic, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, traits> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
-  let results = (outs);  // implicitly sets scc
-  let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1)";
+  let results = (outs WaveASM_AnySReg:$result);  // SCC result (see note above)
+  let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($result)";
 }
 
 // MFMA: Matrix multiply-accumulate with tied accumulator
@@ -185,6 +193,12 @@ class LDSStoreOp<string mnemonic, list<Trait> traits = []>
   let arguments = (ins WaveASM_AnyVGPR:$data, WaveASM_VRegOrImm:$vaddr);
   let assemblyFormat = "$data `,` $vaddr attr-dict `:` type($data) `,` type($vaddr)";
 }
+
+//===----------------------------------------------------------------------===//
+// Control Flow Operations
+//===----------------------------------------------------------------------===//
+
+include "waveasm/Dialect/WaveASMControlFlowOps.td"
 
 //===----------------------------------------------------------------------===//
 // Program Container

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
@@ -104,6 +104,7 @@ public:
 private:
   /// Resolve an SSA Value to its physical register string
   std::string resolveValue(mlir::Value value);
+  std::string resolveScalarValue(mlir::Value value);
 
   /// Get the literal value if the operand is an immediate constant
   /// Returns (isLiteral, value) pair
@@ -166,6 +167,9 @@ private:
 
   int64_t peakVGPRs = 0;
   int64_t peakSGPRs = 0;
+
+  /// Counter for generating unique loop labels in assembly
+  int loopLabelCounter = 0;
 
   /// Scratch VGPR for loading non-inline literals
   /// We use a lower VGPR (v15) to avoid excessive VGPR allocation.

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.h
@@ -21,7 +21,6 @@ std::unique_ptr<mlir::Pass> createWAVEASMValidateSSAPass();
 
 /// Create the liveness analysis pass
 std::unique_ptr<mlir::Pass> createWAVEASMLivenessPass();
-std::unique_ptr<mlir::Pass> createWAVEASMLivenessPass(bool useCFG);
 
 /// Create the linear scan register allocation pass
 std::unique_ptr<mlir::Pass> createWAVEASMLinearScanPass();

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.td
@@ -81,25 +81,18 @@ def WAVEASMValidateSSA : Pass<"waveasm-validate-ssa"> {
 def WAVEASMLiveness : Pass<"waveasm-liveness"> {
   let summary = "Compute liveness information for virtual registers";
   let description = [{
-    Runs CFG-based backward dataflow analysis to compute live ranges
-    for all virtual registers. The analysis:
+    Computes live ranges for all virtual registers using the region
+    structure (LoopOp, IfOp) to determine loop-carried liveness.
 
-    1. Builds a control flow graph from labels and branches
-    2. Computes local use/def sets for each basic block
-    3. Iterates to fixed point using backward dataflow equations:
-       - live_out[B] = union of live_in[S] for all successors S
-       - live_in[B] = use[B] union (live_out[B] - def[B])
-    4. Computes live ranges from definition to last use
-    5. Extends ranges based on CFG liveness for loops
+    The analysis:
+    1. Collects def/use points from the flattened instruction stream
+    2. Builds initial live ranges from definition to last use
+    3. Extends ranges for values used inside loop bodies (LoopOp)
+    4. Computes register pressure using sweep algorithm
 
     The results are stored as an analysis and can be queried by
     subsequent passes (e.g., register allocation).
   }];
-
-  let options = [
-    Option<"useCFG", "use-cfg", "bool", "true",
-           "Use CFG-based analysis (required for loops)">
-  ];
 
   let statistics = [
     Statistic<"numVRegs", "Number of virtual VGPRs", "count">,

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegionBuilder.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegionBuilder.h
@@ -1,0 +1,38 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef WAVEASM_TRANSFORMS_REGIONBUILDER_H
+#define WAVEASM_TRANSFORMS_REGIONBUILDER_H
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "waveasm/Transforms/TranslateFromMLIR.h"
+
+namespace waveasm {
+
+/// Helper for building structured control flow regions during translation
+class RegionBuilder {
+public:
+  RegionBuilder(TranslationContext &ctx) : ctx(ctx) {}
+
+  /// Build a loop from SCF for
+  /// Maps scf.for to waveasm.loop with proper block arguments
+  LoopOp buildLoopFromSCFFor(mlir::scf::ForOp forOp);
+
+  /// Build an if-then-else from SCF if
+  /// Maps scf.if to waveasm.if with proper regions
+  IfOp buildIfFromSCFIf(mlir::scf::IfOp ifOp);
+
+private:
+  TranslationContext &ctx;
+
+  /// Helper: Translate an operation (forward declaration for recursion)
+  mlir::LogicalResult translateOp(mlir::Operation *op);
+};
+
+} // namespace waveasm
+
+#endif // WAVEASM_TRANSFORMS_REGIONBUILDER_H

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/CMakeLists.txt
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRWaveASMDialect
   WaveASMTypes.cpp
   WaveASMAttrs.cpp
   WaveASMOps.cpp
+  WaveASMControlFlowOps.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/waveasm
@@ -19,4 +20,6 @@ add_mlir_dialect_library(MLIRWaveASMDialect
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSupport
+  MLIRControlFlowInterfaces
+  MLIRFunctionInterfaces
 )

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/WaveASMControlFlowOps.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Dialect/WaveASMControlFlowOps.cpp
@@ -1,0 +1,395 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Dialect/WaveASMTypes.h"
+
+using namespace mlir;
+using namespace waveasm;
+
+// typesCompatible() is defined in WaveASMTypes.h as a shared utility.
+
+//===----------------------------------------------------------------------===//
+// LoopOp
+//===----------------------------------------------------------------------===//
+
+void LoopOp::build(OpBuilder &builder, OperationState &result,
+                   ValueRange initArgs) {
+  result.addTypes(initArgs.getTypes());
+  result.addOperands(initArgs);
+
+  // Create body region with block arguments matching initArgs types
+  Region *bodyRegion = result.addRegion();
+  Block *bodyBlock = new Block();
+  bodyRegion->push_back(bodyBlock);
+
+  for (Value arg : initArgs) {
+    bodyBlock->addArgument(arg.getType(), result.location);
+  }
+}
+
+void LoopOp::getSuccessorRegions(RegionBranchPoint point,
+                                 SmallVectorImpl<RegionSuccessor> &regions) {
+
+  // Entry: branch to body region
+  if (point.isParent()) {
+    regions.emplace_back(&getBody());
+    return;
+  }
+
+  // From body: can loop back to body or exit to parent
+  regions.emplace_back(&getBody());
+  regions.push_back(RegionSuccessor::parent());
+}
+
+ValueRange LoopOp::getSuccessorInputs(RegionSuccessor successor) {
+  if (successor.isParent())
+    return getResults();
+  // Successor is the body region - inputs should be block arguments
+  return getBodyBlock().getArguments();
+}
+
+OperandRange LoopOp::getEntrySuccessorOperands(RegionSuccessor successor) {
+  assert(!successor.isParent() && "parent has no entry operands");
+  // When entering the body from the parent, use initArgs
+  return getInitArgs();
+}
+
+// Old API compatibility wrapper (required by this MLIR version)
+
+Block &LoopOp::getBodyBlock() { return getBody().front(); }
+
+Block::BlockArgListType LoopOp::getRegionIterArgs() {
+  return getBodyBlock().getArguments();
+}
+
+unsigned LoopOp::getNumRegionIterArgs() {
+  return getBodyBlock().getNumArguments();
+}
+
+SmallVector<Region *> LoopOp::getLoopRegions() { return {&getBody()}; }
+
+// LoopLikeOpInterface methods
+MutableArrayRef<OpOperand> LoopOp::getInitsMutable() {
+  return getInitArgsMutable();
+}
+
+std::optional<MutableArrayRef<OpOperand>> LoopOp::getYieldedValuesMutable() {
+  auto *term = getBodyBlock().getTerminator();
+  if (auto condOp = dyn_cast<ConditionOp>(term))
+    return condOp.getIterArgsMutable();
+  return std::nullopt;
+}
+
+LogicalResult LoopOp::verify() {
+  // SingleBlockImplicitTerminator<ConditionOp> already ensures the body
+  // has exactly one block terminated by ConditionOp.
+  auto condOp = cast<ConditionOp>(getBodyBlock().getTerminator());
+
+  // Verify initArgs match block arguments
+  if (getInitArgs().size() != getNumRegionIterArgs())
+    return emitOpError("different number of inits (")
+           << getInitArgs().size() << ") and region iter_args ("
+           << getNumRegionIterArgs() << ")";
+
+  // Verify condition iter_args are compatible with block arguments
+  if (!typesCompatible(getBodyBlock().getArgumentTypes(),
+                       condOp.getIterArgs().getTypes()))
+    return emitOpError(
+        "condition iter_arg types must be compatible with loop arg types");
+
+  // Verify result types are compatible with iter arg types
+  if (!typesCompatible(getResultTypes(), getBodyBlock().getArgumentTypes()))
+    return emitOpError("result types must be compatible with iter arg types");
+
+  return success();
+}
+
+void LoopOp::print(OpAsmPrinter &p) {
+  // Print (%i = %init, %acc = %init_acc) or () if empty
+  p << " (";
+  if (getNumRegionIterArgs() > 0) {
+    llvm::interleaveComma(
+        llvm::zip(getRegionIterArgs(), getInitArgs()), p,
+        [&](auto it) { p << std::get<0>(it) << " = " << std::get<1>(it); });
+  }
+  p << ")";
+
+  // Print : (input_types) -> (result_types)
+  p << " : ";
+  auto inputTypes = getInitArgs().getTypes();
+  auto resultTypes = getResults().getTypes();
+  p.printFunctionalType(inputTypes, resultTypes);
+
+  // Print body region
+  p << " ";
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
+
+  p.printOptionalAttrDict((*this)->getAttrs());
+}
+
+ParseResult LoopOp::parse(OpAsmParser &parser, OperationState &result) {
+  // Parse: loop (%i = %init, %acc = %init_acc) : (types) -> (types) { ... }
+
+  SmallVector<OpAsmParser::Argument> regionArgs;
+  SmallVector<OpAsmParser::UnresolvedOperand> initOperands;
+
+  // Parse optional (%arg = %init, ...)
+  OptionalParseResult listResult =
+      parser.parseOptionalAssignmentList(regionArgs, initOperands);
+  if (listResult.has_value() && failed(listResult.value()))
+    return failure();
+
+  // Parse : (arg_types) -> (result_types) as function type
+  FunctionType functionType;
+  SMLoc typeLoc = parser.getCurrentLocation();
+  if (failed(parser.parseColonType(functionType)))
+    return failure();
+
+  // Add result types
+  result.addTypes(functionType.getResults());
+
+  // Check operand count matches input types
+  if (functionType.getNumInputs() != initOperands.size()) {
+    return parser.emitError(typeLoc)
+           << "expected as many input types as operands (expected "
+           << initOperands.size() << " got " << functionType.getNumInputs()
+           << ")";
+  }
+
+  // Resolve init operands
+  if (failed(parser.resolveOperands(initOperands, functionType.getInputs(),
+                                    parser.getCurrentLocation(),
+                                    result.operands)))
+    return failure();
+
+  // Set argument types for region
+  for (size_t i = 0, e = regionArgs.size(); i != e; ++i)
+    regionArgs[i].type = functionType.getInput(i);
+
+  // Parse body region
+  Region *body = result.addRegion();
+  if (parser.parseRegion(*body, regionArgs))
+    return failure();
+
+  // Parse optional attributes
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// IfOp
+//===----------------------------------------------------------------------===//
+
+Block &IfOp::getThenBlock() { return getThenRegion().front(); }
+
+Block *IfOp::getElseBlock() {
+  Region &r = getElseRegion();
+  return r.empty() ? nullptr : &r.front();
+}
+
+bool IfOp::hasElse() { return !getElseRegion().empty(); }
+
+void IfOp::build(OpBuilder &builder, OperationState &result, Value condition,
+                 bool withElseRegion) {
+  result.addOperands(condition);
+
+  Region *thenRegion = result.addRegion();
+  thenRegion->push_back(new Block());
+
+  Region *elseRegion = result.addRegion();
+  if (withElseRegion) {
+    elseRegion->push_back(new Block());
+  }
+}
+
+void IfOp::build(OpBuilder &builder, OperationState &result,
+                 TypeRange resultTypes, Value condition, bool withElseRegion) {
+  result.addTypes(resultTypes);
+  result.addOperands(condition);
+
+  Region *thenRegion = result.addRegion();
+  thenRegion->push_back(new Block());
+
+  Region *elseRegion = result.addRegion();
+  if (withElseRegion) {
+    elseRegion->push_back(new Block());
+  }
+}
+
+void IfOp::getSuccessorRegions(RegionBranchPoint point,
+                               SmallVectorImpl<RegionSuccessor> &regions) {
+
+  // Entry: can go to then or else
+  if (point.isParent()) {
+    regions.push_back(RegionSuccessor(&getThenRegion()));
+    if (hasElse())
+      regions.push_back(RegionSuccessor(&getElseRegion()));
+    else
+      regions.push_back(RegionSuccessor::parent());
+    return;
+  }
+
+  // Both then and else exit to parent
+  regions.push_back(RegionSuccessor::parent());
+}
+
+ValueRange IfOp::getSuccessorInputs(RegionSuccessor successor) {
+  return successor.isParent() ? ValueRange(getResults()) : ValueRange();
+}
+
+// Old API compatibility wrapper (required by this MLIR version)
+
+LogicalResult IfOp::verify() {
+  // SingleBlockImplicitTerminator<YieldOp> already ensures the then region
+  // has exactly one block terminated by YieldOp.
+  auto thenYield = cast<YieldOp>(getThenBlock().getTerminator());
+
+  if (hasElse()) {
+    // SingleBlockImplicitTerminator also covers the else region.
+    auto elseYield = cast<YieldOp>(getElseBlock()->getTerminator());
+
+    if (!typesCompatible(thenYield.getResults().getTypes(),
+                         elseYield.getResults().getTypes()))
+      return emitOpError("then and else must yield compatible types");
+  }
+
+  // If the op produces results, an else region MUST exist to provide values
+  // when the condition is false. Without an else, result values are undefined.
+  if (!getResultTypes().empty() && !hasElse()) {
+    return emitOpError("if operation with results must have an else region");
+  }
+
+  // Verify result types are compatible with yields
+  if (!typesCompatible(getResultTypes(), thenYield.getResults().getTypes()))
+    return emitOpError("result types must be compatible with yield types");
+
+  return success();
+}
+
+void IfOp::print(OpAsmPrinter &p) {
+  p << " " << getCondition();
+
+  // Print result types
+  if (!getResultTypes().empty()) {
+    p << " : " << getCondition().getType() << " -> ";
+    llvm::interleaveComma(getResultTypes(), p);
+  }
+
+  // Print then region
+  p << " ";
+  p.printRegion(getThenRegion(), /*printEntryBlockArgs=*/false);
+
+  // Print else region if present
+  if (hasElse()) {
+    p << " else ";
+    p.printRegion(getElseRegion(), /*printEntryBlockArgs=*/false);
+  }
+
+  p.printOptionalAttrDict((*this)->getAttrs());
+}
+
+ParseResult IfOp::parse(OpAsmParser &parser, OperationState &result) {
+  // Parse: if %cond : type -> types { then } else { else }
+
+  OpAsmParser::UnresolvedOperand condition;
+  Type condType;
+
+  if (parser.parseOperand(condition))
+    return failure();
+
+  // Parse optional types
+  SmallVector<Type> resultTypes;
+  if (succeeded(parser.parseOptionalColon())) {
+    if (parser.parseType(condType))
+      return failure();
+
+    if (succeeded(parser.parseOptionalArrow())) {
+      if (parser.parseTypeList(resultTypes))
+        return failure();
+    }
+  } else {
+    // Default condition type
+    condType = SRegType::get(parser.getContext());
+  }
+
+  // Resolve condition
+  if (parser.resolveOperand(condition, condType, result.operands))
+    return failure();
+
+  result.addTypes(resultTypes);
+
+  // Parse then region
+  Region *thenRegion = result.addRegion();
+  if (parser.parseRegion(*thenRegion))
+    return failure();
+
+  // Ensure terminator exists
+  if (thenRegion->empty())
+    thenRegion->push_back(new Block());
+
+  // Parse optional else region
+  Region *elseRegion = result.addRegion();
+  if (succeeded(parser.parseOptionalKeyword("else"))) {
+    if (parser.parseRegion(*elseRegion))
+      return failure();
+
+    if (elseRegion->empty())
+      elseRegion->push_back(new Block());
+  }
+
+  // Parse optional attributes
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ConditionOp
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// ConditionOp - RegionBranchTerminatorOpInterface
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange
+ConditionOp::getMutableSuccessorOperands(RegionSuccessor point) {
+  // Both successors (loop back to body, exit to parent) use iterArgs.
+  return getIterArgsMutable();
+}
+
+void ConditionOp::getSuccessorRegions(
+    ArrayRef<Attribute> operands, SmallVectorImpl<RegionSuccessor> &regions) {
+  auto loopOp = cast<LoopOp>((*this)->getParentOp());
+  // Condition can either loop back to the body or exit to the parent.
+  regions.emplace_back(&loopOp.getBody());
+  regions.push_back(RegionSuccessor::parent());
+}
+
+LogicalResult ConditionOp::verify() {
+  auto loopOp = dyn_cast<LoopOp>((*this)->getParentOp());
+  if (!loopOp) {
+    return emitOpError("must be nested in a waveasm.loop operation");
+  }
+
+  // Verify iter_args count matches loop args
+  if (getIterArgs().size() != loopOp.getNumRegionIterArgs()) {
+    return emitOpError("iter_args count must match loop args");
+  }
+
+  // Verify types match (structurally, allowing physical register differences)
+  if (!typesCompatible(loopOp.getBodyBlock().getArgumentTypes(),
+                       getIterArgs().getTypes()))
+    return emitOpError("iter_arg types must be compatible with loop arg types");
+
+  return success();
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/CMakeLists.txt
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(MLIRWaveASMTransforms
   HazardMitigation.cpp
   AssemblyEmitter.cpp
   TranslateFromMLIR.cpp
+  RegionBuilder.cpp
   ScopedCSE.cpp
   Peephole.cpp
   MemoryOffsetOptimization.cpp

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/HazardMitigation.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/HazardMitigation.cpp
@@ -14,6 +14,7 @@
 #include "waveasm/Dialect/WaveASMAttrs.h"
 #include "waveasm/Dialect/WaveASMDialect.h"
 #include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Transforms/Liveness.h"
 #include "waveasm/Transforms/Passes.h"
 
 #include "mlir/IR/Builders.h"
@@ -173,11 +174,9 @@ private:
     if (!needsVALUHazard)
       return;
 
-    // Collect operations in order
+    // Collect operations in order, recursively walking into while/if bodies
     llvm::SmallVector<Operation *> ops;
-    for (Operation &op : program.getBodyBlock()) {
-      ops.push_back(&op);
-    }
+    collectOpsRecursive(program.getBodyBlock(), ops);
 
     // Scan for hazards and collect insertion points
     llvm::SmallVector<Operation *> insertionPoints;

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/RegionBuilder.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/RegionBuilder.cpp
@@ -1,0 +1,244 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "waveasm/Transforms/RegionBuilder.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "waveasm/Dialect/WaveASMOps.h"
+
+using namespace mlir;
+using namespace waveasm;
+
+// Forward declaration
+LogicalResult translateOperation(Operation *op, TranslationContext &ctx);
+
+LogicalResult RegionBuilder::translateOp(Operation *op) {
+  return translateOperation(op, ctx);
+}
+
+LoopOp RegionBuilder::buildLoopFromSCFFor(scf::ForOp forOp) {
+  auto &builder = ctx.getBuilder();
+  auto loc = forOp.getLoc();
+
+  // Collect loop-carried values: [induction_var, iter_args...]
+  SmallVector<Value> initArgs;
+  auto lowerBound = ctx.getMapper().getMapped(forOp.getLowerBound());
+  if (!lowerBound) {
+    forOp.emitError("lower bound not mapped");
+    return nullptr;
+  }
+
+  // Convert lower bound to sreg if it's an immediate (loop counter needs sreg
+  // type)
+  Value lowerBoundValue = *lowerBound;
+  if (isa<ImmType>(lowerBoundValue.getType())) {
+    auto sregType = ctx.createSRegType();
+    lowerBoundValue =
+        S_MOV_B32::create(builder, loc, sregType, lowerBoundValue);
+  }
+  initArgs.push_back(lowerBoundValue);
+
+  for (Value arg : forOp.getInitArgs()) {
+    if (auto mapped = ctx.getMapper().getMapped(arg)) {
+      Value mappedValue = *mapped;
+      // Convert immediate iter args to vregs (they'll be used in VALU ops)
+      if (isa<ImmType>(mappedValue.getType())) {
+        // Infer vreg size from the original SCF type.
+        // For vector types (e.g. vector<4xf32> for MFMA accumulators),
+        // we need a vreg with matching element count and alignment.
+        int64_t vregSize = 1;
+        if (auto vecType = dyn_cast<VectorType>(arg.getType())) {
+          vregSize = vecType.getNumElements();
+        }
+        int64_t vregAlign = vregSize > 1 ? vregSize : 1;
+        auto vregType = ctx.createVRegType(vregSize, vregAlign);
+        mappedValue = V_MOV_B32::create(builder, loc, vregType, mappedValue);
+      }
+      initArgs.push_back(mappedValue);
+    } else {
+      forOp.emitError("init arg not mapped");
+      return nullptr;
+    }
+  }
+
+  // Create loop op (result types inferred from initArgs)
+  auto loopOp = LoopOp::create(builder, loc, initArgs);
+  Block &bodyBlock = loopOp.getBodyBlock();
+
+  // Map loop induction variable and iter args to block arguments
+  ctx.getMapper().mapValue(forOp.getInductionVar(), bodyBlock.getArgument(0));
+
+  size_t argIdx = 1;
+  for (Value origArg : forOp.getRegionIterArgs()) {
+    if (argIdx < bodyBlock.getNumArguments()) {
+      ctx.getMapper().mapValue(origArg, bodyBlock.getArgument(argIdx++));
+    }
+  }
+
+  // Translate loop body
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(&bodyBlock);
+
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (failed(translateOp(&op))) {
+      forOp.emitError("failed to translate loop body operation");
+      return nullptr;
+    }
+  }
+
+  // Build loop increment and condition
+  Value inductionVar = bodyBlock.getArgument(0);
+
+  auto step = ctx.getMapper().getMapped(forOp.getStep());
+  auto upperBound = ctx.getMapper().getMapped(forOp.getUpperBound());
+
+  if (!step || !upperBound) {
+    forOp.emitError("step or upper bound not mapped");
+    return nullptr;
+  }
+
+  auto sregType = ctx.createSRegType();
+  Value nextIV = S_ADD_U32::create(builder, loc, sregType, inductionVar, *step);
+  // S_CMP now returns an SCC value explicitly
+  Value cond =
+      S_CMP_LT_U32::create(builder, loc, sregType, nextIV, *upperBound);
+
+  // Collect iter args from yield
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  SmallVector<Value> iterArgs;
+  iterArgs.push_back(nextIV);
+
+  for (Value result : yieldOp.getResults()) {
+    if (auto mapped = ctx.getMapper().getMapped(result)) {
+      iterArgs.push_back(*mapped);
+    } else {
+      yieldOp.emitError("yield result not mapped");
+      return nullptr;
+    }
+  }
+
+  // Create condition terminator
+  ConditionOp::create(builder, loc, cond, iterArgs);
+
+  // Map loop results to for results.
+  // scf.for results correspond 1:1 with iter_args (no induction variable).
+  // waveasm.loop results include the induction variable at index 0,
+  // then iter_args starting at index 1.
+  assert(forOp.getResults().size() + 1 == loopOp.getResults().size() &&
+         "result count mismatch between scf.for and waveasm.loop");
+  size_t resIdx = 0;
+  for (Value forRes : forOp.getResults()) {
+    ctx.getMapper().mapValue(forRes, loopOp.getResults()[resIdx + 1]);
+    resIdx++;
+  }
+
+  return loopOp;
+}
+
+IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
+  auto &builder = ctx.getBuilder();
+  auto loc = ifOp.getLoc();
+
+  // Get mapped condition
+  auto condition = ctx.getMapper().getMapped(ifOp.getCondition());
+  if (!condition) {
+    ifOp.emitError("condition not mapped");
+    return nullptr;
+  }
+
+  // Convert condition to sreg if it's an immediate
+  // (arith.cmpi maps result to immediate placeholder)
+  Value conditionValue = *condition;
+  if (isa<ImmType>(conditionValue.getType())) {
+    auto sregType = ctx.createSRegType();
+    conditionValue = S_MOV_B32::create(builder, loc, sregType, conditionValue);
+  }
+
+  // Infer result types by peeking at what the then region will yield
+  // This requires translating yield operands first to get their mapped types
+  SmallVector<Type> resultTypes;
+  auto thenYield =
+      cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
+  for (Value yieldVal : thenYield.getOperands()) {
+    // If already mapped, use its type
+    if (auto mapped = ctx.getMapper().getMapped(yieldVal)) {
+      resultTypes.push_back(mapped->getType());
+    } else {
+      // Use a default vreg type if not yet mapped
+      // (will be set properly during body translation)
+      resultTypes.push_back(ctx.createVRegType());
+    }
+  }
+
+  // Create if operation with inferred result types
+  bool hasElse = !ifOp.getElseRegion().empty();
+  auto waveIfOp =
+      IfOp::create(builder, loc, resultTypes, conditionValue, hasElse);
+
+  // Translate then region
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&waveIfOp.getThenBlock());
+
+    for (Operation &op : ifOp.getThenRegion().front().without_terminator()) {
+      if (failed(translateOp(&op))) {
+        ifOp.emitError("failed to translate then region");
+        return nullptr;
+      }
+    }
+
+    // Get yield values and create waveasm.yield
+    auto scfYield =
+        cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
+
+    SmallVector<Value> yieldVals;
+    for (Value res : scfYield.getResults()) {
+      if (auto mapped = ctx.getMapper().getMapped(res)) {
+        yieldVals.push_back(*mapped);
+      } else {
+        scfYield.emitError("yield result not mapped");
+        return nullptr;
+      }
+    }
+
+    YieldOp::create(builder, loc, yieldVals);
+  }
+
+  // Translate else region if present
+  if (hasElse) {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(waveIfOp.getElseBlock());
+
+    for (Operation &op : ifOp.getElseRegion().front().without_terminator()) {
+      if (failed(translateOp(&op))) {
+        ifOp.emitError("failed to translate else region");
+        return nullptr;
+      }
+    }
+
+    auto scfYield =
+        cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
+
+    SmallVector<Value> yieldVals;
+    for (Value res : scfYield.getResults()) {
+      if (auto mapped = ctx.getMapper().getMapped(res)) {
+        yieldVals.push_back(*mapped);
+      } else {
+        scfYield.emitError("yield result not mapped");
+        return nullptr;
+      }
+    }
+
+    YieldOp::create(builder, loc, yieldVals);
+  }
+
+  // Map if results
+  for (auto [ifRes, waveRes] :
+       llvm::zip(ifOp.getResults(), waveIfOp.getResults())) {
+    ctx.getMapper().mapValue(ifRes, waveRes);
+  }
+
+  return waveIfOp;
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/Ticketing.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/Ticketing.cpp
@@ -423,8 +423,13 @@ private:
         numWaitcntInserted++;
       }
 
-      // Reset waits at control flow boundaries (labels, branches)
-      if (isa<LabelOp>(op) || op->getName().getStringRef().contains("branch")) {
+      // Reset waits at loop boundaries and branches.
+      // We reset at LoopOp (loop entry) and ConditionOp (loop back-edge)
+      // since pending waits from before the loop may not be valid inside,
+      // and vice versa. We do NOT reset at IfOp/YieldOp to avoid
+      // unnecessary s_waitcnt insertions inside straight-line if-then-else.
+      if (isa<LoopOp, ConditionOp>(op) ||
+          op->getName().getStringRef().contains("branch")) {
         ticketing.resetWaits();
       }
     });

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/TranslateFromMLIR.cpp
@@ -26,6 +26,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Verifier.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -43,9 +44,10 @@ namespace waveasm {
 //===----------------------------------------------------------------------===//
 
 TranslationContext::TranslationContext(OpBuilder &builder, ProgramOp program,
-                                       TargetAttrInterface target)
+                                       TargetAttrInterface target,
+                                       const TranslationOptions &options)
     : builder(builder), registry(builder.getContext()), program(program),
-      target(target) {}
+      target(target), options(options) {}
 
 VRegType TranslationContext::createVRegType(int64_t size, int64_t alignment) {
   return VRegType::get(builder.getContext(), size, alignment);
@@ -59,9 +61,10 @@ ImmType TranslationContext::createImmType(int64_t value) {
   return ImmType::get(builder.getContext(), value);
 }
 
-LabelOp TranslationContext::emitLabel(StringRef name) {
-  return LabelOp::create(builder, builder.getUnknownLoc(), name);
-}
+//===----------------------------------------------------------------------===//
+// Utility Functions
+//===----------------------------------------------------------------------===//
+// Note: Utility functions have been moved to handlers/HandlerUtils.cpp
 
 CommentOp TranslationContext::emitComment(StringRef text) {
   return CommentOp::create(builder, builder.getUnknownLoc(), text);
@@ -107,10 +110,6 @@ void TranslationContext::cacheExpr(StringRef opName, ValueRange operands,
     os << "_c" << c;
   }
   exprCache[os.str()] = result;
-}
-
-std::string TranslationContext::generateLabel(StringRef prefix) {
-  return (prefix + "_" + std::to_string(labelCounter++)).str();
 }
 
 void TranslationContext::queueSRDSetup(Value memref, int64_t argIndex,
@@ -170,6 +169,29 @@ void TranslationContext::emitSRDPrologue() {
 
   // Emit comment for prologue
   CommentOp::create(builder, loc, "SRD setup prologue");
+
+  // Emit precolored SGPR ops for ABI registers used by the raw assembly
+  // prologue below. This makes the implicit physical-register usage visible
+  // to the register allocator so it won't allocate over these indices.
+  //
+  // s[0:1] = kernarg segment pointer (used as source in s_load_dwordx2).
+  auto kernargPtrType = createSRegType(2, 2);
+  PrecoloredSRegOp::create(builder, loc, kernargPtrType, /*index=*/0,
+                           /*size=*/2);
+
+  if (isGFX95) {
+    // On gfx95*, the prologue loads kernarg data into preload locations
+    // s[2:3], s[4:5], etc. Reserve those pairs so regalloc doesn't use them.
+    llvm::DenseSet<int64_t> reservedPreloadBases;
+    for (const auto &pending : pendingSRDs) {
+      int64_t preloadBase = 2 + pending.argIndex * 2;
+      if (reservedPreloadBases.insert(preloadBase).second) {
+        auto preloadType = createSRegType(2, 2);
+        PrecoloredSRegOp::create(builder, loc, preloadType, preloadBase,
+                                 /*size=*/2);
+      }
+    }
+  }
 
   if (isGFX95) {
     // GFX95* path: Use preload pattern with intermediate locations and
@@ -381,20 +403,6 @@ LogicalResult handleVectorExtractStridedSlice(Operation *op,
 //===----------------------------------------------------------------------===//
 
 namespace {
-
-/// Compute buffer size from memref type
-static int64_t computeBufferSizeFromMemRef(MemRefType memrefType) {
-  int64_t numElements = 1;
-  for (int64_t dim : memrefType.getShape()) {
-    if (dim == ShapedType::kDynamic)
-      dim = 1; // Conservative estimate for dynamic dims
-    numElements *= dim;
-  }
-  int64_t elementBytes = memrefType.getElementTypeBitWidth() / 8;
-  if (elementBytes == 0)
-    elementBytes = 1; // Minimum 1 byte
-  return numElements * elementBytes;
-}
 
 /// Check if a memref has LDS address space
 bool isLDSMemRef(MemRefType memrefType) {
@@ -728,7 +736,7 @@ LogicalResult handleVectorLoad(Operation *op, TranslationContext &ctx) {
     if (auto baseOffset = ctx.getLDSBaseOffset(loadOp.getBase())) {
       // If the base offset is a constant, fold it into instOffset instead of
       // emitting VALU instructions. This saves 2 VALU ops per LDS read.
-      if (auto constVal = getConstantValue(*baseOffset)) {
+      if (auto constVal = getArithConstantValue(*baseOffset)) {
         instOffset += *constVal;
       } else {
         // Non-constant base offset: must use VALU
@@ -1023,7 +1031,7 @@ LogicalResult handleVectorStore(Operation *op, TranslationContext &ctx) {
     if (auto baseOffset = ctx.getLDSBaseOffset(storeOp.getBase())) {
       // If the base offset is a constant, fold it into ldsInstOffset instead
       // of emitting VALU instructions. This saves 2 VALU ops per LDS write.
-      if (auto constVal = getConstantValue(*baseOffset)) {
+      if (auto constVal = getArithConstantValue(*baseOffset)) {
         ldsInstOffset += *constVal;
       } else {
         // Non-constant base offset: must use VALU

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/AMDGPUHandlers.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/AMDGPUHandlers.cpp
@@ -298,7 +298,7 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
   bool hasCacheSwizzle = false;
   int64_t swizzleStride = 0;
   if (op->getNumOperands() >= 3) {
-    if (auto swizzleVal = getConstantValue(op->getOperand(2))) {
+    if (auto swizzleVal = getArithConstantValue(op->getOperand(2))) {
       swizzleStride = *swizzleVal;
       hasCacheSwizzle = (swizzleStride > 0);
     }

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/HandlerUtils.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/HandlerUtils.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 
 using namespace mlir;
 
@@ -87,15 +88,13 @@ int64_t log2(int64_t val) {
 }
 
 //===----------------------------------------------------------------------===//
-// getConstantValue
+// getArithConstantValue
 //===----------------------------------------------------------------------===//
 
-std::optional<int64_t> getConstantValue(Value val) {
-  if (auto constOp = val.getDefiningOp<arith::ConstantOp>()) {
-    if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue())) {
-      return intAttr.getInt();
-    }
-  }
+std::optional<int64_t> getArithConstantValue(Value val) {
+  IntegerAttr attr;
+  if (mlir::matchPattern(val, mlir::m_Constant(&attr)))
+    return attr.getInt();
   return std::nullopt;
 }
 

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/Handlers.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/Handlers.h
@@ -227,7 +227,7 @@ bool isPowerOf2(int64_t val);
 int64_t log2(int64_t val);
 
 /// Extract constant value from a Value if it is a constant
-std::optional<int64_t> getConstantValue(mlir::Value val);
+std::optional<int64_t> getArithConstantValue(mlir::Value val);
 
 //===----------------------------------------------------------------------===//
 // Type-safe bit casting (replaces C-style memcpy for type punning)

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/SCFHandlers.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/SCFHandlers.cpp
@@ -16,11 +16,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "Handlers.h"
+#include "waveasm/Transforms/RegionBuilder.h"
 
-#include "waveasm/Dialect/WaveASMOps.h"
 #include "waveasm/Transforms/TranslateFromMLIR.h"
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
 using namespace mlir;
@@ -30,219 +29,25 @@ namespace waveasm {
 
 LogicalResult handleSCFIf(Operation *op, TranslationContext &ctx) {
   auto ifOp = cast<scf::IfOp>(op);
-  auto &builder = ctx.getBuilder();
-  auto loc = op->getLoc();
 
-  // Get condition
-  auto cond = ctx.getMapper().getMapped(ifOp.getCondition());
-  if (!cond) {
-    return op->emitError("condition not mapped");
-  }
+  RegionBuilder regionBuilder(ctx);
+  auto waveIfOp = regionBuilder.buildIfFromSCFIf(ifOp);
 
-  // Create labels for if/else/endif
-  std::string baseName =
-      "L_if_" + std::to_string(reinterpret_cast<uintptr_t>(op));
-  std::string elseLabel = baseName + "_else";
-  std::string endLabel = baseName + "_end";
-
-  // Branch to else block if condition is false
-  auto elseLabelRef = SymbolRefAttr::get(builder.getContext(), elseLabel);
-  S_CBRANCH_SCC0::create(builder, loc, elseLabelRef);
-
-  // Translate then region
-  for (Operation &thenOp : ifOp.getThenRegion().front().without_terminator()) {
-    if (failed(translateOperation(&thenOp, ctx))) {
-      return failure();
-    }
-  }
-
-  // Jump to end (skip else block)
-  if (!ifOp.getElseRegion().empty()) {
-    auto endLabelRef = SymbolRefAttr::get(builder.getContext(), endLabel);
-    S_BRANCH::create(builder, loc, endLabelRef);
-  }
-
-  // Else label and block
-  if (!ifOp.getElseRegion().empty()) {
-    LabelOp::create(builder, loc, elseLabel);
-    for (Operation &elseOp :
-         ifOp.getElseRegion().front().without_terminator()) {
-      if (failed(translateOperation(&elseOp, ctx))) {
-        return failure();
-      }
-    }
-  }
-
-  // End label
-  LabelOp::create(builder, loc, endLabel);
+  if (!waveIfOp)
+    return failure();
 
   return success();
 }
 
 LogicalResult handleSCFFor(Operation *op, TranslationContext &ctx) {
   auto forOp = cast<scf::ForOp>(op);
-  auto &builder = ctx.getBuilder();
-  auto loc = op->getLoc();
 
-  // Generate unique loop label
-  std::string labelName = ctx.generateLabel("L_loop");
-  std::string endLabelName = labelName + "_end";
+  RegionBuilder regionBuilder(ctx);
+  auto loopOp = regionBuilder.buildLoopFromSCFFor(forOp);
 
-  // Initialize loop counter in a FIXED physical SGPR
-  // Using a fixed register ensures the counter value persists across loop
-  // iterations. The counter must start AFTER all SRD registers to avoid
-  // conflicts. With N kernel arguments, SRDs occupy s[srdStart:srdStart+N*4-1],
-  // so we start loop counters after that range.
-  int64_t loopCounterBase = ctx.getFirstFreeSgprAfterSRDs();
-  int64_t loopCounterPhysReg =
-      loopCounterBase + ctx.getLoopDepth(); // Use s[base], s[base+1], etc.
-  auto counterType =
-      PSRegType::get(builder.getContext(), loopCounterPhysReg, 1);
+  if (!loopOp)
+    return failure();
 
-  auto lb = ctx.getMapper().getMapped(forOp.getLowerBound());
-  if (!lb) {
-    auto immType = ctx.createImmType(0);
-    lb = ConstantOp::create(builder, loc, immType, 0);
-  }
-
-  auto counter = S_MOV_B32::create(builder, loc, counterType, *lb);
-  ctx.getMapper().mapValue(forOp.getInductionVar(), counter);
-
-  // Handle iter_args (loop-carried values)
-  // These are values passed from one iteration to the next (e.g., accumulators)
-  // For vector-type iter_args (accumulators), we need to:
-  // 1. Allocate VREGs before the loop
-  // 2. Initialize them with v_mov_b32
-  // 3. Map the region arg to those VREGs for in-place accumulation
-  SmallVector<Value, 4> iterArgValues;
-  for (auto [initArg, regionArg] :
-       llvm::zip(forOp.getInitArgs(), forOp.getRegionIterArgs())) {
-    auto mapped = ctx.getMapper().getMapped(initArg);
-
-    // Check if this is a vector type (likely an accumulator for MFMA)
-    Type regionArgType = regionArg.getType();
-    if (auto vecType = dyn_cast<VectorType>(regionArgType)) {
-      // For vector accumulators, we need to materialize VREGs
-      int64_t numElems = vecType.getNumElements();
-
-      // Check if the init value is a constant 0 (common for accumulators)
-      bool isZeroInit = false;
-      if (auto constOp = initArg.getDefiningOp<arith::ConstantOp>()) {
-        if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
-          if (denseAttr.isSplat()) {
-            if (auto floatAttr =
-                    dyn_cast<FloatAttr>(denseAttr.getSplatValue<Attribute>())) {
-              isZeroInit = (floatAttr.getValueAsDouble() == 0.0);
-            }
-          }
-        }
-      }
-
-      if (isZeroInit) {
-        // Allocate VREGs for the accumulator and initialize to 0
-        // The MFMA instruction will use these registers for in-place
-        // accumulation
-        auto vregType =
-            ctx.createVRegType(numElems, 4); // Quad-aligned for MFMA
-        auto zeroImm = ctx.createImmType(0);
-        auto zero = ConstantOp::create(builder, loc, zeroImm, 0);
-
-        // Create v_mov_b32 to initialize each element of the accumulator
-        // Mark with "no_cse" to prevent CSE from merging multiple accumulators
-        auto accMovOp = V_MOV_B32::create(builder, loc, vregType, zero);
-        accMovOp->setAttr("no_cse", builder.getUnitAttr());
-        Value accReg = accMovOp.getResult();
-
-        // Map the region argument to this register
-        ctx.getMapper().mapValue(regionArg, accReg);
-        iterArgValues.push_back(accReg);
-        continue;
-      }
-    }
-
-    // Default: map to the initial value directly
-    if (mapped) {
-      ctx.getMapper().mapValue(regionArg, *mapped);
-      iterArgValues.push_back(*mapped);
-    }
-  }
-
-  // Set up loop context for nested operations
-  LoopContext loopCtx;
-  loopCtx.inductionVar = counter;
-  loopCtx.iterArgs = iterArgValues;
-  loopCtx.labelName = labelName;
-  loopCtx.depth = ctx.getLoopDepth() + 1;
-  ctx.pushLoopContext(loopCtx);
-
-  // Clear expression cache at loop entry (loop-variant expressions must be
-  // recomputed)
-  ctx.clearExprCache();
-
-  // Loop label
-  LabelOp::create(builder, loc, labelName);
-
-  // Translate loop body
-  for (Operation &bodyOp : forOp.getBody()->without_terminator()) {
-    if (failed(translateOperation(&bodyOp, ctx))) {
-      ctx.popLoopContext();
-      return failure();
-    }
-  }
-
-  // Handle yield - update iter_args for next iteration
-  if (auto yieldOp = dyn_cast<scf::YieldOp>(forOp.getBody()->getTerminator())) {
-    for (auto [yieldedVal, regionArg] :
-         llvm::zip(yieldOp.getOperands(), forOp.getRegionIterArgs())) {
-      auto mapped = ctx.getMapper().getMapped(yieldedVal);
-      if (mapped) {
-        // Update the region argument mapping for the next iteration
-        ctx.getMapper().mapValue(regionArg, *mapped);
-      }
-    }
-  }
-
-  // Increment counter - use the same physical register type as the counter
-  // This ensures the increment writes to the same physical register
-  auto step = ctx.getMapper().getMapped(forOp.getStep());
-  if (!step) {
-    auto immType = ctx.createImmType(1);
-    step = ConstantOp::create(builder, loc, immType, 1);
-  }
-
-  // Get the counter type from the original counter (it is a physical register
-  // type)
-  auto counterPhysType = counter.getType();
-  auto newCounter =
-      S_ADD_U32::create(builder, loc, counterPhysType, counter, *step);
-
-  // Since we are using physical registers, newCounter is in the same register
-  // as counter Update the mapping for any post-loop uses
-  ctx.getMapper().mapValue(forOp.getInductionVar(), newCounter);
-
-  // Compare and branch back to loop header
-  auto ub = ctx.getMapper().getMapped(forOp.getUpperBound());
-  if (ub) {
-    S_CMP_LT_U32::create(builder, loc, newCounter, *ub);
-    auto labelRef = SymbolRefAttr::get(builder.getContext(), labelName);
-    S_CBRANCH_SCC1::create(builder, loc, labelRef);
-  }
-
-  // End label for loop exit
-  LabelOp::create(builder, loc, endLabelName);
-
-  // Map loop results to final iter_arg values
-  if (auto yieldOp = dyn_cast<scf::YieldOp>(forOp.getBody()->getTerminator())) {
-    for (auto [result, yieldedVal] :
-         llvm::zip(forOp.getResults(), yieldOp.getOperands())) {
-      auto mapped = ctx.getMapper().getMapped(yieldedVal);
-      if (mapped) {
-        ctx.getMapper().mapValue(result, *mapped);
-      }
-    }
-  }
-
-  ctx.popLoopContext();
   return success();
 }
 

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/basic.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/basic.mlir
@@ -12,14 +12,8 @@ waveasm.program @simple_kernel
   // Pure SSA instructions - each instruction is its own op
   %sum = waveasm.v_add_u32 %tid, %tid : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-  // Label
-  waveasm.label @loop_start
-
   // Comment
-  waveasm.comment "Loop body begins here"
-
-  // Conditional branch
-  waveasm.s_cbranch_scc1 @loop_start
+  waveasm.comment "Basic kernel body"
 
   // End program
   waveasm.s_endpgm

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/memory-effects.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/memory-effects.mlir
@@ -1,0 +1,97 @@
+// RUN: waveasm-translate %s | FileCheck %s
+// Test memory effect annotations on operations
+
+// CHECK-LABEL: @memory_load_operations
+waveasm.program @memory_load_operations
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %srd = waveasm.precolored.sreg 8 : !waveasm.sreg<4>
+  %offset = waveasm.precolored.vreg 0 : !waveasm.vreg
+
+  // Buffer loads have Read effect on global memory
+  // CHECK: waveasm.buffer_load_dword
+  %val1 = waveasm.buffer_load_dword %srd, %offset
+      : !waveasm.sreg<4>, !waveasm.vreg -> !waveasm.vreg
+
+  // CHECK: waveasm.buffer_load_dwordx4
+  %val2 = waveasm.buffer_load_dwordx4 %srd, %offset
+      : !waveasm.sreg<4>, !waveasm.vreg -> !waveasm.vreg<4>
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: @memory_store_operations
+waveasm.program @memory_store_operations
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %srd = waveasm.precolored.sreg 8 : !waveasm.sreg<4>
+  %offset = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %data = waveasm.precolored.vreg 1 : !waveasm.vreg
+
+  // Buffer stores have Write effect on global memory
+  // CHECK: waveasm.buffer_store_dword
+  waveasm.buffer_store_dword %data, %srd, %offset
+      : !waveasm.vreg, !waveasm.sreg<4>, !waveasm.vreg
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: @lds_operations
+waveasm.program @lds_operations
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64, lds_size = 4096 : i64} {
+
+  %addr = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %data = waveasm.precolored.vreg 1 : !waveasm.vreg
+
+  // LDS operations have Read/Write effects on workgroup memory
+  // CHECK: waveasm.ds_read_b32
+  %loaded = waveasm.ds_read_b32 %addr : !waveasm.vreg -> !waveasm.vreg
+
+  // CHECK: waveasm.ds_write_b32
+  waveasm.ds_write_b32 %data, %addr : !waveasm.vreg, !waveasm.vreg
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: @synchronization_operations
+waveasm.program @synchronization_operations
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  // Barrier synchronizes all memory accesses
+  // Has Read and Write effects on all memory resources
+  // CHECK: waveasm.s_barrier
+  waveasm.s_barrier
+
+  // Waitcnt creates a memory fence
+  // CHECK: waveasm.s_waitcnt
+  waveasm.s_waitcnt lgkmcnt (0)
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: @pure_arithmetic
+waveasm.program @pure_arithmetic
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 16 : i64, sgprs = 16 : i64} {
+
+  %a = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %b = waveasm.precolored.vreg 1 : !waveasm.vreg
+
+  // Arithmetic operations are Pure (no side effects)
+  // CHECK: waveasm.v_add_u32
+  %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+  // CHECK: waveasm.v_mul_lo_u32
+  %product = waveasm.v_mul_lo_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/region-control-flow.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Dialect/region-control-flow.mlir
@@ -1,0 +1,310 @@
+// RUN: waveasm-translate %s | waveasm-translate | FileCheck %s
+// RUN: waveasm-translate %s
+//
+// Round-trip (parse -> print -> parse) tests for region-based control flow ops.
+// Verifies that LoopOp, IfOp, ConditionOp, and YieldOp survive round-trip
+// with correct types, block arguments, iter_args threading, and SSA structure.
+
+//===----------------------------------------------------------------------===//
+// LoopOp Tests
+//===----------------------------------------------------------------------===//
+
+// --- Simple loop: single iter_arg (SGPR counter) ---
+// Verifies init flows into loop, block arg used in body, condition feeds back.
+// CHECK-LABEL: @simple_loop
+waveasm.program @simple_loop
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
+  %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // CHECK-NEXT:   %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next) : !waveasm.sreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- Loop with two iter_args: SGPR counter + VGPR accumulator ---
+// Verifies multi-result (:2), mixed register types, accumulator uses both
+// block args, and condition iter_args feed both back.
+// CHECK-LABEL: @loop_with_accumulator
+waveasm.program @loop_with_accumulator
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 4 : !waveasm.imm<4>
+  %init_i = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg
+
+  // CHECK:      %[[I0:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK-NEXT: %[[A0:.*]] = waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.vreg
+  // CHECK-NEXT: %{{.*}}:2 = waveasm.loop (%[[IV:.*]] = %[[I0]], %[[ACC:.*]] = %[[A0]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+  %final_i, %result = waveasm.loop(%i = %init_i, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+    // Accumulator adds vreg block arg + sreg block arg
+    // CHECK-NEXT:   %[[NEWACC:.*]] = waveasm.v_add_u32 %[[ACC]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+    %new_acc = waveasm.v_add_u32 %acc, %i
+        : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+    // CHECK-NEXT:   %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next, %new_acc) : !waveasm.sreg, !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- MFMA accumulation loop with vreg<4> iter_arg ---
+// Verifies vector register types round-trip and MFMA reads accumulator
+// block arg and feeds its result back through condition iter_args.
+// CHECK-LABEL: @loop_mfma_accumulation
+waveasm.program @loop_mfma_accumulation
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 64 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %four = waveasm.constant 4 : !waveasm.imm<4>
+  %init_k = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg<4>
+
+  // CHECK:      %{{.*}}:2 = waveasm.loop (%[[K:.*]] = %{{.*}}, %[[ACC:.*]] = %{{.*}}) : (!waveasm.sreg, !waveasm.vreg<4>) -> (!waveasm.sreg, !waveasm.vreg<4>) {
+  %final_k, %final_acc = waveasm.loop(%k = %init_k, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4>) -> (!waveasm.sreg, !waveasm.vreg<4>) {
+    %a_tile = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg<2>
+    %b_tile = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg<2>
+
+    // MFMA reads accumulator block arg (%ACC) and produces new accumulator
+    // CHECK:      %[[MFMA:.*]] = waveasm.v_mfma_f32_16x16x16_f16 %{{.*}}, %{{.*}}, %[[ACC]] : !waveasm.vreg<2>, !waveasm.vreg<2>, !waveasm.vreg<4> -> !waveasm.vreg<4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a_tile, %b_tile, %acc
+        : !waveasm.vreg<2>, !waveasm.vreg<2>, !waveasm.vreg<4> -> !waveasm.vreg<4>
+
+    %next_k = waveasm.s_add_u32 %k, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %continue = waveasm.s_cmp_lt_u32 %next_k, %four : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+
+    // MFMA result fed back as accumulator iter_arg (vreg<4>)
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[MFMA]]) : !waveasm.sreg, !waveasm.vreg<4>
+    waveasm.condition %continue : !waveasm.sreg iter_args(%next_k, %new_acc) : !waveasm.sreg, !waveasm.vreg<4>
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// IfOp Tests
+//===----------------------------------------------------------------------===//
+
+// --- If-then-else with single vreg result ---
+// Verifies condition operand flows into if, result types, yield in both branches.
+// CHECK-LABEL: @simple_if_then
+waveasm.program @simple_if_then
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %a = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %b = waveasm.precolored.vreg 1 : !waveasm.vreg
+  %cond_val = waveasm.precolored.sreg 2 : !waveasm.sreg
+
+  // CHECK:      %[[COND:.*]] = waveasm.precolored.sreg 2 : !waveasm.sreg
+  // CHECK-NEXT: %{{.*}} = waveasm.if %[[COND]] : !waveasm.sreg -> !waveasm.vreg {
+  %result = waveasm.if %cond_val : !waveasm.sreg -> !waveasm.vreg {
+    // CHECK-NEXT:   %[[SUM:.*]] = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT:   waveasm.yield %[[SUM]] : !waveasm.vreg
+    waveasm.yield %sum : !waveasm.vreg
+  // CHECK-NEXT: } else {
+  } else {
+    // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
+    waveasm.yield %a : !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- If with computed condition (s_cmp_lt_u32 -> if) ---
+// Verifies comparison result feeds into if, then/else each yield correctly.
+// CHECK-LABEL: @if_then_else
+waveasm.program @if_then_else
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %tid = waveasm.precolored.sreg 0 : !waveasm.sreg
+  %a = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %b = waveasm.precolored.vreg 1 : !waveasm.vreg
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+
+  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %tid, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+
+  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.sreg -> !waveasm.vreg {
+  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+    // CHECK-NEXT:   %{{.*}} = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
+    waveasm.yield %sum : !waveasm.vreg
+  // CHECK-NEXT: } else {
+  } else {
+    // CHECK-NEXT:   %{{.*}} = waveasm.v_sub_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %diff = waveasm.v_sub_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
+    waveasm.yield %diff : !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- If with multiple results (:2) ---
+// Verifies multi-result if, both branches yield two values with matching types.
+// CHECK-LABEL: @if_multiple_results
+waveasm.program @if_multiple_results
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %a = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %b = waveasm.precolored.vreg 1 : !waveasm.vreg
+  %cond = waveasm.precolored.sreg 2 : !waveasm.sreg
+
+  // CHECK:      %{{.*}}:2 = waveasm.if %{{.*}} : !waveasm.sreg -> !waveasm.vreg, !waveasm.vreg {
+  %r1, %r2 = waveasm.if %cond : !waveasm.sreg -> !waveasm.vreg, !waveasm.vreg {
+    // CHECK:      %{{.*}} = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT: %{{.*}} = waveasm.v_mul_lo_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %prod = waveasm.v_mul_lo_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT: waveasm.yield %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg
+    waveasm.yield %sum, %prod : !waveasm.vreg, !waveasm.vreg
+  // CHECK-NEXT: } else {
+  } else {
+    // CHECK-NEXT: %{{.*}} = waveasm.v_sub_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %diff = waveasm.v_sub_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT: %{{.*}} = waveasm.v_and_b32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %mask = waveasm.v_and_b32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT: waveasm.yield %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg
+    waveasm.yield %diff, %mask : !waveasm.vreg, !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Nested Control Flow Tests
+//===----------------------------------------------------------------------===//
+
+// --- Nested loops: accumulator threading across loop nesting ---
+// Verifies outer block arg flows into inner loop init, inner loop result (#1)
+// feeds back to outer condition iter_args.
+// CHECK-LABEL: @nested_loops
+waveasm.program @nested_loops
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %outer_limit = waveasm.constant 4 : !waveasm.imm<4>
+  %inner_limit = waveasm.constant 8 : !waveasm.imm<8>
+  %init_i = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg
+
+  // Outer loop: two iter_args (counter + accumulator)
+  // CHECK:      %{{.*}}:2 = waveasm.loop (%[[OI:.*]] = %{{.*}}, %[[OACC:.*]] = %{{.*}}) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+  %final_i, %outer_result = waveasm.loop(%i = %init_i, %outer_acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    %init_j = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+    // Inner loop: outer accumulator (%OACC) is the init for inner accumulator
+    // CHECK:      %[[INNER:.*]]:2 = waveasm.loop (%{{.*}} = %{{.*}}, %[[IACC:.*]] = %[[OACC]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+    %final_j, %inner_result = waveasm.loop(%j = %init_j, %inner_acc = %outer_acc)
+        : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+      // CHECK:      %{{.*}} = waveasm.v_add_u32 %[[IACC]], %{{.*}} : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+      %val = waveasm.v_add_u32 %inner_acc, %j
+          : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+      %next_j = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      %cond_j = waveasm.s_cmp_lt_u32 %next_j, %inner_limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
+      waveasm.condition %cond_j : !waveasm.sreg iter_args(%next_j, %val) : !waveasm.sreg, !waveasm.vreg
+    }
+
+    %next_i = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond_i = waveasm.s_cmp_lt_u32 %next_i, %outer_limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+
+    // Outer condition: accumulator comes from inner loop's result #1
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond_i : !waveasm.sreg iter_args(%next_i, %inner_result) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- If nested inside a loop ---
+// Verifies if result (sreg) feeds into s_add_u32 which feeds condition iter_args.
+// CHECK-LABEL: @loop_with_if
+waveasm.program @loop_with_if
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %two = waveasm.constant 2 : !waveasm.imm<2>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK:      %{{.*}} = waveasm.loop (%[[IV:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
+  %result = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // Block arg used by s_and to check parity
+    // CHECK:      %[[REM:.*]] = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %rem = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+    %is_even = waveasm.s_cmp_eq_u32 %rem, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+
+    // If branches on the comparison result, producing an sreg step value
+    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.sreg -> !waveasm.sreg {
+    %step = waveasm.if %is_even : !waveasm.sreg -> !waveasm.sreg {
+      // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
+      %step_val = waveasm.s_mov_b32 %two : !waveasm.imm<2> -> !waveasm.sreg
+      waveasm.yield %step_val : !waveasm.sreg
+    // CHECK:      } else {
+    } else {
+      // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
+      %step_val = waveasm.s_mov_b32 %one : !waveasm.imm<1> -> !waveasm.sreg
+      waveasm.yield %step_val : !waveasm.sreg
+    }
+
+    // If result (%STEP) used to update counter, which feeds condition
+    // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
+    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    %continue = waveasm.s_cmp_lt_u32 %next, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %continue : !waveasm.sreg iter_args(%next) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Integration/compile-and-assemble.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Integration/compile-and-assemble.mlir
@@ -1,12 +1,10 @@
-// RUN: waveasm-translate %s --emit-assembly -o %t.s
+// RUN: waveasm-translate %s --waveasm-linear-scan --emit-assembly -o %t.s
 // RUN: FileCheck %s < %t.s
 // RUN: %rocm_clang -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx942 -c %t.s -o %t.o
 // RUN: %rocm_lld -shared -o %t.hsaco %t.o
 // RUN: file %t.hsaco | FileCheck --check-prefix=CHECK-HSACO %s
 //
 // REQUIRES: rocm-toolchain
-// XFAIL: *
-// Assembly emission pass not yet integrated into CLI
 //
 // This test verifies that the generated assembly can be assembled
 // by clang into valid GPU object code and linked into an HSACO.
@@ -17,22 +15,20 @@
 // CHECK: v_add_u32
 // CHECK: s_endpgm
 // CHECK: .amdhsa_kernel simple_add
-// CHECK: .amdhsa_accum_offset
 
 // CHECK-HSACO: ELF 64-bit LSB shared object, AMD GPU
 
 waveasm.program @simple_add
-  abi = #waveasm.abi<flatTidVReg = 0, kernargPtrSRegLo = 0, kernargPtrSRegHi = 1>
   target = #waveasm.target<#waveasm.gfx942, 5>
-  attributes {maxVGPRs = 256, maxSGPRs = 104, workgroupSize = [64, 1, 1]} {
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
 
-  // Physical registers
-  %v0 = waveasm.def_pvreg : !waveasm.pvreg<0>
-  %v1 = waveasm.def_pvreg : !waveasm.pvreg<1>
-  %v2 = waveasm.def_pvreg : !waveasm.pvreg<2>
+  // Get some input values
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %v1 = waveasm.precolored.vreg 1 : !waveasm.vreg
 
-  waveasm.instr "v_add_u32" defs(%v0 : !waveasm.pvreg<0>)
-                           uses(%v1, %v2 : !waveasm.pvreg<1>, !waveasm.pvreg<2>)
+  // Add them
+  %v2 = waveasm.v_add_u32 %v0, %v1 : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-  waveasm.instr "s_endpgm" defs() uses()
+  waveasm.s_endpgm
 }

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/expr-cse.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/expr-cse.mlir
@@ -37,8 +37,9 @@ waveasm.program @cse_arithmetic_only target = #waveasm.target<#waveasm.gfx942, 5
   // Same operation - should be CSE'd (no second v_and_b32 with same operands)
   %v1 = waveasm.v_and_b32 %a, %b : !waveasm.pvreg<0>, !waveasm.pvreg<1> -> !waveasm.vreg
 
-  // Different operand order - not the same (AND is commutative but CSE uses operand order)
-  // CHECK: waveasm.v_and_b32
+  // Reversed operand order - also CSE'd because AND is commutative and
+  // the CSE key canonicalizes operand order for commutative ops.
+  // CHECK-NOT: waveasm.v_and_b32
   %v2 = waveasm.v_and_b32 %b, %a : !waveasm.pvreg<1>, !waveasm.pvreg<0> -> !waveasm.vreg
 
   waveasm.s_endpgm

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/liveness-cfg.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/liveness-cfg.mlir
@@ -1,23 +1,29 @@
 // RUN: waveasm-translate --target=gfx942 %s 2>&1 | FileCheck %s
 //
-// Test CFG-based liveness analysis with loop
+// Test: CFG-based liveness analysis with loop.
+// Verifies scf.for translates to waveasm.loop with correct induction variable
+// threading and condition terminator structure.
 
 module {
   gpu.module @test_liveness_loop {
-    // CHECK: waveasm.program @liveness_loop_kernel
+    // CHECK-LABEL: waveasm.program @liveness_loop_kernel
     gpu.func @liveness_loop_kernel() kernel {
       %c0 = arith.constant 0 : index
       %c4 = arith.constant 4 : index
       %c1 = arith.constant 1 : index
 
-      // CHECK: waveasm.s_mov_b32
-      // CHECK: waveasm.label
+      // Init via s_mov_b32, loop carries single sreg
+      // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
       scf.for %i = %c0 to %c4 step %c1 {
-        // Use the induction variable inside loop
-        // CHECK: waveasm.v_add_u32
+        // Body uses block arg
+        // CHECK:      waveasm.v_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.vreg
         %sum = arith.addi %i, %c1 : index
       }
-      // CHECK: waveasm.s_cbranch_scc1
+      // Increment, compare, condition with iter_arg
+      // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/region-based-translation.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/region-based-translation.mlir
@@ -1,0 +1,116 @@
+// RUN: waveasm-translate %s | FileCheck %s
+//
+// Test: Translation from SCF dialect to region-based WaveASM control flow.
+// Verifies scf.for -> waveasm.loop and scf.if -> waveasm.if with correct
+// SSA threading, iter_args, and condition patterns.
+
+module {
+  gpu.module @test_scf_translation {
+
+    // --- scf.for(0, 16, 1) -> waveasm.loop with SGPR induction variable ---
+    // CHECK-LABEL: waveasm.program @scf_for_to_loop
+    gpu.func @scf_for_to_loop() kernel {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+
+      // Init materialised via s_mov_b32
+      // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // Loop carries single sreg
+      // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
+      scf.for %i = %c0 to %c16 step %c1 {
+        %i_i32 = arith.index_cast %i : index to i32
+      }
+      // Induction variable incremented, compared, condition terminates
+      // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+
+    // --- scf.for with iter_args -> waveasm.loop with two iter_args ---
+    // CHECK-LABEL: waveasm.program @scf_for_with_iter_args
+    gpu.func @scf_for_with_iter_args() kernel {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
+      %init = arith.constant 0 : i32
+
+      // Two inits: sreg counter + vreg accumulator
+      // CHECK:      %[[I0:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK-NEXT: %[[A0:.*]] = waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.vreg
+      // CHECK-NEXT: %{{.*}}:2 = waveasm.loop (%[[IV:.*]] = %[[I0]], %[[ACC:.*]] = %[[A0]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+      %result = scf.for %i = %c0 to %c16 step %c1
+          iter_args(%acc = %init) -> (i32) {
+        %i_i32 = arith.index_cast %i : index to i32
+        %new_acc = arith.addi %acc, %i_i32 : i32
+        scf.yield %new_acc : i32
+      }
+      // Body accumulates: vreg + sreg
+      // CHECK:      %[[NEWACC:.*]] = waveasm.v_add_u32 %[[ACC]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+      // Induction variable incremented, compared, condition with both iter_args
+      // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+
+    // --- scf.if -> waveasm.if with then/else branches ---
+    // CHECK-LABEL: waveasm.program @scf_if_to_wave_if
+    gpu.func @scf_if_to_wave_if() kernel {
+      %arg0 = arith.constant 5 : i32
+      %arg1 = arith.constant 3 : i32
+      %c10 = arith.constant 10 : i32
+      %cond_i32 = arith.cmpi slt, %arg0, %c10 : i32
+      %cond_ext = arith.extui %cond_i32 : i1 to i32
+
+      // CHECK:      %{{.*}} = waveasm.if %{{.*}} : !waveasm.sreg -> !waveasm.vreg {
+      %result = scf.if %cond_i32 -> i32 {
+        // CHECK:      waveasm.v_add_u32
+        %sum = arith.addi %arg0, %arg1 : i32
+        // CHECK:      waveasm.yield %{{.*}} : !waveasm.vreg
+        scf.yield %sum : i32
+      } else {
+        // CHECK:      waveasm.v_sub_u32
+        %diff = arith.subi %arg0, %arg1 : i32
+        // CHECK:      waveasm.yield %{{.*}} : !waveasm.vreg
+        scf.yield %diff : i32
+      }
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+
+    // --- Nested scf.for -> nested waveasm.loop ---
+    // CHECK-LABEL: waveasm.program @nested_scf_loops
+    gpu.func @nested_scf_loops() kernel {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      %c8 = arith.constant 8 : index
+
+      // Outer loop: sreg counter
+      // CHECK:      %{{.*}} = waveasm.loop (%[[OI:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
+      scf.for %i = %c0 to %c4 step %c1 {
+        // Inner loop: sreg counter
+        // CHECK:      %{{.*}} = waveasm.loop (%[[II:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
+        scf.for %j = %c0 to %c8 step %c1 {
+          // Body uses both outer and inner IVs
+          // CHECK:      waveasm.v_add_u32 %[[OI]], %[[II]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.vreg
+          %sum = arith.addi %i, %j : index
+        }
+        // Inner condition
+        // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}) : !waveasm.sreg
+      }
+      // Outer condition
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}) : !waveasm.sreg
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/region-cf-integration.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/region-cf-integration.mlir
@@ -1,0 +1,200 @@
+// RUN: waveasm-translate %s | FileCheck %s
+//
+// Integration test: verifies that already-formed WaveASM region-based control
+// flow survives a round-trip through waveasm-translate with correct SSA
+// threading, iter_arg types, and structural fidelity.
+
+//===----------------------------------------------------------------------===//
+// LoopOp integration
+//===----------------------------------------------------------------------===//
+
+// --- Basic loop: single sreg iter_arg ---
+// CHECK-LABEL: @test_loop_structure
+waveasm.program @test_loop_structure
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 16 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %ten = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
+  %counter = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // CHECK-NEXT:   %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next, %ten : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next) : !waveasm.sreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- Loop with accumulator: sreg + vreg iter_args ---
+// CHECK-LABEL: @test_loop_accumulator
+waveasm.program @test_loop_accumulator
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 16 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 16 : !waveasm.imm<16>
+  %init_i = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+  %init_sum = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg
+
+  // CHECK:      %[[I0:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK-NEXT: %[[S0:.*]] = waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.vreg
+  // CHECK-NEXT: %{{.*}}:2 = waveasm.loop (%[[IV:.*]] = %[[I0]], %[[SUM:.*]] = %[[S0]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+  %i_final, %result = waveasm.loop(%i = %init_i, %sum = %init_sum)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+    // CHECK-NEXT:   %[[NEWSUM:.*]] = waveasm.v_add_u32 %[[SUM]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+    %new_sum = waveasm.v_add_u32 %sum, %i
+        : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
+    // CHECK-NEXT:   %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next, %limit : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next, %new_sum) : !waveasm.sreg, !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// IfOp integration
+//===----------------------------------------------------------------------===//
+
+// --- If-then-else producing vreg ---
+// CHECK-LABEL: @test_if_then_else
+waveasm.program @test_if_then_else
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 16 : i64, sgprs = 16 : i64} {
+
+  %tid = waveasm.precolored.sreg 0 : !waveasm.sreg
+  %a = waveasm.precolored.vreg 0 : !waveasm.vreg
+  %b = waveasm.precolored.vreg 1 : !waveasm.vreg
+  %threshold = waveasm.constant 100 : !waveasm.imm<100>
+
+  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %tid, %threshold : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
+
+  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.sreg -> !waveasm.vreg {
+  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+    // CHECK-NEXT:   %{{.*}} = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %add = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
+    waveasm.yield %add : !waveasm.vreg
+  // CHECK-NEXT: } else {
+  } else {
+    // CHECK-NEXT:   %{{.*}} = waveasm.v_sub_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %sub = waveasm.v_sub_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
+    waveasm.yield %sub : !waveasm.vreg
+  // CHECK-NEXT: }
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Nested control flow integration
+//===----------------------------------------------------------------------===//
+
+// --- Nested loops: accumulator threads from outer to inner and back ---
+// CHECK-LABEL: @test_nested_loops
+waveasm.program @test_nested_loops
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %outer_lim = waveasm.constant 4 : !waveasm.imm<4>
+  %inner_lim = waveasm.constant 8 : !waveasm.imm<8>
+  %init_i = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc = waveasm.v_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.vreg
+
+  // CHECK:      %{{.*}}:2 = waveasm.loop (%[[OI:.*]] = %{{.*}}, %[[OACC:.*]] = %{{.*}}) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+  %i_final, %outer_result = waveasm.loop(%i = %init_i, %acc_outer = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    %init_j = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+    // Inner loop inherits accumulator from outer block arg
+    // CHECK:      %[[INNER:.*]]:2 = waveasm.loop (%{{.*}} = %{{.*}}, %{{.*}} = %[[OACC]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+    %j_final, %inner_result = waveasm.loop(%j = %init_j, %acc_inner = %acc_outer)
+        : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+      // Inner body: multiply outer * inner counters, accumulate
+      // CHECK:      waveasm.v_mul_lo_u32 %[[OI]], %{{.*}} : !waveasm.sreg, !waveasm.sreg -> !waveasm.vreg
+      %product = waveasm.v_mul_lo_u32 %i, %j
+          : !waveasm.sreg, !waveasm.sreg -> !waveasm.vreg
+      %new_acc = waveasm.v_add_u32 %acc_inner, %product
+          : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+      %next_j = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      %cond_j = waveasm.s_cmp_lt_u32 %next_j, %inner_lim : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+      waveasm.condition %cond_j : !waveasm.sreg iter_args(%next_j, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    }
+
+    %next_i = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond_i = waveasm.s_cmp_lt_u32 %next_i, %outer_lim : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+
+    // Outer condition: inner loop's vreg result (#1) becomes outer accumulator
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond_i : !waveasm.sreg iter_args(%next_i, %inner_result) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}
+
+// --- If inside a loop ---
+// CHECK-LABEL: @test_if_in_loop
+waveasm.program @test_if_in_loop
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 16 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %two = waveasm.constant 2 : !waveasm.imm<2>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK:      %{{.*}} = waveasm.loop (%[[IV:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
+  %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // CHECK:      %[[REM:.*]] = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %rem = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+    %is_even = waveasm.s_cmp_eq_u32 %rem, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+
+    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.sreg -> !waveasm.sreg {
+    %step = waveasm.if %is_even : !waveasm.sreg -> !waveasm.sreg {
+      // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
+      %step_val = waveasm.s_mov_b32 %two : !waveasm.imm<2> -> !waveasm.sreg
+      waveasm.yield %step_val : !waveasm.sreg
+    // CHECK:      } else {
+    } else {
+      // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
+      %step_val = waveasm.s_mov_b32 %one : !waveasm.imm<1> -> !waveasm.sreg
+      waveasm.yield %step_val : !waveasm.sreg
+    }
+
+    // If result feeds loop counter update
+    // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
+    %next = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
+    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    %cont = waveasm.s_cmp_lt_u32 %next, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cont : !waveasm.sreg iter_args(%next) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-iter-args.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-iter-args.mlir
@@ -1,36 +1,41 @@
 // RUN: waveasm-translate %s 2>&1 | FileCheck %s
 //
-// Test scf.for loop translation with iter_args (loop-carried values)
+// Test: scf.for with iter_args (loop-carried values) translated to
+// waveasm.loop with correct multi-iter_arg handling.
 
 module {
   gpu.module @test_loop_iter_args {
-    // Test 1: Simple accumulator loop with iter_args
-    // CHECK: waveasm.program @accumulator_loop
+
+    // --- Single iter_arg: accumulator pattern (sum += i) ---
+    // CHECK-LABEL: waveasm.program @accumulator_loop
     gpu.func @accumulator_loop() kernel {
       %c0 = arith.constant 0 : index
       %c4 = arith.constant 4 : index
       %c1 = arith.constant 1 : index
       %init_sum = arith.constant 0 : i32
 
-      // Loop with single iter_arg (accumulator pattern)
-      // CHECK: waveasm.label @L_loop_
+      // Two inits: sreg counter (from scf.for IV) + vreg accumulator
+      // CHECK:      %[[I0:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK-NEXT: %[[A0:.*]] = waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.vreg
+      // CHECK-NEXT: %{{.*}}:2 = waveasm.loop (%[[IV:.*]] = %[[I0]], %[[ACC:.*]] = %[[A0]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
       %final_sum = scf.for %i = %c0 to %c4 step %c1 iter_args(%sum = %init_sum) -> (i32) {
-        // Accumulate: sum += i
         %i_i32 = arith.index_cast %i : index to i32
-        // CHECK: waveasm.v_add_u32
+        // Accumulate: vreg acc + sreg IV
+        // CHECK:      %[[NEWSUM:.*]] = waveasm.v_add_u32 %[[ACC]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
         %new_sum = arith.addi %sum, %i_i32 : i32
         scf.yield %new_sum : i32
       }
-      // CHECK: waveasm.s_add_u32
-      // CHECK: waveasm.s_cmp_lt_u32
-      // CHECK: waveasm.s_cbranch_scc1
+      // Increment, compare, condition with both iter_args
+      // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
     }
 
-    // Test 2: Loop with multiple iter_args
-    // CHECK: waveasm.program @multi_iter_args
+    // --- Two iter_args: a' = a + b, b' = a << 1 ---
+    // CHECK-LABEL: waveasm.program @multi_iter_args
     gpu.func @multi_iter_args() kernel {
       %c0 = arith.constant 0 : index
       %c8 = arith.constant 8 : index
@@ -38,46 +43,50 @@ module {
       %init_a = arith.constant 1 : i32
       %init_b = arith.constant 2 : i32
 
-      // Loop with two iter_args
-      // CHECK: waveasm.label @L_loop_
+      // Three inits: sreg counter + vreg a + vreg b
+      // CHECK:      %{{.*}}:3 = waveasm.loop (%{{.*}} = %{{.*}}, %[[A:.*]] = %{{.*}}, %[[B:.*]] = %{{.*}}) : (!waveasm.sreg, !waveasm.vreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg, !waveasm.vreg) {
       %final_a, %final_b = scf.for %i = %c0 to %c8 step %c1
           iter_args(%a = %init_a, %b = %init_b) -> (i32, i32) {
-        // a' = a + b
-        // b' = a * 2
-        // CHECK: waveasm.v_add_u32
+        // a' = a + b (vreg + vreg)
+        // CHECK:      %[[NEWA:.*]] = waveasm.v_add_u32 %[[A]], %[[B]] : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
         %new_a = arith.addi %a, %b : i32
-        // CHECK: waveasm.v_lshlrev_b32
+        // b' = a << 1 (shift left by 1)
+        // CHECK:      %[[NEWB:.*]] = waveasm.v_lshlrev_b32 %{{.*}}, %[[A]] : !waveasm.imm<1>, !waveasm.vreg -> !waveasm.vreg
         %two = arith.constant 1 : i32
         %new_b = arith.shli %a, %two : i32
         scf.yield %new_a, %new_b : i32, i32
       }
-      // CHECK: waveasm.s_add_u32
-      // CHECK: waveasm.s_cbranch_scc1
+      // Condition feeds back all three iter_args
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[NEWA]], %[[NEWB]]) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
     }
 
-    // Test 3: Nested loops with iter_args
-    // CHECK: waveasm.program @nested_loops
+    // --- Nested loops with iter_args threading ---
+    // CHECK-LABEL: waveasm.program @nested_loops
     gpu.func @nested_loops() kernel {
       %c0 = arith.constant 0 : index
       %c2 = arith.constant 2 : index
       %c1 = arith.constant 1 : index
       %init = arith.constant 0 : i32
 
-      // Outer loop
-      // CHECK: waveasm.label @L_loop_
+      // Outer loop: sreg counter + vreg accumulator
+      // CHECK:      %{{.*}}:2 = waveasm.loop (%{{.*}} = %{{.*}}, %[[OACC:.*]] = %{{.*}}) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
       %outer_result = scf.for %i = %c0 to %c2 step %c1 iter_args(%outer_acc = %init) -> (i32) {
-        // Inner loop
-        // CHECK: waveasm.label @L_loop_
+        // Inner loop: accumulator threads from outer -> inner init
+        // CHECK:      %[[INNER:.*]]:2 = waveasm.loop (%{{.*}} = %{{.*}}, %{{.*}} = %[[OACC]]) : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
         %inner_result = scf.for %j = %c0 to %c2 step %c1 iter_args(%inner_acc = %outer_acc) -> (i32) {
           %one = arith.constant 1 : i32
           %next = arith.addi %inner_acc, %one : i32
           scf.yield %next : i32
         }
+        // Inner condition
+        // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
         scf.yield %inner_result : i32
       }
+      // Outer condition uses inner loop result (#1) for accumulator
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-loop.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-loop.mlir
@@ -1,25 +1,28 @@
 // RUN: waveasm-translate %s 2>&1 | FileCheck %s
 //
-// Test scf.for loop translation to WAVEASM instructions
+// Test: scf.for loop translation to WaveASM loop with induction variable
+// handling, body translation, and condition terminator.
 
 module {
   gpu.module @test_loop {
-    // CHECK: waveasm.program @loop_kernel
+    // CHECK-LABEL: waveasm.program @loop_kernel
     gpu.func @loop_kernel() kernel {
       %c0 = arith.constant 0 : index
       %c4 = arith.constant 4 : index
       %c1 = arith.constant 1 : index
 
-      // CHECK: waveasm.s_mov_b32
-      // CHECK: waveasm.label @L_loop_
+      // Induction variable init via s_mov_b32, loop carries sreg
+      // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
       scf.for %i = %c0 to %c4 step %c1 {
-        // Loop body: arith.addi uses SGPR loop counter + immediate
-        // CHECK: waveasm.v_add_u32 {{.*}} : !waveasm.psreg{{.*}}, !waveasm.imm
+        // Body: arith.addi %i, %c1 -> v_add_u32 using block arg
+        // CHECK:      waveasm.v_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.vreg
         %sum = arith.addi %i, %c1 : index
       }
-      // CHECK: waveasm.s_add_u32
-      // CHECK: waveasm.s_cmp_lt_u32
-      // CHECK: waveasm.s_cbranch_scc1
+      // Increment, compare, condition
+      // CHECK:      %[[NEXT:.*]] = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return


### PR DESCRIPTION
Replace the label-based SCF translation path with structured region-based control flow using waveasm.while and waveasm.if ops.

Key changes:
- WhileOp/IfOp/ConditionOp/YieldOp implement RegionBranchOpInterface for structured loop and conditional control flow
- RegionBuilder translates scf.for -> waveasm.while with proper loop-carried values (induction var + iter_args as block arguments)
- LinearScanPass ties while-op block args, init args, iter args, and results to ensure consistent physical register assignment
- Liveness uses region structure directly for live range extension (no CFG backward dataflow needed)
- AssemblyEmitter lowers WhileOp to label + body + s_cbranch_scc1
- SGPR reservation driven by explicit PrecoloredSRegOp for ABI registers instead of WhileOp-gated blanket reservation
- Waitcnt insertion resets at WhileOp/IfOp/ConditionOp boundaries

Removed:
- Label-based SCF translation path (LoopContext, ControlFlowMode)
- StructuredControlFlow placeholder pass
- CFG/BasicBlock backward dataflow infrastructure
- BranchOp/CondBranchOp structured ops (waveasm.br/waveasm.cond_br)

All 63 e2e tests pass.