### PR TITLE
partially fix wrong types in reshape

### DIFF
--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -3359,10 +3359,13 @@ class Reshape(CustomOp, ABC):
 
     @property
     def indexing_dims(self) -> list[IndexExpr]:
-        return get_custom(_to_sequence(self.args)[0]).indexing_dims
+        if not self.type:
+            return get_custom(_to_sequence(self.args)[0]).indexing_dims
+        return list(self.type.symbolic_shape)
 
     def infer_type(self, *args):
-        self.type = get_custom(_to_sequence(self.args)[0]).type
+        if not self.type:
+            self.type = get_custom(_to_sequence(self.args)[0]).type
 
 
 @define_op("tensor_load_to_lds")


### PR DESCRIPTION
Reshape op inherits its type from its first argument, which doesn't make
sense for concatenation-style reshapes since those may add a new
dimension, the one along which concatenation happens. (The symmetric
case is beyond the point here). Allow creators of these operations to
directly set the type that won't be overridden later. Use this
functionality in in-thread transpose that creates concatenation-style
reshapes as a partial workaround for #873. Otherwise we could have
considered reconstructing the type from the target vector shape, though
it is unclear whether the order of dimensions is guaranteed in that.