### PR TITLE
[wave2water] support select op

### DIFF
--- a/lit_tests/kernel/wave/mlir_converter.py
+++ b/lit_tests/kernel/wave/mlir_converter.py
@@ -478,6 +478,7 @@ def mlir_converter_select():
     # CHECK: %[[READ_B:.*]] = wave.read
     # CHECK: %[[READ_C:.*]] = wave.read
     # CHECK: %[[SELECT:.*]] = wave.select %[[READ_C]], %[[READ_A]], %[[READ_B]]
+    # CHECK-SAME: (!wave.tensor<[@M] of i1, <register>>
     # CHECK: wave.write %[[SELECT]]
 
 

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -76,7 +76,6 @@ from wave_lang.kernel.ops.wave_ops import (
     Placeholder,
     Placeholder,
     ReduceOp as Reduce,
-    SelectOp,
     SelfIndex,
     SharedMemoryBarrier,
     ShuffleOp as Shuffle,
@@ -194,6 +193,7 @@ DATATYPE_MAP: dict[str, Callable[[], ir.Type]] = {
     "f32": ir.F32Type.get,
     "f64": ir.F64Type.get,
     "i1": lambda: ir.IntegerType.get_signless(1),
+    # 'bool' is an alias for 'i1'.
     "bool": lambda: ir.IntegerType.get_signless(1),
     "i8": lambda: ir.IntegerType.get_signless(8),
     "i16": lambda: ir.IntegerType.get_signless(16),


### PR DESCRIPTION
The op was added previously but its translation wasn't. This requires
supporting "bool" dtypes that are secretly "i1".