### PR TITLE
[wave2water] sort symbols on export

### DIFF
--- a/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
+++ b/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
@@ -140,9 +140,11 @@ def preprocess_symbols(
       2. replacing ITER_SYMBOL_NAME_WAVE_PREFIX (`$ARG`) prefix of argument
          symbols (e.g. `ARG0`) by ITER_SYMBOL_NAME_WATER_PREFIX (`_Iter_`) to
          match dialect expectations.
+      3. sorting symbols by name for deterministic symbol order as they may be
+         coming from, e.g., a set.
     """
     result = {}
-    for sym in symbols:
+    for sym in sorted(symbols, key=lambda s: s.name):
         if sym.name.startswith(ITER_SYMBOL_NAME_WAVE_PREFIX):
             new_name = sym.name.replace(
                 ITER_SYMBOL_NAME_WAVE_PREFIX, ITER_SYMBOL_NAME_WATER_PREFIX


### PR DESCRIPTION
Sort symbols by name while preprocessing them. This ensure the order in which they are printed in textual tests is deterministic. While this wasn't a correctness problem since we build the expression maps from a full dictionary, compilers must be deterministic in output for debugging sanity.

Note that Python dictionaries have deterministic order, that of insertion since 3.7.