### PR TITLE
Initial implementation of split-k gemm for fp16, with atomic_add fixes.

### DIFF
--- a/wave_lang/kernel/compiler/kernel_codegen.py
+++ b/wave_lang/kernel/compiler/kernel_codegen.py
@@ -47,7 +47,14 @@ from ..lang.kernel_buffer import (
     is_kernel_buffer_meta_derived,
 )
 from ..lang.wave_types import Memory, SymbolBind
-from ..ops.wave_ops import NestedRegionOp, Placeholder, Read, Write, get_custom
+from ..ops.wave_ops import (
+    AtomicOp,
+    NestedRegionOp,
+    Placeholder,
+    Read,
+    Write,
+    get_custom,
+)
 from .base import (
     CodegenError,
 )
@@ -411,7 +418,10 @@ class KernelSignature:
             if len(node.users) == 0:
                 return False
             return any(
-                [isinstance(get_custom(x), Write) for x in get_users_recursive(node)]
+                [
+                    isinstance(get_custom(x), (Write, AtomicOp))
+                    for x in get_users_recursive(node)
+                ]
             )
 
         for node in placeholder_nodes:

--- a/wave_lang/kernel/compiler/wave_codegen/handlers.py
+++ b/wave_lang/kernel/compiler/wave_codegen/handlers.py
@@ -587,12 +587,6 @@ def handle_atomic_op(op):
                     f"{op}\nGot\n"
                     f"lhs: {lhs_data_type} vs rhs: {rhs_data_type}\n"
                 )
-            if is_float_type(lhs_data_type):
-                # TODO: To support float types, MLIR LLVM dialect needs to be updated with
-                # float types. LLVM already supports fmin and fmax (https://llvm.org/docs/LangRef.html#atomicrmw-instruction)
-                # and thus atomicrmw operation in MLIR dialect needs to target those instructions with "workgroup" scope.
-                raise NotImplementedError(f"Atomic ops don't support float types yet\n")
-
             lhs = lhs.ir_value
             rhs = rhs.ir_value
             lhs_type = lhs.type

--- a/wave_lang/kernel/ops/wave_ops.py
+++ b/wave_lang/kernel/ops/wave_ops.py
@@ -1776,6 +1776,10 @@ class AtomicOp(BinaryOpBase):
     def memory_type(self) -> "Memory":
         return get_custom(self.rhs).type
 
+    @property
+    def has_side_effects(self) -> bool:
+        return True
+
 
 @define_op("atomic_add")
 @dataclass

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -19,6 +19,7 @@ from ..._support.indexing import IndexingContext, IndexSymbol
 from ..._support.tracing import CapturedTrace
 from ...ops.wave_ops import (
     Allocate,
+    AtomicOp,
     Conditional,
     CustomOp,
     GetResult,
@@ -971,6 +972,7 @@ def is_leaf_node(node):
     custom = get_custom(node)
     return (
         isinstance(custom, Write)
+        or isinstance(custom, AtomicOp)
         or (isinstance(custom, GetResult) and not custom.users)
         or isinstance(custom, SetSymbol)
         or isinstance(custom, ScatterAdd)


### PR DESCRIPTION
We want a split-k gemm for mxfp4, but since we didn't have any split-k implementation yet, I wanted to add a simpler one first. This split-k uses atomic_add to do the final reduction between the splits. In order to do this, a couple of minor fixes to atomic_add were necessary, most notably making it count as a leaf node for expansion.