### PR TITLE
Fix function name from _symbol_name_to_attribute to symbol_name_to_attribtue

### DIFF
--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -727,7 +727,7 @@ def _emit_ops_from_graph(
                     mlir_op = op_builder(
                         result_type,
                         *create_mlir_operands(),
-                        dim=_symbol_name_to_attribute(node.dim.name),
+                        dim=symbol_name_to_attribute(node.dim.name),
                         elements_per_thread=node.elements_per_thread,
                     )
                 elif isinstance(node, Shuffle):


### PR DESCRIPTION
Race condition in merging PRs: one added a new use, another renamed the function.