### PR TITLE
[hotfix] mark merge_contiguous_reads xfail roundtrip

### DIFF
--- a/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
+++ b/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
@@ -208,6 +208,7 @@ def gemm_progressive_roundtrip():
             "decompose_dot_mma",
             "generate_bounds_exprs",
             "location_check_pass",
+            "merge_contiguous_reads",
         }
     )
 


### PR DESCRIPTION
There was a race condition in merging this pass and merging the water roundtrip check, so the HEAD is currently broken. Just mark this pass as xfailing roundtrip for now.

There is a deeper error to investigate: water IR produced after this pass does not verify, specifically, the reads are missing a bound on the `K` dimension. This likely means the logic of the pass is incomplete and needs to be fixed to provide the correct bounds.