### PR TITLE
[water] only allow single-result exprs in bounds

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -1554,9 +1554,14 @@ static LogicalResult verifyReadWriteBounds(Location loc,
     }
 
     // Value type must be WaveExprListAttr.
-    if (!isa<wave::WaveExprListAttr>(value.getValue()))
+    auto exprListAttr = dyn_cast<wave::WaveExprListAttr>(value.getValue());
+    if (!exprListAttr)
       return emitError(loc) << "'bounds' values must be WaveExprListAttr, got "
                             << value.getValue();
+    if (exprListAttr.getRank() != 1) {
+      return emitError(loc)
+             << "'bounds' must only contain single-result expressions";
+    }
 
     knownSymbolNames.insert(value.getName().strref());
   }

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -479,6 +479,14 @@ func.func @bounds_wrong_type(%mem: !wave.tensor<[@N] of f32>) {
 
 // -----
 
+func.func @bounds_wrong_rank(%mem: !wave.tensor<[@N] of f32>) {
+  // expected-error @below {{'bounds' must only contain single-result expressions}}
+  wave.read %mem { bounds = #wave.read_write_bounds<{ N = #wave.expr_list<[#wave.symbol<"BLOCK_M">] -> (BLOCK_M * 64, BLOCK_M * 64)>}> } : (!wave.tensor<[@N] of f32>) -> !wave.tensor<[@N] of f32, <register>>
+  return
+}
+
+// -----
+
 func.func @read_index_multi_step(%mem: !wave.tensor<[@M, @N] of f32>) {
   // expected-error @below {{'index' has more than one entry with non-unit step}}
   // expected-note @below {{second non-unit step dimension: 1}}


### PR DESCRIPTION
Initially, we expected bounds to be co-indexed with the shape, but we moved towards symbol indexing instead so each expression defines bounds for an individual symbol.