### PR TITLE
[asm] Fix critical correctness bugs and add missing op handlers

### DIFF
--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
@@ -998,8 +998,21 @@ def WaveASM_S_BARRIER : WAVEASMOp<"s_barrier", [WaveASM_ControlFlowOp]> {
   let assemblyFormat = "attr-dict";
 }
 
-def WaveASM_S_NOP : WaveASM_CountedWaitOp<"s_nop"> {
+// Ops that take a single integer operand but are not memory waits.
+// Structurally identical to CountedWaitOp (same arguments and format)
+// but semantically distinct: these are scalar control ops, not waitcnts.
+class WaveASM_CountedScalarOp<string mnemonic> :
+  WAVEASMOp<mnemonic, [WaveASM_ControlFlowOp]> {
+  let arguments = (ins I32Attr:$count);
+  let assemblyFormat = "$count attr-dict";
+}
+
+def WaveASM_S_NOP : WaveASM_CountedScalarOp<"s_nop"> {
   let summary = "No operation (wait cycles)";
+}
+
+def WaveASM_S_SETPRIO : WaveASM_CountedScalarOp<"s_setprio"> {
+  let summary = "Set wave priority level (0=default, 1-3=elevated)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
@@ -119,6 +119,12 @@ private:
   llvm::SmallVector<std::string>
   generateOpWithLiteralHandling(mlir::Operation *op);
 
+  /// Emit a v_mov_b32 to materialize a literal into scratch VGPR, then
+  /// emit the instruction with the scratch register replacing the literal.
+  void emitMaterializedLiteral(llvm::SmallVector<std::string> &lines,
+                               mlir::Operation *op, llvm::StringRef mnemonic,
+                               int literalOperandIdx, int64_t literalValue);
+
   /// Generate code for a label op
   std::string generateLabel(LabelOp labelOp);
 

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegAlloc.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegAlloc.h
@@ -78,6 +78,11 @@ public:
     }
   }
 
+  /// Check if a register is currently in the free list
+  bool isFree(int64_t reg) const {
+    return std::find(freeList.begin(), freeList.end(), reg) != freeList.end();
+  }
+
   /// Reserve a specific register (for precoloring)
   void reserve(int64_t reg, int64_t size) {
     for (int64_t i = 0; i < size; ++i) {

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -518,6 +518,12 @@ public:
   /// Get the total LDS size requirement
   int64_t getTotalLDSSize() const { return totalLDSSize; }
 
+  /// Get the current LDS allocation byte offset (for typed allocs)
+  int64_t getLDSAllocOffset() const { return ldsAllocOffset; }
+
+  /// Advance the LDS allocation offset by the given number of bytes
+  void advanceLDSAllocOffset(int64_t size) { ldsAllocOffset += size; }
+
   //===--------------------------------------------------------------------===//
   // System Register Usage Tracking (for kernel descriptor metadata)
   //===--------------------------------------------------------------------===//
@@ -643,6 +649,10 @@ private:
   int64_t nextSwizzleSRDIndex =
       -1; // Will be computed in emitSRDPrologue(), after all regular SRDs
   int64_t totalLDSSize = 0; // Total LDS allocation size in bytes
+  // Running byte offset for typed LDS allocations (pattern b in
+  // handleMemRefAlloc). Reset implicitly: a fresh TranslationContext is
+  // created per gpu.func in translateModule / createProgramFromFunc.
+  int64_t ldsAllocOffset = 0;
   bool srdPrologueEmitted = false;
   // System register usage tracking
   bool usesWorkgroupIdX = false;

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/CMakeLists.txt
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,8 @@ add_mlir_dialect_library(MLIRWaveASMTransforms
   Ticketing.cpp
   HazardMitigation.cpp
   AssemblyEmitter.cpp
+  MetadataEmitter.cpp
+  LiteralMaterialization.cpp
   TranslateFromMLIR.cpp
   RegionBuilder.cpp
   ScopedCSE.cpp

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/LiteralMaterialization.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/LiteralMaterialization.cpp
@@ -1,0 +1,152 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// AMDGCN Literal Materialization
+//
+// Handles immediate operands outside the inline constant range [-16, 64]
+// for VALU instructions. VOP2 instructions require the literal in src0;
+// VOP3+ instructions need a scratch VGPR via v_mov_b32. SALU instructions
+// accept 32-bit literals natively.
+//===----------------------------------------------------------------------===//
+
+#include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Dialect/WaveASMTypes.h"
+#include "waveasm/Target/AMDGCN/RegisterInfo.h"
+#include "waveasm/Transforms/AssemblyEmitter.h"
+#include "waveasm/Transforms/RegAlloc.h"
+
+#include "llvm/ADT/StringSet.h"
+
+using namespace mlir;
+
+namespace waveasm {
+
+// AMDGCN inline constants: -16 to 64 (inclusive), plus special float values.
+static bool isInlineConstant(int64_t val) {
+  if (val >= -16 && val <= 64)
+    return true;
+  return false;
+}
+
+static const llvm::StringSet<> &getVOP2Instructions() {
+  static const llvm::StringSet<> kVOP2 = {
+      "v_add_u32",     "v_sub_u32", "v_subrev_u32",  "v_and_b32",
+      "v_or_b32",      "v_xor_b32", "v_lshlrev_b32", "v_lshrrev_b32",
+      "v_ashrrev_i32", "v_max_u32", "v_min_u32",     "v_add_i32",
+      "v_sub_i32",
+  };
+  return kVOP2;
+}
+
+static bool needsLiteralMaterialization(llvm::StringRef mnemonic) {
+  if (!mnemonic.starts_with("v_"))
+    return false;
+  if (mnemonic == "v_mov_b32")
+    return false;
+  if (mnemonic.starts_with("v_cmp_"))
+    return false;
+  if (getVOP2Instructions().count(mnemonic))
+    return false;
+  return true;
+}
+
+llvm::SmallVector<std::string>
+KernelGenerator::generateOpWithLiteralHandling(Operation *op) {
+  llvm::SmallVector<std::string> lines;
+
+  llvm::StringRef opName = op->getName().getStringRef();
+  llvm::StringRef mnemonic = opName;
+  if (opName.starts_with("waveasm.")) {
+    mnemonic = opName.drop_front(8);
+  }
+
+  bool hasNonInlineLiteral = false;
+  int64_t literalValue = 0;
+  int literalOperandIdx = -1;
+
+  for (int i = 0; i < static_cast<int>(op->getNumOperands()); ++i) {
+    auto [isLiteral, val] = getLiteralValue(op->getOperand(i));
+    if (isLiteral && !isInlineConstant(val)) {
+      hasNonInlineLiteral = true;
+      literalValue = val;
+      literalOperandIdx = i;
+      break;
+    }
+  }
+
+  if (!hasNonInlineLiteral) {
+    if (auto line = generateOp(op)) {
+      lines.push_back(*line);
+    }
+    return lines;
+  }
+
+  // SALU instructions support 32-bit literals natively
+  if (mnemonic.starts_with("s_")) {
+    if (auto line = generateOp(op)) {
+      lines.push_back(*line);
+    }
+    return lines;
+  }
+
+  // VOP3+ instructions need literal materialization into scratch VGPR
+  if (needsLiteralMaterialization(mnemonic)) {
+    emitMaterializedLiteral(lines, op, mnemonic, literalOperandIdx,
+                            literalValue);
+    return lines;
+  }
+
+  // VOP2: literal MUST be in src0. Swap for commutative ops, materialize
+  // otherwise.
+  bool isCommutative = op->hasTrait<mlir::OpTrait::IsCommutative>();
+
+  if (literalOperandIdx == 0) {
+    if (auto line = generateOp(op)) {
+      lines.push_back(*line);
+    }
+    return lines;
+  }
+
+  if (literalOperandIdx == 1 && isCommutative && op->getNumOperands() == 2) {
+    llvm::SmallVector<std::string> operands;
+    for (Value result : op->getResults()) {
+      operands.push_back(resolveValue(result));
+    }
+    operands.push_back(std::to_string(literalValue));
+    operands.push_back(resolveValue(op->getOperand(0)));
+    lines.push_back(formatter.format(mnemonic, operands));
+    return lines;
+  }
+
+  emitMaterializedLiteral(lines, op, mnemonic, literalOperandIdx, literalValue);
+  return lines;
+}
+
+void KernelGenerator::emitMaterializedLiteral(
+    llvm::SmallVector<std::string> &lines, Operation *op,
+    llvm::StringRef mnemonic, int literalOperandIdx, int64_t literalValue) {
+  std::string scratchReg = formatVGPRRange(kScratchVGPR, 1);
+  lines.push_back("  v_mov_b32 " + scratchReg + ", " +
+                  std::to_string(literalValue));
+
+  llvm::SmallVector<std::string> operands;
+  for (Value result : op->getResults()) {
+    operands.push_back(resolveValue(result));
+  }
+  for (int i = 0; i < static_cast<int>(op->getNumOperands()); ++i) {
+    if (i == literalOperandIdx) {
+      operands.push_back(scratchReg);
+    } else {
+      operands.push_back(resolveValue(op->getOperand(i)));
+    }
+  }
+
+  lines.push_back(formatter.format(mnemonic, operands));
+  peakVGPRs = std::max(peakVGPRs, kScratchVGPR + 1);
+}
+
+} // namespace waveasm

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/MetadataEmitter.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/MetadataEmitter.cpp
@@ -1,0 +1,347 @@
+// Copyright 2025 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// Instruction Formatter and Metadata Emitter
+//
+// InstructionFormatter: formats individual AMDGCN assembly instructions.
+// MetadataEmitter: emits kernel prologue (.text, symbol), epilogue (kernel
+//   descriptor, YAML metadata) for AMDGCN assembly output.
+//===----------------------------------------------------------------------===//
+
+#include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Dialect/WaveASMTypes.h"
+#include "waveasm/Transforms/AssemblyEmitter.h"
+
+using namespace mlir;
+
+namespace waveasm {
+
+//===----------------------------------------------------------------------===//
+// Instruction Formatter Implementation
+//===----------------------------------------------------------------------===//
+
+std::string InstructionFormatter::format(llvm::StringRef name,
+                                         llvm::ArrayRef<std::string> operands) {
+  std::string result = "  " + name.str();
+
+  if (!operands.empty()) {
+    result += " ";
+    for (size_t i = 0; i < operands.size(); ++i) {
+      if (i > 0)
+        result += ", ";
+      result += operands[i];
+    }
+  }
+
+  return result;
+}
+
+std::string InstructionFormatter::formatLabel(llvm::StringRef label) {
+  return label.str() + ":";
+}
+
+std::string InstructionFormatter::formatComment(llvm::StringRef text) {
+  return "  ; " + text.str();
+}
+
+std::string InstructionFormatter::formatWaitcnt(std::optional<int64_t> vmcnt,
+                                                std::optional<int64_t> lgkmcnt,
+                                                std::optional<int64_t> expcnt) {
+  std::string result = "  s_waitcnt";
+  llvm::SmallVector<std::string> counts;
+
+  if (vmcnt.has_value()) {
+    counts.push_back("vmcnt(" + std::to_string(*vmcnt) + ")");
+  }
+  if (lgkmcnt.has_value()) {
+    counts.push_back("lgkmcnt(" + std::to_string(*lgkmcnt) + ")");
+  }
+  if (expcnt.has_value()) {
+    counts.push_back("expcnt(" + std::to_string(*expcnt) + ")");
+  }
+
+  if (!counts.empty()) {
+    result += " ";
+    for (size_t i = 0; i < counts.size(); ++i) {
+      if (i > 0)
+        result += " & ";
+      result += counts[i];
+    }
+  }
+
+  return result;
+}
+
+std::string InstructionFormatter::formatBarrier() { return "  s_barrier"; }
+
+std::string InstructionFormatter::formatEndpgm() { return "  s_endpgm"; }
+
+std::string InstructionFormatter::formatRaw(llvm::StringRef text) {
+  return "  " + text.str();
+}
+
+//===----------------------------------------------------------------------===//
+// Metadata Emitter Implementation
+//===----------------------------------------------------------------------===//
+
+MetadataEmitter::MetadataEmitter(ProgramOp program, TargetAttrInterface target)
+    : program(program), target(target) {}
+
+llvm::SmallVector<std::string> MetadataEmitter::emitPrologue() {
+  llvm::SmallVector<std::string> lines;
+
+  lines.push_back(target.getTargetDirective().str());
+  lines.push_back("");
+  lines.push_back(".text");
+  lines.push_back("");
+
+  std::string symName = program.getSymName().str();
+  lines.push_back(".protected " + symName);
+  lines.push_back(".globl " + symName);
+  lines.push_back(".p2align 8");
+  lines.push_back(".type " + symName + ",@function");
+  lines.push_back(symName + ":");
+
+  return lines;
+}
+
+llvm::SmallVector<std::string> MetadataEmitter::emitEpilogue(int64_t peakVGPRs,
+                                                             int64_t peakSGPRs,
+                                                             int64_t ldsSize) {
+  llvm::SmallVector<std::string> lines;
+
+  auto descriptor = emitKernelDescriptor(peakVGPRs, peakSGPRs, ldsSize);
+  lines.append(descriptor.begin(), descriptor.end());
+  lines.push_back("");
+
+  auto metadata = emitMetadataYAML(peakVGPRs, peakSGPRs, ldsSize);
+  lines.append(metadata.begin(), metadata.end());
+
+  return lines;
+}
+
+/// Scan program operations to detect system register usage
+static void scanSystemRegisterUsage(ProgramOp program, bool &usesWorkgroupIdX,
+                                    bool &usesWorkgroupIdY,
+                                    bool &usesWorkgroupIdZ,
+                                    bool &usesWorkitemId) {
+  usesWorkgroupIdX = false;
+  usesWorkgroupIdY = false;
+  usesWorkgroupIdZ = false;
+  usesWorkitemId = false;
+
+  auto targetAttr = program.getTarget();
+  auto targetKind = targetAttr.getTargetKind();
+  bool isGfx950 = llvm::isa<GFX950TargetAttr>(targetKind);
+
+  int64_t numArgs = 2;
+  if (auto numArgsAttr =
+          program->getAttrOfType<IntegerAttr>("num_kernel_args")) {
+    numArgs = numArgsAttr.getInt();
+  }
+
+  int64_t userSgprCount = 2;
+  if (isGfx950) {
+    userSgprCount = 2 + numArgs * 2;
+  }
+
+  int64_t wgIdXIndex = userSgprCount;
+  int64_t wgIdYIndex = userSgprCount + 1;
+  int64_t wgIdZIndex = userSgprCount + 2;
+
+  program.walk([&](Operation *op) {
+    if (auto precolored = dyn_cast<PrecoloredSRegOp>(op)) {
+      int64_t idx = precolored.getIndex();
+      int64_t size = precolored.getSize();
+      if (size == 1) {
+        if (idx == wgIdXIndex)
+          usesWorkgroupIdX = true;
+        else if (idx == wgIdYIndex)
+          usesWorkgroupIdY = true;
+        else if (idx == wgIdZIndex)
+          usesWorkgroupIdZ = true;
+      }
+    }
+  });
+}
+
+llvm::SmallVector<std::string>
+MetadataEmitter::emitKernelDescriptor(int64_t peakVGPRs, int64_t peakSGPRs,
+                                      int64_t ldsSize) {
+  llvm::SmallVector<std::string> lines;
+  std::string symName = program.getSymName().str();
+
+  bool usesWorkgroupIdX, usesWorkgroupIdY, usesWorkgroupIdZ, usesWorkitemId;
+  scanSystemRegisterUsage(program, usesWorkgroupIdX, usesWorkgroupIdY,
+                          usesWorkgroupIdZ, usesWorkitemId);
+
+  lines.push_back("");
+  lines.push_back(".section .rodata,#alloc");
+  lines.push_back(".p2align 6");
+  lines.push_back(".amdhsa_kernel " + symName);
+
+  int64_t ldsBlocks = (ldsSize + 127) / 128;
+  lines.push_back("  .amdhsa_group_segment_fixed_size " +
+                  std::to_string(ldsBlocks * 128));
+  lines.push_back("  .amdhsa_private_segment_fixed_size 0");
+
+  auto targetAttr = program.getTarget();
+  auto targetKind = targetAttr.getTargetKind();
+  int64_t preloadLength = program.getKernargPreloadLength();
+  bool usePreloading = llvm::isa<GFX950TargetAttr>(targetKind);
+
+  if (usePreloading && preloadLength == 0) {
+    int64_t numArgs = 2;
+    if (auto numArgsAttr =
+            program->getAttrOfType<IntegerAttr>("num_kernel_args")) {
+      numArgs = numArgsAttr.getInt();
+    }
+    preloadLength = numArgs * 2;
+  }
+
+  int64_t userSgprCount = 2;
+  if (usePreloading && preloadLength > 0) {
+    userSgprCount = 2 + preloadLength;
+  }
+
+  lines.push_back("  .amdhsa_user_sgpr_count " + std::to_string(userSgprCount));
+  lines.push_back("  .amdhsa_user_sgpr_dispatch_ptr 0");
+  lines.push_back("  .amdhsa_user_sgpr_queue_ptr 0");
+  lines.push_back("  .amdhsa_user_sgpr_kernarg_segment_ptr 1");
+  lines.push_back("  .amdhsa_user_sgpr_dispatch_id 0");
+
+  if (usePreloading && preloadLength > 0) {
+    lines.push_back("  .amdhsa_user_sgpr_kernarg_preload_length " +
+                    std::to_string(preloadLength));
+    lines.push_back("  .amdhsa_user_sgpr_kernarg_preload_offset 0");
+  }
+
+  lines.push_back("  .amdhsa_user_sgpr_private_segment_size 0");
+  lines.push_back("  .amdhsa_uses_dynamic_stack 0");
+  lines.push_back("  .amdhsa_enable_private_segment 0");
+
+  int64_t vgprGranularity = 4;
+  if (llvm::isa<GFX942TargetAttr, GFX950TargetAttr>(targetKind)) {
+    vgprGranularity = 8;
+  }
+  int64_t nextFreeVGPR =
+      ((peakVGPRs + vgprGranularity - 1) / vgprGranularity) * vgprGranularity;
+
+  int64_t sgprGranularity = 8;
+  int64_t nextFreeSGPR =
+      ((peakSGPRs + sgprGranularity - 1) / sgprGranularity) * sgprGranularity;
+  if (llvm::isa<GFX942TargetAttr, GFX950TargetAttr>(targetKind)) {
+    nextFreeSGPR = std::min(nextFreeSGPR, int64_t(102));
+  }
+
+  if (llvm::isa<GFX942TargetAttr, GFX950TargetAttr>(targetKind)) {
+    int64_t accumOffset = std::max(int64_t(4), ((nextFreeVGPR + 3) / 4) * 4);
+    lines.push_back("  .amdhsa_accum_offset " + std::to_string(accumOffset));
+  }
+
+  lines.push_back("  .amdhsa_next_free_vgpr " + std::to_string(nextFreeVGPR));
+  lines.push_back("  .amdhsa_next_free_sgpr " + std::to_string(nextFreeSGPR));
+
+  lines.push_back("  .amdhsa_system_sgpr_workgroup_id_x " +
+                  std::to_string(usesWorkgroupIdX ? 1 : 0));
+  lines.push_back("  .amdhsa_system_sgpr_workgroup_id_y " +
+                  std::to_string(usesWorkgroupIdY ? 1 : 0));
+  lines.push_back("  .amdhsa_system_sgpr_workgroup_id_z " +
+                  std::to_string(usesWorkgroupIdZ ? 1 : 0));
+
+  int64_t systemVgprWorkitemId = 0;
+  auto workgroupSize = program.getWorkgroupSize();
+  if (workgroupSize.has_value() && workgroupSize->size() >= 2) {
+    int64_t wgY = 1, wgZ = 1;
+    if (auto intAttr = dyn_cast<IntegerAttr>((*workgroupSize)[1])) {
+      wgY = intAttr.getInt();
+    }
+    if (workgroupSize->size() >= 3) {
+      if (auto intAttr = dyn_cast<IntegerAttr>((*workgroupSize)[2])) {
+        wgZ = intAttr.getInt();
+      }
+    }
+    if (wgY > 1 || wgZ > 1) {
+      systemVgprWorkitemId = 1;
+    }
+  }
+  lines.push_back("  .amdhsa_system_vgpr_workitem_id " +
+                  std::to_string(systemVgprWorkitemId));
+
+  lines.push_back("  .amdhsa_float_denorm_mode_32 3");
+  lines.push_back("  .amdhsa_float_denorm_mode_16_64 3");
+
+  lines.push_back(".end_amdhsa_kernel");
+
+  return lines;
+}
+
+llvm::SmallVector<std::string>
+MetadataEmitter::emitMetadataYAML(int64_t peakVGPRs, int64_t peakSGPRs,
+                                  int64_t ldsSize) {
+  llvm::SmallVector<std::string> lines;
+  std::string symName = program.getSymName().str();
+
+  lines.push_back(".amdgpu_metadata");
+  lines.push_back("---");
+  lines.push_back("amdhsa.version:");
+  lines.push_back("  - 1");
+  lines.push_back("  - 2");
+  lines.push_back("amdhsa.kernels:");
+  lines.push_back("  - .name: " + symName);
+  lines.push_back("    .symbol: " + symName + ".kd");
+
+  int64_t numArgs = 2;
+  if (auto numArgsAttr =
+          program->getAttrOfType<IntegerAttr>("num_kernel_args")) {
+    numArgs = numArgsAttr.getInt();
+  } else {
+    int64_t kernargPreload = program.getKernargPreloadLength();
+    if (kernargPreload > 0) {
+      numArgs = kernargPreload / 2;
+    }
+  }
+  int64_t kernargSize = numArgs * 8;
+  lines.push_back("    .args:");
+  for (int64_t i = 0; i < numArgs; ++i) {
+    lines.push_back("      - .name:       arg" + std::to_string(i) + "_ptr");
+    lines.push_back("        .offset:     " + std::to_string(i * 8));
+    lines.push_back("        .size:       8");
+    lines.push_back("        .value_kind: global_buffer");
+    lines.push_back("        .value_type: 'i8*'");
+  }
+
+  lines.push_back("    .kernarg_segment_size: " + std::to_string(kernargSize));
+  lines.push_back("    .group_segment_fixed_size: " + std::to_string(ldsSize));
+  lines.push_back("    .private_segment_fixed_size: 0");
+  lines.push_back("    .kernarg_segment_align: 8");
+
+  int64_t waveSizeVal = target.getDefaultWaveSize();
+  lines.push_back("    .wavefront_size: " + std::to_string(waveSizeVal));
+  lines.push_back("    .sgpr_count: " + std::to_string(peakSGPRs));
+  lines.push_back("    .vgpr_count: " + std::to_string(peakVGPRs));
+
+  auto workgroupSize = program.getWorkgroupSize();
+  int64_t maxFlatSize = 256;
+  if (workgroupSize.has_value()) {
+    maxFlatSize = 1;
+    for (Attribute attr : *workgroupSize) {
+      if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+        maxFlatSize *= intAttr.getInt();
+      }
+    }
+  }
+  lines.push_back("    .max_flat_workgroup_size: " +
+                  std::to_string(maxFlatSize));
+
+  lines.push_back("...");
+  lines.push_back(".end_amdgpu_metadata");
+
+  return lines;
+}
+
+} // namespace waveasm

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/TranslateFromMLIR.cpp
@@ -1277,6 +1277,8 @@ LogicalResult handleSCFYield(Operation *op, TranslationContext &ctx);
 
 // From AMDGPUHandlers.cpp
 LogicalResult handleAMDGPULdsBarrier(Operation *op, TranslationContext &ctx);
+LogicalResult handleAMDGPUMemoryCounterWait(Operation *op,
+                                            TranslationContext &ctx);
 LogicalResult handleAMDGPUMfma(Operation *op, TranslationContext &ctx);
 LogicalResult handleAMDGPUScaledMfma(Operation *op, TranslationContext &ctx);
 LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx);
@@ -1284,6 +1286,8 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx);
 LogicalResult handleRawBufferLoad(Operation *op, TranslationContext &ctx);
 LogicalResult handleRawBufferStore(Operation *op, TranslationContext &ctx);
 LogicalResult handleReadFirstLane(Operation *op, TranslationContext &ctx);
+LogicalResult handleROCDLSBarrier(Operation *op, TranslationContext &ctx);
+LogicalResult handleROCDLSetPrio(Operation *op, TranslationContext &ctx);
 LogicalResult handleSWaitcnt(Operation *op, TranslationContext &ctx);
 
 //===----------------------------------------------------------------------===//
@@ -1426,6 +1430,7 @@ void OpHandlerRegistry::registerDefaultHandlers(mlir::MLIRContext *ctx) {
 
   // AMDGPU dialect
   REGISTER_HANDLER(amdgpu::LDSBarrierOp, handleAMDGPULdsBarrier);
+  REGISTER_HANDLER(amdgpu::MemoryCounterWaitOp, handleAMDGPUMemoryCounterWait);
   REGISTER_HANDLER(amdgpu::MFMAOp, handleAMDGPUMfma);
   REGISTER_HANDLER(amdgpu::ScaledMFMAOp, handleAMDGPUScaledMfma);
   REGISTER_HANDLER(amdgpu::FatRawBufferCastOp, handleFatRawBufferCast);
@@ -1435,6 +1440,8 @@ void OpHandlerRegistry::registerDefaultHandlers(mlir::MLIRContext *ctx) {
 
   // ROCDL dialect
   REGISTER_HANDLER(ROCDL::ReadfirstlaneOp, handleReadFirstLane);
+  REGISTER_HANDLER(ROCDL::SBarrierOp, handleROCDLSBarrier);
+  REGISTER_HANDLER(ROCDL::SetPrioOp, handleROCDLSetPrio);
   REGISTER_HANDLER(ROCDL::SWaitcntOp, handleSWaitcnt);
 
   // IREE/Stream dialect (unregistered operations)

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-waitcnt.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-waitcnt.mlir
@@ -99,11 +99,13 @@ waveasm.program @existing_waitcnt_observed target = #waveasm.target<#waveasm.gfx
   // CHECK: waveasm.buffer_load_dword
   %load1 = waveasm.buffer_load_dword %srd, %voff0 : !waveasm.psreg<0, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
 
-  // Pre-existing waitcnt - pass should observe this and not emit redundant waits
+  // Pre-existing waitcnt - pass observes this and knows VMEM is drained.
+  // No LGKM ops were issued, so barrier needs no additional lgkmcnt wait.
   // CHECK: waveasm.s_waitcnt_vmcnt 0
   waveasm.s_waitcnt_vmcnt 0
 
-  // Barrier follows - no additional waitcnt needed since vmcnt(0) already observed
+  // Barrier follows - no additional waitcnt needed since vmcnt(0) already
+  // observed and no LGKM operations are outstanding.
   // CHECK-NOT: waveasm.s_waitcnt
   // CHECK: waveasm.s_barrier
   waveasm.s_barrier

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/salu-vop2-literals.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/salu-vop2-literals.mlir
@@ -1,0 +1,51 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s | FileCheck %s
+//
+// Test: SALU and VOP2 literal operand handling.
+//
+// SALU instructions support 32-bit literals natively -- no materialization
+// into scratch VGPR needed.
+//
+// VOP2 instructions require the literal in src0.  For commutative ops with
+// the literal in src1, the emitter swaps operands.  For non-commutative ops
+// it falls back to scratch VGPR materialization.
+
+// CHECK-LABEL: salu_literal_test:
+
+waveasm.program @salu_literal_test target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+
+  // SALU with large literal: should emit directly, no v_mov_b32
+  // CHECK-NOT: v_mov_b32
+  // CHECK: s_add_u32 s{{[0-9]+}}, s0, 4096
+  %c4096 = waveasm.constant 4096 : !waveasm.imm<4096>
+  %r1 = waveasm.s_add_u32 %s0, %c4096 : !waveasm.psreg<0>, !waveasm.imm<4096> -> !waveasm.sreg
+
+  // Another SALU with literal -- should also be direct
+  // CHECK-NOT: v_mov_b32
+  // CHECK: s_lshl_b32 s{{[0-9]+}}, s{{[0-9]+}}, 7
+  %c7 = waveasm.constant 7 : !waveasm.imm<7>
+  %r2 = waveasm.s_lshl_b32 %r1, %c7 : !waveasm.sreg, !waveasm.imm<7> -> !waveasm.sreg
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: vop2_literal_test:
+
+waveasm.program @vop2_literal_test target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  // VOP2 commutative op with literal in src1: should swap to put literal in src0
+  // v_add_u32 is commutative, so emit literal first
+  // CHECK-NOT: v_mov_b32 v15
+  // CHECK: v_add_u32 v{{[0-9]+}}, 256, v0
+  %c256 = waveasm.constant 256 : !waveasm.imm<256>
+  %r1 = waveasm.v_add_u32 %v0, %c256 : !waveasm.pvreg<0>, !waveasm.imm<256> -> !waveasm.vreg
+
+  // VOP2 with literal already in src0: should emit directly
+  // CHECK-NOT: v_mov_b32 v15
+  // CHECK: v_add_u32 v{{[0-9]+}}, 512, v{{[0-9]+}}
+  %c512 = waveasm.constant 512 : !waveasm.imm<512>
+  %r2 = waveasm.v_add_u32 %c512, %r1 : !waveasm.imm<512>, !waveasm.vreg -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/scaled-mfma-double-buffer.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/scaled-mfma-double-buffer.mlir
@@ -1,0 +1,94 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s 2>&1 | FileCheck %s
+//
+// Test: Full assembly output for scaled MFMA with double-buffered LDS allocs.
+//
+// This verifies the end-to-end pipeline from MLIR to AMDGCN assembly for the
+// MXFP4 pattern: direct memref.alloc (no memref.view), memref iter_args for
+// double-buffering, vector.bitcast + vector.extract for scale factors, and
+// amdgpu.scaled_mfma for the scaled matrix multiply.
+//
+// Expected assembly features:
+// 1. s_mov_b32 for LDS offset SGPR initialization
+// 2. v_add_u32 with SGPR offset for LDS address computation
+// 3. ds_read for data and scale loads
+// 4. v_mfma_scale_f32_16x16x128_f8f6f4 with cbsz/blgp attributes
+// 5. s_mov_b32 SGPR rotation (swap) at loop tail
+
+module {
+  gpu.module @test_scaled_mfma_double_buffer {
+
+    // CHECK-LABEL: scaled_mfma_dbuf_asm:
+    gpu.func @scaled_mfma_dbuf_asm(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c3 = arith.constant 3 : index
+      %c1 = arith.constant 1 : index
+
+      // Two data buffers + two scale buffers for double-buffering
+      %data0 = memref.alloc() : memref<16x128xi8, 3>
+      %data1 = memref.alloc() : memref<16x128xi8, 3>
+      %scale0 = memref.alloc() : memref<16x8xi8, 3>
+      %scale1 = memref.alloc() : memref<16x8xi8, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // SGPR init for LDS offsets
+      // CHECK-DAG: s_mov_b32 s{{[0-9]+}}, 0
+      // CHECK-DAG: s_mov_b32 s{{[0-9]+}}, 2048
+      // CHECK-DAG: s_mov_b32 s{{[0-9]+}}, 4096
+      // CHECK-DAG: s_mov_b32 s{{[0-9]+}}, 4224
+
+      // CHECK: L_loop_0:
+      %result:5 = scf.for %i = %c0 to %c3 step %c1
+          iter_args(%acc = %acc_init,
+                    %curData = %data0, %nextData = %data1,
+                    %curScale = %scale0, %nextScale = %scale1)
+          -> (vector<4xf32>,
+              memref<16x128xi8, 3>, memref<16x128xi8, 3>,
+              memref<16x8xi8, 3>, memref<16x8xi8, 3>) {
+
+        // Data load with SGPR-carried LDS offset
+        // CHECK: v_add_u32
+        // CHECK: ds_read_b128
+        %raw_data = vector.load %curData[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %data_a = "vector.bitcast"(%raw_data) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        %raw_data2 = vector.load %curData[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %data_b = "vector.bitcast"(%raw_data2) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        // Scale load
+        // CHECK: ds_read_u8
+        %raw_sa = vector.load %curScale[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %svec_a = "vector.bitcast"(%raw_sa) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %sa = "vector.extract"(%svec_a) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        %raw_sb = vector.load %curScale[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %svec_b = "vector.bitcast"(%raw_sb) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %sb = "vector.extract"(%svec_b) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        // Scaled MFMA instruction
+        // CHECK: v_mfma_scale_f32_16x16x128_f8f6f4 {{.*}} cbsz:4 blgp:4
+        %new_acc = "amdgpu.scaled_mfma"(%data_a, %data_b, %acc, %sa, %sb) <{
+          k = 128 : i32, m = 16 : i32, n = 16 : i32,
+          scalesIdxA = 0 : i32, scalesIdxB = 0 : i32
+        }> : (vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<4xf32>, f8E8M0FNU, f8E8M0FNU) -> vector<4xf32>
+
+        scf.yield %new_acc, %nextData, %curData, %nextScale, %curScale
+            : vector<4xf32>,
+              memref<16x128xi8, 3>, memref<16x128xi8, 3>,
+              memref<16x8xi8, 3>, memref<16x8xi8, 3>
+      }
+
+      // SGPR rotation for 2 swap pairs (data + scale)
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+      // CHECK: s_cbranch_scc1 L_loop_0
+
+      // CHECK: s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-cap.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-cap.mlir
@@ -1,0 +1,41 @@
+// RUN: waveasm-translate --waveasm-insert-waitcnt %s | FileCheck %s
+//
+// Test: Waitcnt values are capped to hardware limits.
+// GFX9 has 4-bit lgkmcnt (max 15) and 6-bit vmcnt (max 63).
+// When the computed threshold exceeds the hardware limit, the pass
+// must fall back to 0 (full drain) for correctness.
+
+// CHECK-LABEL: waveasm.program @lgkmcnt_overflow_cap
+waveasm.program @lgkmcnt_overflow_cap target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %addr = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  // Issue 17 LDS reads to make the first load's lgkmcnt threshold = 16,
+  // which exceeds the 4-bit hardware max of 15.
+  %ld0  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld1  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld2  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld3  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld4  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld5  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld6  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld7  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld8  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld9  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld10 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld11 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld12 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld13 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld14 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld15 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+  %ld16 = waveasm.ds_read_b32 %addr : !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // Using ld0 requires lgkmcnt(16) but max is 15.
+  // The pass must cap this to lgkmcnt(0) instead of emitting an invalid value.
+  // CHECK: waveasm.s_waitcnt
+  // CHECK-NOT: lgkmcnt(16)
+  // CHECK-NOT: lgkmcnt(17)
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %result = waveasm.v_add_u32 %ld0, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-combine-mixed.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-combine-mixed.mlir
@@ -1,0 +1,48 @@
+// RUN: waveasm-translate --waveasm-insert-waitcnt %s | FileCheck %s
+//
+// Test: Merging S_WAITCNT with adjacent individual S_WAITCNT_VMCNT or
+// S_WAITCNT_LGKMCNT.  The combineAdjacentWaitcnts pass should fold the
+// individual counter into the combined waitcnt, taking the minimum of
+// each field.
+
+// --- Pattern: S_WAITCNT followed by S_WAITCNT_VMCNT -------------------------
+// CHECK-LABEL: waveasm.program @combined_then_vmcnt
+waveasm.program @combined_then_vmcnt target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %srd = waveasm.precolored.sreg 0, 4 : !waveasm.psreg<0, 4>
+  %voff = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %addr = waveasm.precolored.vreg 1 : !waveasm.pvreg<1>
+
+  %vmem = waveasm.buffer_load_dword %srd, %voff : !waveasm.psreg<0, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %lds  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<1> -> !waveasm.vreg
+
+  // Pre-existing combined wait + individual vmcnt should merge.
+  // CHECK: waveasm.s_waitcnt vmcnt(0) lgkmcnt(0)
+  // CHECK-NOT: waveasm.s_waitcnt_vmcnt
+  // CHECK-NEXT: waveasm.s_barrier
+  waveasm.s_waitcnt vmcnt(0) lgkmcnt(0)
+  waveasm.s_waitcnt_vmcnt 0
+  waveasm.s_barrier
+
+  waveasm.s_endpgm
+}
+
+// --- Pattern: S_WAITCNT_LGKMCNT followed by S_WAITCNT ------------------------
+// CHECK-LABEL: waveasm.program @lgkmcnt_then_combined
+waveasm.program @lgkmcnt_then_combined target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %srd = waveasm.precolored.sreg 0, 4 : !waveasm.psreg<0, 4>
+  %voff = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %addr = waveasm.precolored.vreg 1 : !waveasm.pvreg<1>
+
+  %vmem = waveasm.buffer_load_dword %srd, %voff : !waveasm.psreg<0, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %lds  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<1> -> !waveasm.vreg
+
+  // Individual lgkmcnt followed by combined wait should merge.
+  // CHECK: waveasm.s_waitcnt vmcnt(0) lgkmcnt(0)
+  // CHECK-NOT: waveasm.s_waitcnt_lgkmcnt
+  // CHECK-NEXT: waveasm.s_barrier
+  waveasm.s_waitcnt_lgkmcnt 0
+  waveasm.s_waitcnt vmcnt(0) lgkmcnt(0)
+  waveasm.s_barrier
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-combine.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/waitcnt-combine.mlir
@@ -1,0 +1,51 @@
+// RUN: waveasm-translate --waveasm-insert-waitcnt %s | FileCheck %s
+//
+// Test: Adjacent waitcnt combining and double-free safety.
+// The combineAdjacentWaitcnts pass merges consecutive s_waitcnt_vmcnt and
+// s_waitcnt_lgkmcnt into a single s_waitcnt.  When three consecutive waits
+// form a vmcnt/lgkmcnt/vmcnt triple, the first pair shares an element with
+// the second pair -- the erased-set tracking prevents a double-free crash.
+
+// CHECK-LABEL: waveasm.program @combine_vmcnt_lgkmcnt
+waveasm.program @combine_vmcnt_lgkmcnt target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %srd = waveasm.precolored.sreg 0, 4 : !waveasm.psreg<0, 4>
+  %voff = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %addr = waveasm.precolored.vreg 1 : !waveasm.pvreg<1>
+
+  // Issue both VMEM and LDS loads
+  %vmem = waveasm.buffer_load_dword %srd, %voff : !waveasm.psreg<0, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %lds  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<1> -> !waveasm.vreg
+
+  // Using both results forces vmcnt and lgkmcnt waits.
+  // The pass inserts s_waitcnt_vmcnt + s_waitcnt_lgkmcnt, then the
+  // combine pass should merge them into a single s_waitcnt.
+  // CHECK: waveasm.s_waitcnt vmcnt({{[0-9]+}}) lgkmcnt({{[0-9]+}})
+  // CHECK-NEXT: waveasm.v_add_u32
+  %result = waveasm.v_add_u32 %vmem, %lds : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}
+
+// Test: pre-existing separate waits followed by barrier.
+// The schedule places s_waitcnt_vmcnt, then the pass adds s_waitcnt_lgkmcnt
+// for the barrier, and the combine pass merges the adjacent pair.
+// This exercises the path where consecutive toCombine pairs may share ops.
+// CHECK-LABEL: waveasm.program @combine_with_barrier
+waveasm.program @combine_with_barrier target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %srd = waveasm.precolored.sreg 0, 4 : !waveasm.psreg<0, 4>
+  %voff = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %addr = waveasm.precolored.vreg 1 : !waveasm.pvreg<1>
+
+  %vmem = waveasm.buffer_load_dword %srd, %voff : !waveasm.psreg<0, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %lds  = waveasm.ds_read_b32 %addr : !waveasm.pvreg<1> -> !waveasm.vreg
+
+  // Schedule-placed vmcnt wait
+  waveasm.s_waitcnt_vmcnt 0
+
+  // Barrier needs lgkmcnt(0) too; the pass adds it and combine merges
+  // CHECK: waveasm.s_waitcnt vmcnt(0) lgkmcnt(0)
+  // CHECK-NEXT: waveasm.s_barrier
+  waveasm.s_barrier
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/lds-alloc-epilogue.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/lds-alloc-epilogue.mlir
@@ -1,0 +1,43 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: LDS base offset propagation through scf.for results to epilogue.
+//
+// In pipelined MXFP4 GEMM, the epilogue code (after the scf.for) reads from
+// memref results of the loop.  The LDS base offset must be propagated from the
+// loop's init args through the yield/results so the epilogue vector.load can
+// find the correct LDS address.
+
+module {
+  gpu.module @test_lds_alloc_epilogue {
+
+    // CHECK-LABEL: waveasm.program @lds_alloc_epilogue
+    gpu.func @lds_alloc_epilogue(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c3 = arith.constant 3 : index
+      %c1 = arith.constant 1 : index
+
+      // Two LDS allocations at different offsets
+      %bufA = memref.alloc() : memref<16x128xi8, 3>
+      %bufB = memref.alloc() : memref<16x128xi8, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // CHECK: waveasm.loop
+      %result:3 = scf.for %i = %c0 to %c3 step %c1
+          iter_args(%acc = %acc_init, %curA = %bufA, %curB = %bufB)
+          -> (vector<4xf32>, memref<16x128xi8, 3>, memref<16x128xi8, 3>) {
+        %data = vector.load %curA[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        scf.yield %acc, %curB, %curA : vector<4xf32>, memref<16x128xi8, 3>, memref<16x128xi8, 3>
+      }
+
+      // Epilogue: load from the loop result memref (result #1).
+      // The LDS base offset should be propagated from the loop result.
+      // CHECK: v_add_u32
+      // CHECK: ds_read_b128
+      %epilogue_data = vector.load %result#1[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/lds-alloc-offset-tracking.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/lds-alloc-offset-tracking.mlir
@@ -1,0 +1,57 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: LDS base offset tracking for direct memref.alloc (without memref.view).
+//
+// In MXFP4 scheduled GEMM kernels, LDS buffers are allocated as separate typed
+// memrefs (e.g. memref<256x128xi8, 3>) rather than as views into a single raw
+// byte buffer.  The backend must assign cumulative byte offsets so that each
+// buffer occupies a distinct LDS region.
+//
+// This test verifies that:
+// 1. Each memref.alloc gets a cumulative LDS base offset
+// 2. When these memrefs are used as scf.for iter_args, the offsets are
+//    materialized as SGPRs and carried through the loop
+// 3. vector.load from iter_arg memrefs uses the SGPR-carried offset
+
+module {
+  gpu.module @test_lds_alloc_offset {
+
+    // CHECK-LABEL: waveasm.program @lds_alloc_double_buffer
+    gpu.func @lds_alloc_double_buffer(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c7 = arith.constant 7 : index
+      %c1 = arith.constant 1 : index
+
+      // Two separate LDS allocations (no memref.view):
+      //   bufA: 256x128 bytes = 32768 bytes at offset 0
+      //   bufB: 256x128 bytes = 32768 bytes at offset 32768
+      %bufA = memref.alloc() : memref<256x128xi8, 3>
+      %bufB = memref.alloc() : memref<256x128xi8, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // The loop carries bufA and bufB as memref iter_args.
+      // They should be resolved to SGPR offsets (0 and 32768).
+      //
+      // CHECK: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<32768> -> !waveasm.sreg
+      //
+      // Loop with iter_args including the SGPR offsets:
+      // CHECK: waveasm.loop
+      %result:3 = scf.for %i = %c0 to %c7 step %c1
+          iter_args(%acc = %acc_init, %curA = %bufA, %curB = %bufB)
+          -> (vector<4xf32>, memref<256x128xi8, 3>, memref<256x128xi8, 3>) {
+
+        // vector.load from iter_arg memref should use SGPR-carried offset
+        // CHECK: v_add_u32
+        // CHECK: ds_read_b128
+        %data = vector.load %curA[%tidx, %c0] : memref<256x128xi8, 3>, vector<16xi8>
+
+        scf.yield %acc, %curB, %curA : vector<4xf32>, memref<256x128xi8, 3>, memref<256x128xi8, 3>
+      }
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/rocdl-handlers.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/rocdl-handlers.mlir
@@ -1,0 +1,37 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: ROCDL and AMDGPU op handlers that were previously silently dropped.
+// Without these handlers, s_barrier, s_setprio, and s_waitcnt vmcnt(N)
+// instructions were missing from generated assembly.
+
+// CHECK: waveasm.program @sync_ops_test
+
+// rocdl.s.setprio -> waveasm.s_setprio
+// CHECK: waveasm.s_setprio 1
+
+// rocdl.s.barrier -> waveasm.s_barrier
+// CHECK: waveasm.s_barrier
+
+// rocdl.s.setprio -> waveasm.s_setprio
+// CHECK: waveasm.s_setprio 0
+
+// amdgpu.memory_counter_wait with load(10) -> waveasm.s_waitcnt_vmcnt 10
+// CHECK: waveasm.s_waitcnt_vmcnt 10
+
+// amdgpu.memory_counter_wait with ds(0) -> waveasm.s_waitcnt_lgkmcnt 0
+// CHECK: waveasm.s_waitcnt_lgkmcnt 0
+
+// CHECK: waveasm.s_endpgm
+
+module {
+  gpu.module @test_sync_ops {
+    gpu.func @sync_ops_test() kernel {
+      rocdl.s.setprio 1
+      rocdl.s.barrier
+      rocdl.s.setprio 0
+      amdgpu.memory_counter_wait load(10)
+      amdgpu.memory_counter_wait ds(0)
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scaled-mfma-pipelined.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Translate/scaled-mfma-pipelined.mlir
@@ -1,0 +1,91 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: amdgpu.scaled_mfma with pipelined double-buffer iter_args.
+//
+// This exercises the MXFP4 GEMM pattern where:
+// 1. Data and scale buffers are separate memref.alloc (not memref.view)
+// 2. scf.for carries them as memref iter_args for double-buffering
+// 3. vector.load reads data + scales from the iter_arg memrefs
+// 4. vector.bitcast reinterprets i8 data as f4E2M1FN and f8E8M0FNU
+// 5. vector.extract extracts scalar scales
+// 6. amdgpu.scaled_mfma consumes data + scales + accumulator
+//
+// The backend must:
+// - Assign cumulative LDS offsets to each memref.alloc
+// - Materialize offsets as SGPRs for iter_args
+// - Map all scaled_mfma operands through the value mapper
+
+module {
+  gpu.module @test_scaled_mfma_pipelined {
+
+    // CHECK-LABEL: waveasm.program @scaled_mfma_dbuf
+    gpu.func @scaled_mfma_dbuf(%tidx: index {llvm.mlir.workitem_id_x}) kernel {
+      %c0 = arith.constant 0 : index
+      %c3 = arith.constant 3 : index
+      %c1 = arith.constant 1 : index
+
+      // 4 LDS allocations: data_A0, data_A1 (ping-pong), scale_A0, scale_A1
+      //   data_A0:  16x128 bytes = 2048 bytes at offset 0
+      //   data_A1:  16x128 bytes = 2048 bytes at offset 2048
+      //   scale_A0: 16x8 bytes   = 128 bytes  at offset 4096
+      //   scale_A1: 16x8 bytes   = 128 bytes  at offset 4224
+      %data0 = memref.alloc() : memref<16x128xi8, 3>
+      %data1 = memref.alloc() : memref<16x128xi8, 3>
+      %scale0 = memref.alloc() : memref<16x8xi8, 3>
+      %scale1 = memref.alloc() : memref<16x8xi8, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // SGPR materialization for all 4 LDS offsets:
+      // CHECK-DAG: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
+      // CHECK-DAG: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<2048> -> !waveasm.sreg
+      // CHECK-DAG: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<4096> -> !waveasm.sreg
+      // CHECK-DAG: waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<4224> -> !waveasm.sreg
+      //
+      // CHECK: waveasm.loop
+      %result:5 = scf.for %i = %c0 to %c3 step %c1
+          iter_args(%acc = %acc_init,
+                    %curData = %data0, %nextData = %data1,
+                    %curScale = %scale0, %nextScale = %scale1)
+          -> (vector<4xf32>,
+              memref<16x128xi8, 3>, memref<16x128xi8, 3>,
+              memref<16x8xi8, 3>, memref<16x8xi8, 3>) {
+
+        // Load data (16xi8 -> bitcast to 32xf4E2M1FN)
+        // CHECK: ds_read_b128
+        %raw_data_a = vector.load %curData[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %data_a = "vector.bitcast"(%raw_data_a) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        // Load same data as srcB (simplified: reuse same buffer for both A and B)
+        %raw_data_b = vector.load %curData[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %data_b = "vector.bitcast"(%raw_data_b) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        // Load scales (1xi8 -> bitcast to 1xf8E8M0FNU -> extract scalar)
+        // CHECK: ds_read_u8
+        %raw_scale_a = vector.load %curScale[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %scale_vec_a = "vector.bitcast"(%raw_scale_a) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %scale_a = "vector.extract"(%scale_vec_a) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        %raw_scale_b = vector.load %curScale[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %scale_vec_b = "vector.bitcast"(%raw_scale_b) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %scale_b = "vector.extract"(%scale_vec_b) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        // Scaled MFMA: all 5 operands should be mapped
+        // CHECK: waveasm.v_mfma_scale_f32_16x16x128_f8f6f4
+        %new_acc = "amdgpu.scaled_mfma"(%data_a, %data_b, %acc, %scale_a, %scale_b) <{
+          k = 128 : i32, m = 16 : i32, n = 16 : i32,
+          scalesIdxA = 0 : i32, scalesIdxB = 0 : i32
+        }> : (vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<4xf32>, f8E8M0FNU, f8E8M0FNU) -> vector<4xf32>
+
+        // Swap ping-pong buffers
+        scf.yield %new_acc, %nextData, %curData, %nextScale, %curScale
+            : vector<4xf32>,
+              memref<16x128xi8, 3>, memref<16x128xi8, 3>,
+              memref<16x8xi8, 3>, memref<16x8xi8, 3>
+      }
+
+      // CHECK: waveasm.s_endpgm
+      gpu.return
+    }
+  }
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/e2e/test_asm_backend_e2e.py
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/e2e/test_asm_backend_e2e.py
@@ -17,6 +17,8 @@ Tests included:
 4. test_mma_multi_wave_cpp_backend - Multi-wave MMA
 5. test_gemm_cpp_backend - Full GEMM with K-loop
 6. test_mxfp4_scaled_gemm_cpp_backend - MXFP4 scaled GEMM (gfx950+ only)
+7. test_dbuf_4wave_mxfp4_gemm_cpp_backend - Double-buffered MXFP4 GEMM, 4 waves (gfx950+)
+8. test_dbuf_8wave_mxfp4_gemm_cpp_backend - Double-buffered MXFP4 GEMM, 8 waves (gfx950+)
 
 Run with:
     # Run all e2e tests with C++ backend (default, requires GPU)
@@ -1310,6 +1312,179 @@ def test_mxfp4_scaled_gemm_cpp_backend(
         c_cpu,
         check_dtype=False,
         msg=f"MXFP4 GEMM {m}x{n}x{k} ({g2s_str}, {backend}) failed numerical validation",
+    )
+
+
+# =============================================================================
+# Test: MXFP4 Double-Buffered Scheduled GEMM (from 7.1_schedule.py)
+# =============================================================================
+
+
+def _dbuf_mxfp4_helper(
+    shape,
+    block,
+    num_waves,
+    use_stagger,
+    compiler,
+    backend,
+    dump_asm,
+):
+    """Shared helper for double-buffered MXFP4 scheduled GEMM tests.
+
+    Mirrors the 7.1_schedule.py examples using get_tagged_mxfp4_gemm
+    (tagged kernel template) + get_mxfp4_dbuf_schedule (double-buffer
+    schedule with 2-stage pipeline and K-partitioned clusters).
+
+    This exercises the C++ ASM backend on MLIR produced by the full
+    Wave scheduling pipeline (MANUAL schedule + wave_schedule clusters).
+    """
+    if not is_cdna4():
+        pytest.skip("MXFP4 double-buffered GEMM only supported on gfx950+ (CDNA4)")
+
+    skip_if_no_gpu()
+    skip_if_no_wave_lang()
+
+    import torch
+
+    from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+    from wave_lang.kernel.wave.schedules import get_mxfp4_dbuf_schedule
+    from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+    from wave_lang.kernel.wave.utils.mxfp_utils import (
+        generate_gemm_afp4wfp4_inputs,
+        torchScaledGemmMXFP4,
+    )
+
+    # Get tagged kernel + options (same as 7.1_schedule.py)
+    gemm, options = get_tagged_mxfp4_gemm(shape, block, num_waves=num_waves)
+    schedule = get_mxfp4_dbuf_schedule(use_stagger=use_stagger)
+
+    # Override to ASM backend for C++ compilation path
+    options.backend = "asm"
+    options.wave_runtime = True
+    options.compile_to_mlir = False
+    options = set_default_run_config(options)
+
+    # Generate MXFP4 inputs and reference output
+    x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+    torch_out = torchScaledGemmMXFP4(x, w, x_scales, w_scales)
+
+    x, w = x.cuda(), w.cuda()
+    x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+    c = torch.zeros(shape[0], shape[1], dtype=torch.float32).cuda()
+
+    # Capture MLIR with schedule applied
+    kernel_info = capture_wave_kernel_info(options, gemm, schedule=schedule)
+
+    # Verify MLIR contains scaled_mfma operation
+    assert (
+        "amdgpu.scaled_mfma" in kernel_info.mlir_text
+    ), "Expected amdgpu.scaled_mfma operation in MLIR"
+
+    waves_str = f"{num_waves}wave"
+    stagger_str = "stagger" if use_stagger else "no_stagger"
+    m, n, k = shape
+    test_id = f"mxfp4_dbuf_{waves_str}_{m}x{n}x{k}_{stagger_str}"
+
+    # Compile with C++ backend
+    cpp_result = compiler.compile_full(
+        kernel_info.mlir_text, kernel_info.workgroup_size
+    )
+    if not cpp_result.success:
+        pytest.fail(f"C++ compilation failed: {cpp_result.error_message}")
+
+    # Verify assembly contains scaled MFMA instruction
+    assert (
+        "v_mfma_scale_f32_16x16x128_f8f6f4" in cpp_result.asm_text
+    ), "Expected v_mfma_scale_f32_16x16x128_f8f6f4 instruction in assembly"
+
+    # Dump assembly if requested
+    if dump_asm and cpp_result.asm_text:
+        with open(f"/tmp/{test_id}_cpp.s", "w") as f:
+            f.write(cpp_result.asm_text)
+        with open(f"/tmp/{test_id}.mlir", "w") as f:
+            f.write(kernel_info.mlir_text)
+
+    kernel_name = cpp_result.get_kernel_name() or kernel_info.kernel_name
+
+    # Use Wave compiler's launch info
+    block_size = kernel_info.workgroup_size
+    lds_size = kernel_info.lds_size
+    grid = kernel_info.grid_size
+
+    # Execute on GPU
+    # Kernel signature: (a, a_scale, b, b_scale, c)
+    run_with_wave_runtime(
+        binary_path=cpp_result.binary_path,
+        inputs=[x, x_scales, w.T.contiguous(), w_scales],
+        outputs=[c],
+        grid=grid,
+        block=block_size,
+        shared_memory_bytes=lds_size,
+        func_name=kernel_name,
+    )
+
+    # Numerical correctness validation (same tolerance as existing MXFP4 test)
+    c_cpu = c.cpu()
+    torch_out_cpu = torch_out.cpu() if torch_out.is_cuda else torch_out
+    torch.testing.assert_close(
+        torch_out_cpu,
+        c_cpu,
+        check_dtype=False,
+        msg=f"MXFP4 double-buffered {waves_str} GEMM {m}x{n}x{k} "
+        f"({stagger_str}, {backend}) failed numerical validation",
+    )
+
+
+@pytest.mark.xfail(
+    reason="C++ backend linear scan register allocator exceeds VGPR limit "
+    "(~898 VGPRs needed vs 256 limit) for the full MXFP4 double-buffered "
+    "kernel with 64 accumulator iter_args + 8 memref iter_args",
+    strict=True,
+)
+def test_dbuf_4wave_mxfp4_gemm_cpp_backend(compiler, backend, dump_asm):
+    """End-to-end test for double-buffered MXFP4 GEMM with 4 waves.
+
+    Mirrors: test_dbuf_4wave_mxfp_gemm from examples/python/7.1_schedule.py
+
+    4-wave configuration (2 M-tiles x 2 N-tiles), no stagger.
+    Uses tagged kernel template + double-buffer schedule with 2-stage
+    pipeline and K-dimension partitioning for memory/compute interleaving.
+    """
+    _dbuf_mxfp4_helper(
+        shape=(1024, 1024, 8192),
+        block=(256, 256, 256),
+        num_waves=4,
+        use_stagger=False,
+        compiler=compiler,
+        backend=backend,
+        dump_asm=dump_asm,
+    )
+
+
+@pytest.mark.xfail(
+    reason="C++ backend register allocator needs ~260 VGPRs for 8-wave MXFP4 "
+    "double-buffered kernel (exceeds 256 limit). Needs AccVGPR support to "
+    "move accumulator VGPRs off the regular VGPR budget.",
+    strict=True,
+)
+def test_dbuf_8wave_mxfp4_gemm_cpp_backend(compiler, backend, dump_asm):
+    """End-to-end test for double-buffered MXFP4 GEMM with 8 waves.
+
+    Mirrors: test_dbuf_8wave_mxfp_gemm from examples/python/7.1_schedule.py
+
+    8-wave configuration (4 M-tiles x 2 N-tiles), with stagger.
+    Uses tagged kernel template + double-buffer schedule with 2-stage
+    pipeline, K-dimension partitioning, and wave staggering for better
+    overlap.
+    """
+    _dbuf_mxfp4_helper(
+        shape=(1024, 1024, 8192),
+        block=(256, 256, 256),
+        num_waves=8,
+        use_stagger=True,
+        compiler=compiler,
+        backend=backend,
+        dump_asm=dump_asm,
     )
 
 

--- a/wave_lang/kernel/wave/asm/wave_asm/test/e2e/waveasm_e2e.py
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/e2e/waveasm_e2e.py
@@ -424,7 +424,7 @@ def capture_wave_mlir(options, kernel_func) -> str:
     return mlir_text
 
 
-def capture_wave_kernel_info(options, kernel_func) -> CapturedKernelInfo:
+def capture_wave_kernel_info(options, kernel_func, schedule=None) -> CapturedKernelInfo:
     """
     Capture MLIR and kernel launch info from Wave compilation.
 
@@ -434,6 +434,7 @@ def capture_wave_kernel_info(options, kernel_func) -> CapturedKernelInfo:
     Args:
         options: WaveCompileOptions
         kernel_func: Decorated wave kernel function
+        schedule: Optional WaveSchedule to apply during compilation
 
     Returns:
         CapturedKernelInfo with all launch information
@@ -458,7 +459,9 @@ def capture_wave_kernel_info(options, kernel_func) -> CapturedKernelInfo:
         kernel_func.initialize_workgroup_constraints()
 
         # Trace and get MLIR - this populates options.kernel_launch_info
-        result = _trace_launchable_and_get_kernel_signature(kernel_func, options)
+        result = _trace_launchable_and_get_kernel_signature(
+            kernel_func, options, schedule=schedule
+        )
         mb = result[0]
 
         # Get full MLIR text (Python bindings can parse stream dialect)

--- a/wave_lang/kernel/wave/asm/wave_asm/tools/waveasm-translate/waveasm-translate.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/tools/waveasm-translate/waveasm-translate.cpp
@@ -125,6 +125,16 @@ static llvm::cl::opt<int64_t>
     subgroupSize("subgroup-size", llvm::cl::desc("Subgroup (wavefront) size"),
                  llvm::cl::init(64));
 
+static llvm::cl::opt<int64_t>
+    maxVGPRs("max-vgprs",
+             llvm::cl::desc("Maximum VGPRs for register allocation"),
+             llvm::cl::init(256));
+
+static llvm::cl::opt<int64_t>
+    maxSGPRs("max-sgprs",
+             llvm::cl::desc("Maximum SGPRs for register allocation"),
+             llvm::cl::init(104));
+
 //===----------------------------------------------------------------------===//
 // Main Function
 //===----------------------------------------------------------------------===//
@@ -238,7 +248,7 @@ int main(int argc, char **argv) {
   // see the final register assignments.  Matches compare_backends.py order:
   // LinearScan -> Waitcnt -> Hazard.
   if (runLinearScan) {
-    pm.addPass(waveasm::createWAVEASMLinearScanPass());
+    pm.addPass(waveasm::createWAVEASMLinearScanPass(maxVGPRs, maxSGPRs));
     // After register allocation, physical register types (pvreg/psreg) replace
     // virtual types (vreg/sreg). The MLIR RegionBranchOpInterface verifier
     // checks exact type equality between entry operands and block arguments,


### PR DESCRIPTION
Consolidated correctness fixes from the reduce_reg_pressure branch, excluding AGPR-related changes (not yet upstream).

Tier 1 -- Critical correctness fixes:

1. Fix tied-register double-allocation at loop boundaries: when a tied value (e.g., MFMA accumulator loop result) was processed after its partner expired from the active list, the physical register was never re-reserved, allowing silent data corruption. Also extend block arg live ranges to bridge the gap to loop result def points, preventing pool fragmentation. (from 8cf5e21c)

2. Fix waitcnt double-free crash: combineAdjacentWaitcnts could erase the same operation twice when consecutive combine pairs shared an op. Also replace program.walk() with pre-collected op vector iteration to avoid iterator invalidation on large kernels. (from 2152583)

Tier 2 -- High-impact correctness + performance fixes:

3. Reduce s_waitcnt count from 51 to 4 in kernel loop body: fix incremental wait tracking (don't reset on new loads), correct barrier outstanding detection, remove ConditionOp from resetWaits (loop back-edge), add LGKM latency-covering heuristic (skip waits with 40+ intervening ops), and combine adjacent single-counter waits. (from de5ba25)

4. Add missing MLIR op handlers that were silently dropped: amdgpu.memory_counter_wait -> s_waitcnt vmcnt(N), rocdl.s_barrier -> s_barrier, rocdl.s_setprio -> s_setprio N. Fixes barrier count (2 -> 4), adds wave priority (0 -> 8 s_setprio instructions). (from 93cad74)

5. Fix LDS offset tracking for direct memref.alloc: MXFP4 kernels use typed shaped allocations (memref<256x128xi8, 3>) instead of memref.view. Add cumulative ldsAllocOffset counter so each alloc gets a distinct byte offset. (from de2f312)

6. Fix SALU/VOP2 literal handling: SALU instructions support 32-bit literals natively (don't materialize into VGPR scratch). VOP2 instructions require literal in src0 -- swap commutative ops, fall back to materialization for non-commutative. (from 53b5b9d)

7. Fix VALU literal operand handling: all v_* instructions (except v_mov_b32) correctly materialize out-of-range literals. Fix v_cmp_* to use VOP3 encoding (_e64 suffix) with explicit VCC destination. (from 2196f9c1)

Also adds --max-vgprs/--max-sgprs CLI options, cap waitcnt values to hardware limits (lgkmcnt<=15, vmcnt<=63), and add lit tests for LDS offset tracking, scaled MFMA pipelining, and double-buffer assembly.