### PR TITLE
keep track of reshape slicing in expansion

### DIFF
--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -1246,13 +1246,13 @@ def test_chained_gemm_32x32x8():
     # CHECK: %read_2_shared_M:0_N:0_K2:3
     # CHECK-SAME: (args = (%v, 4, None, (), None, MemoryAccessFlags.NONE, None, None, None)
     # CHECK: %reshape_M:0_N:0_K2:0
-    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0})
+    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0}, 0, 4)
     # CHECK: %reshape_M:0_N:0_K2:1
-    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0})
+    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0}, 1, 4)
     # CHECK: %reshape_M:0_N:0_K2:2
-    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0})
+    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0}, 2, 4)
     # CHECK: %reshape_M:0_N:0_K2:3
-    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0})
+    # CHECK-SAME: (args = ([%cast_M:0_K2:0], {K2: 32, M: 32, K1: 8, B: 0}, 3, 4)
     # CHECK: %mma_1_M:0_N:0_K2:0
     # CHECK-SAME: (args = (%reshape_M:0_N:0_K2:0, %read_2_shared_M:0_N:0_K2:0, %acc_M:0_N:0_K2:0, MMAType.F32_32x32x8_F16)
     # CHECK: %mma_1_M:0_N:0_K2:1

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -3262,10 +3262,16 @@ class Reshape(CustomOp, ABC):
     Represents a reshape operation that reshapes
     vectors along the same dimension.
 
+    Conceptually, this either concatenates multiple vectors into a single vector
+    or extracts slices from the vector. Since this operation appears after
+    graph expansion, it never actually has multiple results: each expanded
+    instance of this operation extracts a single slice.
     """
 
     args: fx.Node | Sequence[fx.Node]
     target_vector_shape: dict[IndexSymbol, int]
+    logical_slice: int = 0
+    num_slices: int = 1
 
     @property
     def indexing_dims(self) -> list[IndexExpr]:


### PR DESCRIPTION
Instead of leaking expansion-related information all the way down to codegen, compute it during expansion where it is readily available and store it on the node itself. Then just use it during codegen.

Reshape is conceptually two different kinds of operations: vector concatenation or vector splitting into multiple sub-vectors. In the latter case, since expansion has already happened, codegen needs to know which of the small slices each individual reshape corresponds to. It shouldn't need to inspect the guts of the expansion-specific attributes for that.

It is unclear why this wasn't included into the index sequence originally and a quick analysis shows a discrepancy between the index sequence currently associated with reshape nodes and the logical offset: the offests and the sizes appear scaled in the index expression compared to the offsets needed in the vector and the size thereof. There is also no trivial way of extracting this information from the offset since it contains a more complex expression.  Keeping that as is to avoid disturbing the fragile logic of index propagation.