### PR TITLE
[asm] Add pipelined double-buffering support with SGPR rotation

### DIFF
--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/pipelined-double-buffer.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/pipelined-double-buffer.mlir
@@ -1,0 +1,55 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s 2>&1 | FileCheck %s
+//
+// Test: Full assembly output for a pipelined double-buffer loop.
+// Verifies the SGPR rotation (swap) pattern in the generated assembly.
+//
+// The loop carries two memref iter_args (LDS buffers A and B) and swaps them
+// each iteration. The assembly must contain:
+// 1. s_mov_b32 initialization of the two SGPR offsets
+// 2. A loop label
+// 3. ds_read using one of the SGPR offsets
+// 4. s_mov_b32 rotation (3-instruction swap using a temporary)
+// 5. s_cbranch_scc1 back to the loop label
+
+module {
+  gpu.module @test_pipelined_double_buffer {
+
+    // CHECK-LABEL: pipelined_double_buffer:
+    gpu.func @pipelined_double_buffer(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c15 = arith.constant 15 : index
+      %c1 = arith.constant 1 : index
+
+      %lds = memref.alloc() : memref<8192xi8, 3>
+      %c0_byte = arith.constant 0 : index
+      %c4096_byte = arith.constant 4096 : index
+      %viewA = memref.view %lds[%c0_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+      %viewB = memref.view %lds[%c4096_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // Init: s_mov_b32 for both LDS offsets
+      // CHECK-DAG:  s_mov_b32 s{{[0-9]+}}, 0
+      // CHECK-DAG:  s_mov_b32 s{{[0-9]+}}, 4096
+      //
+      // Loop with ds_read using SGPR offset
+      // CHECK:      L_loop_0:
+      // CHECK:      ds_read_b64
+      //
+      // SGPR rotation: 3-instruction swap pattern
+      // CHECK:      s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_cbranch_scc1 L_loop_0
+      %result:3 = scf.for %i = %c0 to %c15 step %c1
+          iter_args(%acc = %acc_init, %curA = %viewA, %curB = %viewB)
+          -> (vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>) {
+        %data = vector.load %curA[%tidx, %c0] : memref<64x16xf16, 3>, vector<4xf16>
+        scf.yield %acc, %curB, %curA : vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>
+      }
+
+      // CHECK: s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/pipelined-gemm-g2s.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/pipelined-gemm-g2s.mlir
@@ -1,0 +1,95 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s 2>&1 | FileCheck %s
+//
+// End-to-end integration test: pipelined GEMM with g2s double-buffering.
+//
+// This test exercises the complete pipeline from MLIR to AMDGCN assembly:
+// 1. Prologue: SRD setup, first gather_to_lds loads
+// 2. Loop: interleaved ds_read (from "current" buffer via SGPR offset)
+//          + MFMA, with memref iter_args for ping-pong swap
+// 3. SGPR rotation (3-instruction swap per pair) before s_cbranch_scc1
+// 4. Epilogue: s_endpgm
+
+module {
+  gpu.module @test_pipelined_gemm_g2s {
+
+    // CHECK-LABEL: pipelined_gemm_g2s:
+    gpu.func @pipelined_gemm_g2s(
+        %src_a: memref<?xf16>,
+        %src_b: memref<?xf16>,
+        %tidx: index {llvm.mlir.workitem_id_x}
+    ) kernel {
+      %c0 = arith.constant 0 : index
+      %c15 = arith.constant 15 : index
+      %c1 = arith.constant 1 : index
+
+      // LDS allocation: two buffers for A, two for B
+      %lds = memref.alloc() : memref<8192xi8, 3>
+      %c0_byte = arith.constant 0 : index
+      %c2048_byte = arith.constant 2048 : index
+      %c4096_byte = arith.constant 4096 : index
+      %c6144_byte = arith.constant 6144 : index
+      %lds_a0 = memref.view %lds[%c0_byte][] : memref<8192xi8, 3> to memref<32x16xf16, 3>
+      %lds_a1 = memref.view %lds[%c2048_byte][] : memref<8192xi8, 3> to memref<32x16xf16, 3>
+      %lds_b0 = memref.view %lds[%c4096_byte][] : memref<8192xi8, 3> to memref<32x16xf16, 3>
+      %lds_b1 = memref.view %lds[%c6144_byte][] : memref<8192xi8, 3> to memref<32x16xf16, 3>
+
+      // === PROLOGUE: load first tile into buffer 0 ===
+      // CHECK: s_mov_b32 m0, 0
+      // CHECK: buffer_load_dword {{.*}} offen lds
+      "amdgpu.gather_to_lds"(%src_a, %tidx, %lds_a0, %c0, %c0) <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, transferType = vector<2xf16>}> : (memref<?xf16>, index, memref<32x16xf16, 3>, index, index) -> ()
+
+      // CHECK: s_mov_b32 m0, 4096
+      // CHECK: buffer_load_dword {{.*}} offen lds
+      "amdgpu.gather_to_lds"(%src_b, %tidx, %lds_b0, %c0, %c0) <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, transferType = vector<2xf16>}> : (memref<?xf16>, index, memref<32x16xf16, 3>, index, index) -> ()
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // === MAIN LOOP with double-buffered g2s ===
+      //
+      // CHECK: L_loop_0:
+      //
+      // ds_read from current A buffer (SGPR-carried offset)
+      // CHECK: ds_read_b64
+      //
+      // ds_read from current B buffer (SGPR-carried offset)
+      // CHECK: ds_read_b64
+      //
+      // MFMA
+      // CHECK: v_mfma_f32_16x16x16_f16
+      //
+      // SGPR rotation: two independent swap pairs (A pair + B pair)
+      // First swap pair (A buffers): tmp=s_a, s_a=s_a', s_a'=tmp
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // Second swap pair (B buffers): tmp=s_b, s_b=s_b', s_b'=tmp
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK-NEXT: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      //
+      // Branch back
+      // CHECK-NEXT: s_cbranch_scc1 L_loop_0
+      %result:5 = scf.for %i = %c0 to %c15 step %c1
+          iter_args(%acc = %acc_init, %cur_a = %lds_a0, %next_a = %lds_a1,
+                    %cur_b = %lds_b0, %next_b = %lds_b1)
+          -> (vector<4xf32>, memref<32x16xf16, 3>, memref<32x16xf16, 3>,
+              memref<32x16xf16, 3>, memref<32x16xf16, 3>) {
+
+        // Read from current buffers
+        %data_a = vector.load %cur_a[%tidx, %c0] : memref<32x16xf16, 3>, vector<4xf16>
+        %data_b = vector.load %cur_b[%tidx, %c0] : memref<32x16xf16, 3>, vector<4xf16>
+
+        // MFMA 16x16x16 f16: src is vector<4xf16>, acc is vector<4xf32>
+        %new_acc = "amdgpu.mfma"(%data_b, %data_a, %acc) <{abid = 0 : i32, blgp = #amdgpu<mfma_perm_b none>, blocks = 1 : i32, cbsz = 0 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32}> : (vector<4xf16>, vector<4xf16>, vector<4xf32>) -> vector<4xf32>
+
+        // Swap: next iteration reads from "next", writes to "current"
+        scf.yield %new_acc, %next_a, %cur_a, %next_b, %cur_b
+            : vector<4xf32>, memref<32x16xf16, 3>, memref<32x16xf16, 3>,
+              memref<32x16xf16, 3>, memref<32x16xf16, 3>
+      }
+
+      // CHECK: s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/g2s-prologue-epilogue.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/g2s-prologue-epilogue.mlir
@@ -1,0 +1,51 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: amdgpu.gather_to_lds outside of scf.for (prologue and epilogue).
+// In pipelined GEMM, the prologue loads the first tile into LDS before the
+// loop starts, and the epilogue may process the last tile after the loop.
+
+module {
+  gpu.module @test_g2s_prologue_epilogue {
+
+    // CHECK-LABEL: waveasm.program @g2s_prologue
+    gpu.func @g2s_prologue(
+        %src_buf: memref<?xf16>,
+        %tidx: index {llvm.mlir.workitem_id_x}
+    ) kernel {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c1 = arith.constant 1 : index
+
+      // Allocate LDS with two buffers
+      %lds = memref.alloc() : memref<8192xi8, 3>
+      %c0_byte = arith.constant 0 : index
+      %c4096_byte = arith.constant 4096 : index
+      %viewA = memref.view %lds[%c0_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+      %viewB = memref.view %lds[%c4096_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+
+      // === PROLOGUE: gather_to_lds before the loop ===
+      // Load first tile into viewA (offset 0)
+      // CHECK: waveasm.s_mov_b32_m0 %{{.*}} : !waveasm.imm<0>
+      // CHECK: waveasm.buffer_load_dword_lds
+      "amdgpu.gather_to_lds"(%src_buf, %tidx, %viewA, %c0, %c0) <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, transferType = vector<2xf16>}> : (memref<?xf16>, index, memref<64x16xf16, 3>, index, index) -> ()
+
+      // Load second prologue tile into viewB (offset 4096)
+      // CHECK: waveasm.s_mov_b32_m0 %{{.*}} : !waveasm.imm<4096>
+      // CHECK: waveasm.buffer_load_dword_lds
+      "amdgpu.gather_to_lds"(%src_buf, %tidx, %viewB, %c0, %c0) <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, transferType = vector<2xf16>}> : (memref<?xf16>, index, memref<64x16xf16, 3>, index, index) -> ()
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // Main loop (just yield for simplicity)
+      // CHECK: waveasm.loop
+      %result:3 = scf.for %i = %c0 to %c7 step %c1
+          iter_args(%acc = %acc_init, %curA = %viewA, %curB = %viewB)
+          -> (vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>) {
+        scf.yield %acc, %curB, %curA : vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>
+      }
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/pipelined-lds-load.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/pipelined-lds-load.mlir
@@ -1,0 +1,49 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: vector.load from LDS memref iter_args inside a pipelined loop.
+// The vector.load should use the SGPR-carried LDS base offset from the
+// memref iter_arg, not a static offset.
+
+module {
+  gpu.module @test_pipelined_lds_load {
+
+    // CHECK-LABEL: waveasm.program @pipelined_lds_read
+    gpu.func @pipelined_lds_read(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c1 = arith.constant 1 : index
+
+      // Allocate LDS with two buffers
+      %lds = memref.alloc() : memref<4096xi8, 3>
+      %c0_byte = arith.constant 0 : index
+      %c2048_byte = arith.constant 2048 : index
+      %viewA = memref.view %lds[%c0_byte][] : memref<4096xi8, 3> to memref<64x16xf16, 3>
+      %viewB = memref.view %lds[%c2048_byte][] : memref<4096xi8, 3> to memref<64x16xf16, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // CHECK: waveasm.loop
+      %result:3 = scf.for %i = %c0 to %c7 step %c1
+          iter_args(%acc = %acc_init, %curRead = %viewA, %curWrite = %viewB)
+          -> (vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>) {
+
+        // vector.load from the current read buffer (memref iter_arg)
+        // The SGPR-carried LDS base offset should be added to the address
+        // via v_add_u32 (not v_mov_b32 -- SGPRs go directly into VALU src).
+        //
+        // CHECK:      v_add_u32 {{.*}}, %arg2 : !waveasm.vreg, !waveasm.sreg
+        // CHECK-NEXT: ds_read_b64
+        %data = vector.load %curRead[%tidx, %c0] : memref<64x16xf16, 3>, vector<4xf16>
+
+        // Yield with swapped buffers
+        scf.yield %acc, %curWrite, %curRead : vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>
+      }
+
+      // Condition swaps: %arg3, %arg2 (B then A)
+      // CHECK: waveasm.condition {{.*}} iter_args({{.*}}, {{.*}}, %arg3, %arg2)
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-memref-iter-args.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scf-for-memref-iter-args.mlir
@@ -1,0 +1,66 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: scf.for with memref iter_args (LDS double-buffering) translated to
+// waveasm.loop with SGPR-carried LDS offsets.
+//
+// In pipelined GEMM, scf.for carries memref iter_args that swap each iteration
+// (ping-pong double buffering). The C++ backend must:
+// 1. Resolve each memref init arg to its LDS base offset (from memref.view)
+// 2. Materialize the offset as an SGPR (s_mov_b32)
+// 3. Pass the SGPR through the loop as an iter_arg
+// 4. At yield, resolve the swapped memref's offset for the condition iter_args
+
+module {
+  gpu.module @test_memref_iter_args {
+
+    // --- Two memref iter_args: double-buffer ping-pong ---
+    // The scf.for swaps viewA <-> viewB each iteration.
+    // CHECK-LABEL: waveasm.program @memref_double_buffer
+    gpu.func @memref_double_buffer() kernel {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c1 = arith.constant 1 : index
+
+      // Allocate LDS and create two views at different offsets
+      %lds = memref.alloc() : memref<8192xi8, 3>
+      %c0_byte = arith.constant 0 : index
+      %c4096_byte = arith.constant 4096 : index
+      %viewA = memref.view %lds[%c0_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+      %viewB = memref.view %lds[%c4096_byte][] : memref<8192xi8, 3> to memref<64x16xf16, 3>
+
+      // MFMA accumulator init
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // Loop with 3 iter_args: accumulator (vector), viewA (memref), viewB (memref)
+      // The memref iter_args should become SGPR-carried LDS offsets.
+      //
+      // Init: [IV=0, acc=vreg<4>, offsetA=sreg(0), offsetB=sreg(4096)]
+      //
+      // CHECK:      %[[IV_INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK:      %[[ACC_INIT:.*]] = waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+      // Memref A (offset 0) -> s_mov_b32 with immediate 0
+      // CHECK:      %[[OA_INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // Memref B (offset 4096) -> s_mov_b32 with immediate 4096
+      // CHECK:      %[[OB_INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<4096> -> !waveasm.sreg
+      //
+      // Loop with 4 iter_args: [IV, acc, offsetA, offsetB]
+      // CHECK:      %{{.*}}:4 = waveasm.loop (%[[IV:.*]] = %[[IV_INIT]], %[[ACC:.*]] = %[[ACC_INIT]], %[[OA:.*]] = %[[OA_INIT]], %[[OB:.*]] = %[[OB_INIT]])
+      // CHECK-SAME:   (!waveasm.sreg, !waveasm.vreg<4, 4>, !waveasm.sreg, !waveasm.sreg)
+      %result:3 = scf.for %i = %c0 to %c7 step %c1
+          iter_args(%acc = %acc_init, %curA = %viewA, %curB = %viewB)
+          -> (vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>) {
+        // Loop body would normally have vector.load, mfma, gather_to_lds, etc.
+        // For this test, just yield with swapped memrefs.
+
+        // Yield: swap viewA <-> viewB (double-buffer ping-pong)
+        scf.yield %acc, %curB, %curA : vector<4xf32>, memref<64x16xf16, 3>, memref<64x16xf16, 3>
+      }
+
+      // Condition should carry: [nextIV, acc, offsetB, offsetA] (swapped!)
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[ACC]], %[[OB]], %[[OA]]) : !waveasm.sreg, !waveasm.vreg<4, 4>, !waveasm.sreg, !waveasm.sreg
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}


### PR DESCRIPTION
Implement memref iter_arg handling for pipelined GEMM with g2s in the C++ WaveASM backend. When scf.for carries memref iter_args for double-buffering, the LDS base offsets are now materialized as SGPRs and rotated at the loop tail using s_mov_b32 swap sequences.

Key changes:
- RegionBuilder: detect LDS memref iter_args, resolve to SGPR offsets, propagate through block args, handle cross-swap at yield
- TranslateFromMLIR: use V_ADD_U32 directly with SGPR offsets in vector.load/store (V_MOV_B32 rejects SGPR sources)
- AMDGPUHandlers: handle dynamic SGPR-carried LDS base offsets in gather_to_lds m0 computation, prefer SALU when both operands are SGPRs
- LinearScanPass: fix block arg type propagation to use allocation mapping directly instead of condition iter_arg types (broken for cross-swap patterns)
- AssemblyEmitter: emit SGPR rotation copies at loop tail, detecting independent swap pairs and using 3-instruction swap with temporary