### PR TITLE
[asm] Add AGPR support, fix liveness, optimize address computation

### DIFF
--- a/wave_lang/kernel/wave/asm/scripts/compare_backends.py
+++ b/wave_lang/kernel/wave/asm/scripts/compare_backends.py
@@ -24,10 +24,12 @@ Requirements:
 """
 
 import argparse
+import copy
 import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,6 +43,21 @@ from wave_lang.kernel.wave.perf.benchmark_asm_backend import (
     create_gemm_schedule,
 )
 from wave_lang.kernel.wave.asm.utils import extract_func_from_stream_mlir
+
+# Shared parity analysis from the unified benchmark script
+try:
+    # When running from repo root
+    sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
+    from bench_mxfp4_comparison import (
+        ParityConfig,
+        LoopStructure,
+        analyze_loop_structure as _analyze_loop_structure,
+    )
+except ImportError:
+    # Stub fallback if bench_mxfp4_comparison is not on the path
+    _analyze_loop_structure = None
+    ParityConfig = None
+    LoopStructure = None
 
 
 # =============================================================================
@@ -179,6 +196,141 @@ class InstructionMetrics:
     ds_write: int = 0
     m0_setup: int = 0
     readfirstlane: int = 0
+
+
+MXFP4_CONFIGS = {
+    "4wave": {
+        "name": "mxfp4_4wave",
+        "shape": (1024, 1024, 8192),
+        "block": (256, 256, 256),
+        "num_waves": 4,
+        "wave_m": 128,
+        "wave_n": 128,
+        "use_stagger": False,
+    },
+    "8wave": {
+        "name": "mxfp4_8wave",
+        "shape": (1024, 1024, 8192),
+        "block": (256, 256, 256),
+        "num_waves": 8,
+        "wave_m": 64,
+        "wave_n": 128,
+        "use_stagger": True,
+    },
+}
+
+
+def _capture_mlir_from_kernel(kernel, options, schedule=None) -> Optional[str]:
+    """Capture MLIR text for a wave kernel using the internal trace path."""
+    from wave_lang.kernel.wave.compile import _trace_launchable_and_get_kernel_signature
+    from wave_lang.kernel._support.indexing import IndexingContext
+
+    try:
+        with IndexingContext() as idxc:
+            idxc.set_subs(options.subs)
+            kernel.initialize_wave_constraints()
+            kernel.initialize_symbolic_constraints()
+            kernel.initialize_workgroup_constraints()
+            result = _trace_launchable_and_get_kernel_signature(
+                kernel, options, schedule
+            )
+            mb = result[0]
+            return mb.module_op.get_asm(enable_debug_info=False)
+    except Exception:
+        return None
+
+
+def compile_kernel_with_options(
+    kernel,
+    base_options,
+    backend: str,
+    output_dir: Optional[Path] = None,
+    schedule=None,
+) -> BackendResult:
+    """Compile a wave kernel with explicit options for llvm/asm backends."""
+    options = copy.deepcopy(base_options)
+    options.backend = backend
+    options.compile_to_mlir = False
+    if backend == "asm":
+        options.wave_runtime = True
+    if output_dir:
+        options.dump_intermediates = str(output_dir)
+
+    try:
+        if schedule:
+            result = wave_compile(options, kernel, schedule)
+        else:
+            result = wave_compile(options, kernel)
+    except Exception as e:
+        return BackendResult(
+            backend=backend,
+            raw_asm=f"{backend} backend error: {e}",
+            hsaco_path=None,
+            disasm=None,
+            vgpr_count=0,
+            sgpr_count=0,
+            lds_size=0,
+        )
+
+    raw_asm = ""
+    hsaco_path = None
+    disasm = None
+    rocmasm_content = None
+
+    if backend == "asm":
+        raw_asm = getattr(result, "asm", "") or ""
+        hsaco_path = getattr(result, "gpu_binary_path", None)
+    else:
+        hsaco_path = getattr(result, "gpu_binary_path", None)
+        search_dirs = []
+        if output_dir:
+            search_dirs.append(Path(output_dir))
+        if hsaco_path:
+            search_dirs.append(Path(hsaco_path).parent)
+        for search_dir in search_dirs:
+            if search_dir.exists():
+                rocmasm_files = list(search_dir.glob("*.rocmasm"))
+                if rocmasm_files:
+                    try:
+                        rocmasm_content = rocmasm_files[0].read_text()
+                        break
+                    except Exception:
+                        pass
+
+    if hsaco_path and Path(hsaco_path).exists():
+        try:
+            disasm = subprocess.check_output(
+                ["/opt/rocm/llvm/bin/llvm-objdump", "-d", hsaco_path],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            pass
+
+    if backend == "llvm" and not raw_asm and disasm:
+        raw_asm = disasm
+
+    if backend == "asm" and raw_asm:
+        vgpr_count, sgpr_count, lds_size = extract_resource_usage(raw_asm)
+    elif backend == "llvm" and rocmasm_content:
+        vgpr_count, sgpr_count, lds_size = extract_resource_usage(rocmasm_content)
+    elif backend == "llvm" and hsaco_path:
+        vgpr_count, sgpr_count, lds_size = extract_resource_usage_from_hsaco(hsaco_path)
+    else:
+        vgpr_count, sgpr_count, lds_size = extract_resource_usage(disasm or raw_asm)
+
+    if backend == "llvm" and rocmasm_content:
+        raw_asm = rocmasm_content
+
+    return BackendResult(
+        backend=backend,
+        raw_asm=raw_asm,
+        hsaco_path=hsaco_path,
+        disasm=disasm,
+        vgpr_count=vgpr_count,
+        sgpr_count=sgpr_count,
+        lds_size=lds_size,
+    )
 
 
 def load_benchmark_config(name: str) -> dict:
@@ -464,6 +616,8 @@ def compile_cpp_backend(
             "--waveasm-peephole",
             "--waveasm-memory-offset-opt",  # Fold constant addresses into offset fields
             "--waveasm-linear-scan",
+            "--max-vgprs=512",  # Allow up to 512 VGPRs (4-wave occupancy)
+            "--max-agprs=512",  # Allow up to 512 AGPRs (accumulators)
             "--waveasm-insert-waitcnt",
             "--waveasm-hazard-mitigation",
             "--emit-assembly",
@@ -967,6 +1121,82 @@ def format_resource_comparison(
     return "\n".join(lines)
 
 
+def format_llvm_cpp_metrics_comparison(
+    llvm_metrics: InstructionMetrics, cpp_metrics: InstructionMetrics
+) -> str:
+    """Format LLVM vs C++ metrics comparison."""
+    lines = []
+    lines.append("=" * 90)
+    lines.append("Instruction Metrics Comparison")
+    lines.append("=" * 90)
+    lines.append(
+        f"{'Category':<25} {'LLVM':>10} {'C++':>10} {'Diff':>10} {'C++/LLVM':>10}"
+    )
+    lines.append("-" * 90)
+
+    def row(name, llvm_val, cpp_val):
+        diff = cpp_val - llvm_val
+        diff_str = f"+{diff}" if diff > 0 else str(diff)
+        ratio = f"{cpp_val/llvm_val:.2f}x" if llvm_val > 0 else "N/A"
+        return f"{name:<25} {llvm_val:>10} {cpp_val:>10} {diff_str:>10} {ratio:>10}"
+
+    lines.append(row("Total Instructions", llvm_metrics.total, cpp_metrics.total))
+    lines.append("-" * 90)
+    lines.append(row("Scalar ALU (SALU)", llvm_metrics.salu, cpp_metrics.salu))
+    lines.append(row("Vector ALU (VALU)", llvm_metrics.valu, cpp_metrics.valu))
+    lines.append(row("Vector Memory (VMEM)", llvm_metrics.vmem, cpp_metrics.vmem))
+    lines.append(row("Scalar Memory (SMEM)", llvm_metrics.smem, cpp_metrics.smem))
+    lines.append(row("LDS/GDS (DS)", llvm_metrics.ds, cpp_metrics.ds))
+    lines.append(row("Matrix Ops (MFMA)", llvm_metrics.mfma, cpp_metrics.mfma))
+    lines.append(row("Branch/Control", llvm_metrics.branch, cpp_metrics.branch))
+    lines.append(row("Waits (s_waitcnt)", llvm_metrics.wait, cpp_metrics.wait))
+    lines.append(row("Barriers (s_barrier)", llvm_metrics.barrier, cpp_metrics.barrier))
+    lines.append(row("NOPs (s_nop)", llvm_metrics.nop, cpp_metrics.nop))
+    lines.append(row("Other", llvm_metrics.other, cpp_metrics.other))
+    lines.append("-" * 90)
+    lines.append("Specific Patterns:")
+    lines.append(
+        row(
+            "  buffer_load...lds",
+            llvm_metrics.buffer_load_lds,
+            cpp_metrics.buffer_load_lds,
+        )
+    )
+    lines.append(row("  ds_read*", llvm_metrics.ds_read, cpp_metrics.ds_read))
+    lines.append(row("  ds_write*", llvm_metrics.ds_write, cpp_metrics.ds_write))
+    lines.append(
+        row("  M0 setup (s_mov m0)", llvm_metrics.m0_setup, cpp_metrics.m0_setup)
+    )
+    lines.append(
+        row("  v_readfirstlane", llvm_metrics.readfirstlane, cpp_metrics.readfirstlane)
+    )
+    lines.append("=" * 90)
+    return "\n".join(lines)
+
+
+def format_llvm_cpp_resource_comparison(
+    llvm_result: BackendResult, cpp_result: BackendResult
+) -> str:
+    """Format LLVM vs C++ resource comparison."""
+    lines = []
+    lines.append("=" * 70)
+    lines.append("Resource Usage Comparison")
+    lines.append("=" * 70)
+    lines.append(f"{'Resource':<25} {'LLVM':>10} {'C++':>10} {'Diff':>10}")
+    lines.append("-" * 70)
+
+    def row(name, llvm_val, cpp_val):
+        diff = cpp_val - llvm_val
+        diff_str = f"+{diff}" if diff > 0 else str(diff)
+        return f"{name:<25} {llvm_val:>10} {cpp_val:>10} {diff_str:>10}"
+
+    lines.append(row("VGPRs", llvm_result.vgpr_count, cpp_result.vgpr_count))
+    lines.append(row("SGPRs", llvm_result.sgpr_count, cpp_result.sgpr_count))
+    lines.append(row("LDS (bytes)", llvm_result.lds_size, cpp_result.lds_size))
+    lines.append("=" * 70)
+    return "\n".join(lines)
+
+
 def find_context_around_pattern(
     asm_text: str,
     pattern: str,
@@ -1151,6 +1381,278 @@ def generate_report(
     return "\n".join(lines)
 
 
+def run_mxfp4_comparison(
+    key: str,
+    output_dir: Path,
+    include_cpp: bool,
+):
+    """Run llvm/asm/cpp comparison for an MXFP4 dbuf kernel variant."""
+    from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+    from wave_lang.kernel.wave.schedules import (
+        get_mxfp4_dbuf_schedule,
+        get_mxfp4_aiter_style_schedule,
+    )
+    from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+
+    cfg = MXFP4_CONFIGS[key]
+    case_dir = output_dir / cfg["name"]
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use the aiter-style schedule for 4-wave configs (4 K-partitions,
+    # 16 MFMAs per barrier, no stagger).  Keep the double-buffer schedule
+    # for 8-wave configs.
+    if cfg["num_waves"] <= 4:
+        schedule = get_mxfp4_aiter_style_schedule()
+    else:
+        schedule = get_mxfp4_dbuf_schedule(use_stagger=cfg["use_stagger"])
+
+    # Create a *fresh* kernel + options for each backend.  The wave kernel
+    # object is stateful and mutated during tracing/lowering, so reusing it
+    # across two compile_kernel_with_options calls corrupts internal state and
+    # causes the second compilation to silently fail (returning 0 metrics).
+
+    def _fresh_options():
+        """Return a fresh (kernel, options) pair for this MXFP4 config."""
+        _nw = cfg["num_waves"]
+        gemm, opts = get_tagged_mxfp4_gemm(cfg["shape"], cfg["block"], num_waves=_nw)
+        opts = set_default_run_config(opts)
+        opts.compile_to_mlir = False
+        opts.wave_runtime = True
+        return gemm, opts
+
+    print("\n" + "=" * 80)
+    print(f"LLVM vs C++ - {cfg['name']}")
+    print("=" * 80)
+    print(f"Shape: {cfg['shape']}")
+    print(f"Block: {cfg['block']}")
+    print(f"Waves: {cfg['num_waves']} (stagger={cfg['use_stagger']})")
+    print(f"Output directory: {case_dir}")
+
+    # LLVM backend -- must pass schedule (double-buffered pipeline requires it)
+    print("\n>>> Compiling LLVM backend (with schedule)...")
+    llvm_gemm, llvm_opts = _fresh_options()
+    llvm_result = compile_kernel_with_options(
+        llvm_gemm,
+        llvm_opts,
+        "llvm",
+        output_dir=case_dir / "llvm_intermediates",
+        schedule=schedule,
+    )
+    print(
+        f"  Resources: VGPR={llvm_result.vgpr_count}, SGPR={llvm_result.sgpr_count}, LDS={llvm_result.lds_size}"
+    )
+
+    # Python ASM backend currently doesn't support this MXFP4 dbuf path reliably.
+    print("\n>>> Skipping ASM backend for MXFP4 dbuf kernels (known unsupported path)")
+
+    cpp_result = None
+    if include_cpp:
+        print("\n>>> Compiling C++ waveasm-translate backend...")
+        cpp_gemm, cpp_opts = _fresh_options()
+        cpp_opts.backend = "asm"
+        mlir_text = _capture_mlir_from_kernel(cpp_gemm, cpp_opts, schedule=schedule)
+        if mlir_text:
+            (case_dir / "cpp_intermediates").mkdir(parents=True, exist_ok=True)
+            (case_dir / "cpp_intermediates" / "input.mlir").write_text(mlir_text)
+            cpp_result = compile_cpp_backend(
+                mlir_text,
+                target=get_default_arch(),
+                output_dir=case_dir / "cpp_intermediates",
+            )
+            if cpp_result.raw_asm.startswith("C++ backend error"):
+                print(f"  Error: {cpp_result.raw_asm}")
+            else:
+                print(
+                    f"  Resources: VGPR={cpp_result.vgpr_count}, SGPR={cpp_result.sgpr_count}, LDS={cpp_result.lds_size}"
+                )
+        else:
+            print("  Error: Failed to capture MLIR for C++ backend")
+
+    llvm_text = llvm_result.raw_asm or llvm_result.disasm or ""
+    llvm_metrics = compute_metrics(llvm_text)
+    cpp_metrics = None
+    if cpp_result and not cpp_result.raw_asm.startswith("C++ backend error"):
+        cpp_metrics = compute_metrics(cpp_result.raw_asm)
+
+    # Loop structure analysis (if available from parity harness)
+    llvm_loop = None
+    cpp_loop = None
+    if _analyze_loop_structure is not None:
+        llvm_loop = _analyze_loop_structure(llvm_text)
+        if cpp_result and cpp_metrics:
+            cpp_loop = _analyze_loop_structure(cpp_result.raw_asm)
+
+    # Save parity manifest (Phase 2 - config equivalence)
+    report_cfg = {
+        "m": cfg["shape"][0],
+        "n": cfg["shape"][1],
+        "k": cfg["shape"][2],
+        "block_m": cfg["block"][0],
+        "block_n": cfg["block"][1],
+        "block_k": cfg["block"][2],
+        "wave_m": cfg["wave_m"],
+        "wave_n": cfg["wave_n"],
+        "num_waves": cfg["num_waves"],
+        "use_stagger": cfg["use_stagger"],
+        "schedule": "aiter_style" if cfg["num_waves"] <= 4 else "dbuf",
+        "arch": get_default_arch(),
+    }
+    manifest_path = case_dir / "parity_manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump(report_cfg, f, indent=2)
+
+    # Save artifacts
+    (case_dir / "llvm_asm.s").write_text(llvm_text)
+    if llvm_result.disasm:
+        (case_dir / "llvm_disasm.s").write_text(llvm_result.disasm)
+    if cpp_result and not cpp_result.raw_asm.startswith("C++ backend error"):
+        (case_dir / "cpp_asm.s").write_text(cpp_result.raw_asm)
+        if cpp_result.disasm:
+            (case_dir / "cpp_disasm.s").write_text(cpp_result.disasm)
+
+    if cpp_result and cpp_metrics:
+        metrics_table = format_llvm_cpp_metrics_comparison(llvm_metrics, cpp_metrics)
+        resource_table = format_llvm_cpp_resource_comparison(llvm_result, cpp_result)
+        report_lines = [
+            "=" * 80,
+            "LLVM vs C++ Backend Assembly Comparison Report",
+            "=" * 80,
+            "",
+            "Configuration:",
+            f"  Name: {cfg['name']}",
+            f"  Shape: M={report_cfg['m']}, N={report_cfg['n']}, K={report_cfg['k']}",
+            f"  Blocks: BLOCK_M={report_cfg['block_m']}, BLOCK_N={report_cfg['block_n']}, BLOCK_K={report_cfg['block_k']}",
+            f"  Waves: WAVE_M={report_cfg['wave_m']}, WAVE_N={report_cfg['wave_n']}",
+            f"  Waves/WG: {cfg['num_waves']}",
+            f"  Schedule: {report_cfg['schedule']}",
+            f"  Architecture: {get_default_arch()}",
+            "",
+            metrics_table,
+            "",
+            resource_table,
+        ]
+
+        # Append loop structure if available
+        if llvm_loop is not None and cpp_loop is not None:
+            report_lines.append("")
+            report_lines.append("=" * 70)
+            report_lines.append("Loop Structure Analysis")
+            report_lines.append("=" * 70)
+            report_lines.append(
+                f"{'Metric':<30s} {'LLVM':>12s} {'C++':>12s} {'Diff':>12s}"
+            )
+            report_lines.append("-" * 70)
+
+            def _lrow(label, llvm_val, cpp_val, fmt="d"):
+                diff = cpp_val - llvm_val
+                diff_s = f"+{diff}" if diff > 0 else str(diff)
+                if fmt == "d":
+                    return f"{label:<30s} {int(llvm_val):>12d} {int(cpp_val):>12d} {diff_s:>12s}"
+                else:
+                    return (
+                        f"{label:<30s} {llvm_val:>12.2f} {cpp_val:>12.2f} {diff_s:>12s}"
+                    )
+
+            report_lines.append(
+                _lrow("Loop count", llvm_loop.loop_count, cpp_loop.loop_count)
+            )
+            report_lines.append(
+                _lrow(
+                    "Loop body instructions",
+                    llvm_loop.loop_body_instructions,
+                    cpp_loop.loop_body_instructions,
+                )
+            )
+            report_lines.append(
+                _lrow(
+                    "Prologue instructions",
+                    llvm_loop.prologue_instructions,
+                    cpp_loop.prologue_instructions,
+                )
+            )
+            report_lines.append(
+                _lrow(
+                    "Epilogue instructions",
+                    llvm_loop.epilogue_instructions,
+                    cpp_loop.epilogue_instructions,
+                )
+            )
+            report_lines.append("-" * 70)
+            report_lines.append(
+                _lrow("  Loop MFMA", llvm_loop.loop_mfma, cpp_loop.loop_mfma)
+            )
+            report_lines.append(
+                _lrow("  Loop VMEM", llvm_loop.loop_vmem, cpp_loop.loop_vmem)
+            )
+            report_lines.append(_lrow("  Loop DS", llvm_loop.loop_ds, cpp_loop.loop_ds))
+            report_lines.append(
+                _lrow("  Loop SALU", llvm_loop.loop_salu, cpp_loop.loop_salu)
+            )
+            report_lines.append(
+                _lrow("  Loop VALU", llvm_loop.loop_valu, cpp_loop.loop_valu)
+            )
+            report_lines.append(
+                _lrow("  Loop waits", llvm_loop.loop_wait, cpp_loop.loop_wait)
+            )
+            report_lines.append(
+                _lrow("  Loop barriers", llvm_loop.loop_barrier, cpp_loop.loop_barrier)
+            )
+            report_lines.append(
+                _lrow("  Loop NOPs", llvm_loop.loop_nop, cpp_loop.loop_nop)
+            )
+            report_lines.append("-" * 70)
+            report_lines.append(
+                _lrow(
+                    "MFMA density", llvm_loop.mfma_density, cpp_loop.mfma_density, ".2f"
+                )
+            )
+            report_lines.append(
+                _lrow(
+                    "Prefetch loads",
+                    llvm_loop.prefetch_loads_before_first_mfma,
+                    cpp_loop.prefetch_loads_before_first_mfma,
+                )
+            )
+            report_lines.append("=" * 70)
+
+        report_lines.append("")
+        report_lines.append("=" * 70)
+        report_lines.append("Preliminary Analysis")
+        report_lines.append("=" * 70)
+
+        if llvm_metrics.total > 0:
+            cpp_overhead_ratio = cpp_metrics.total / llvm_metrics.total
+            report_lines.append(
+                f"C++ vs LLVM instruction ratio: {cpp_overhead_ratio:.2f}x ({cpp_metrics.total - llvm_metrics.total:+d} instructions)"
+            )
+        else:
+            report_lines.append(
+                "LLVM metrics unavailable (compile/metadata issue), cannot compute ratios."
+            )
+        report_lines.append("=" * 70)
+        report = "\n".join(report_lines)
+    else:
+        report = (
+            "LLVM vs C++ comparison could not be completed because C++ backend "
+            "compilation failed. See console output for details."
+        )
+    (case_dir / "comparison_report.txt").write_text(report)
+    if cpp_result and cpp_metrics:
+        print("\n" + format_llvm_cpp_metrics_comparison(llvm_metrics, cpp_metrics))
+        print("\n" + format_llvm_cpp_resource_comparison(llvm_result, cpp_result))
+        # Print loop structure if available
+        if llvm_loop and cpp_loop:
+            print(
+                f"\nLoop Structure: LLVM body={llvm_loop.loop_body_instructions}, "
+                f"C++ body={cpp_loop.loop_body_instructions}, "
+                f"LLVM MFMA_density={llvm_loop.mfma_density:.2f}, "
+                f"C++ MFMA_density={cpp_loop.mfma_density:.2f}"
+            )
+    else:
+        print("\nC++ backend failed; skipped LLVM vs C++ metrics table.")
+    print(f"\nSaved: {case_dir / 'comparison_report.txt'}, {manifest_path}")
+
+
 def main():
     # Disable cache to ensure fresh compilation for each run
     # (moved from module level to avoid side effects at import time)
@@ -1202,7 +1704,21 @@ Examples:
         action="store_true",
         help="Include C++ waveasm-translate backend in comparison",
     )
+    parser.add_argument(
+        "--mxfp4",
+        choices=["4wave", "8wave", "both"],
+        help="Compare MXFP4 dbuf kernels (4-wave / 8-wave / both)",
+    )
     args = parser.parse_args()
+
+    if args.mxfp4:
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        keys = ["4wave", "8wave"] if args.mxfp4 == "both" else [args.mxfp4]
+        for key in keys:
+            run_mxfp4_comparison(key, output_dir, include_cpp=args.cpp)
+        print("\n>>> Done!")
+        return
 
     # Determine configuration
     if args.benchmark:

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMOps.td
@@ -110,7 +110,7 @@ class SALUBinaryOp<string mnemonic, list<Trait> traits = []>
 class SALUCmpOp<string mnemonic, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, traits> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
-  let results = (outs WaveASM_AnySReg:$result);  // SCC result (see note above)
+  let results = (outs WaveASM_AnySGPR:$result);  // SCC result (see note above)
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($result)";
 }
 
@@ -119,8 +119,8 @@ class SALUCmpOp<string mnemonic, list<Trait> traits = []>
 // MFMA instructions support inline 0 for the accumulator (no tying needed).
 class MFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_MFMAOp], traits)> {
-  let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_VALUSrc:$acc);
-  let results = (outs WaveASM_AnyVGPR:$dst);
+  let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_MFMAAccSrc:$acc);
+  let results = (outs WaveASM_AnyVecReg:$dst);
   let assemblyFormat = "$a `,` $b `,` $acc attr-dict `:` type($a) `,` type($b) `,` type($acc) `->` type($dst)";
 
   // Tied operand: result 0 is tied to operand 2 (accumulator) when acc is VGPR
@@ -322,6 +322,17 @@ def WaveASM_PrecoloredSRegOp : WAVEASMOp<"precolored.sreg", [Pure]> {
   let assemblyFormat = "$index (`,` $size^)? attr-dict `:` type($result)";
 }
 
+def WaveASM_PrecoloredARegOp : WAVEASMOp<"precolored.areg", [Pure]> {
+  let summary = "Define a precolored physical AGPR";
+  let description = [{
+    Defines an AGPR at a specific physical register index.
+  }];
+
+  let arguments = (ins I64Attr:$index, DefaultValuedAttr<I64Attr, "1">:$size);
+  let results = (outs WaveASM_AnyAGPR:$result);
+  let assemblyFormat = "$index (`,` $size^)? attr-dict `:` type($result)";
+}
+
 //===----------------------------------------------------------------------===//
 // Immediate Constant
 //===----------------------------------------------------------------------===//
@@ -364,26 +375,39 @@ def WaveASM_PackOp : WAVEASMOp<"pack", [Pure]> {
 }
 
 def WaveASM_ExtractOp : WAVEASMOp<"extract", [Pure]> {
-  let summary = "Extract scalar from vector VGPR";
+  let summary = "Extract element(s) from a vector register (VGPR or AGPR)";
   let description = [{
-    Extracts a scalar VGPR from a vector VGPR.
+    Extracts element(s) from a vector register at a given offset.
+    Supports both VGPR and AGPR sources. When the source is an AGPR,
+    the result is also an AGPR - this preserves AGPR type information
+    so that downstream store handlers can insert v_accvgpr_read_b32.
 
     Example:
     ```mlir
     %v0 = waveasm.extract %vec[0] : !waveasm.vreg<4> -> !waveasm.vreg
+    %a0 = waveasm.extract %avec[0] : !waveasm.areg<4> -> !waveasm.areg
     ```
   }];
 
-  let arguments = (ins WaveASM_AnyVGPR:$vector, I64Attr:$index);
-  let results = (outs WaveASM_AnyVGPR:$result);
+  let arguments = (ins WaveASM_AnyVecReg:$vector, I64Attr:$index);
+  let results = (outs WaveASM_AnyVecReg:$result);
   let assemblyFormat = "$vector `[` $index `]` attr-dict `:` type($vector) `->` type($result)";
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
 // VALU Unary Instructions
 //===----------------------------------------------------------------------===//
 
-def WaveASM_V_MOV_B32 : VALUUnaryOp<"v_mov_b32">;
+// v_mov_b32 supports both VGPR and AGPR destinations. When the destination
+// is an AGPR, the assembly emitter produces v_accvgpr_write_b32 instead.
+// This enables AGPR zero-init for MFMA accumulator loop init args on gfx950,
+// eliminating 128 VGPRs of accumulator zero-init pressure.
+def WaveASM_V_MOV_B32 : WAVEASMOp<"v_mov_b32", [Pure, WaveASM_ArithmeticOp]> {
+  let arguments = (ins WaveASM_VRegOrImm:$src);
+  let results = (outs WaveASM_AnyVecReg:$dst);
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($dst)";
+}
 def WaveASM_V_MOV_B64 : VALUUnaryOp<"v_mov_b64">;
 
 // Conversions
@@ -564,6 +588,21 @@ def WaveASM_V_WRITELANE_B32 : WAVEASMOp<"v_writelane_b32", [Pure]> {
   let arguments = (ins WaveASM_SRegOrImm:$src, WaveASM_SRegOrImm:$lane, WaveASM_AnyVGPR:$vdst_in);
   let results = (outs WaveASM_AnyVGPR:$dst);
   let assemblyFormat = "$src `,` $lane `,` $vdst_in attr-dict `:` type($src) `,` type($lane) `,` type($vdst_in) `->` type($dst)";
+}
+
+// VGPR/AGPR cross-bank moves
+def WaveASM_V_ACCVGPR_READ_B32 : WAVEASMOp<"v_accvgpr_read_b32", [Pure]> {
+  let summary = "Read AGPR lane into VGPR";
+  let arguments = (ins WaveASM_AnyAGPR:$src);
+  let results = (outs WaveASM_AnyVGPR:$dst);
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($dst)";
+}
+
+def WaveASM_V_ACCVGPR_WRITE_B32 : WAVEASMOp<"v_accvgpr_write_b32", [Pure]> {
+  let summary = "Write VGPR lane into AGPR";
+  let arguments = (ins WaveASM_AnyVGPR:$src, WaveASM_AnyAGPR:$adst);
+  let results = (outs);
+  let assemblyFormat = "$src `,` $adst attr-dict `:` type($src) `,` type($adst)";
 }
 
 //===----------------------------------------------------------------------===//
@@ -759,9 +798,9 @@ def WaveASM_V_MFMA_F32_32X32X16_BF8_BF8 : MFMAOp<"v_mfma_f32_32x32x16_bf8_bf8", 
 class ScaledMFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_MFMAOp], traits)> {
   // Operands: a_data, b_data, acc, a_scale, b_scale
-  let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_VALUSrc:$acc,
+  let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_MFMAAccSrc:$acc,
                        WaveASM_VALUSrc:$a_scale, WaveASM_VALUSrc:$b_scale);
-  let results = (outs WaveASM_AnyVGPR:$dst);
+  let results = (outs WaveASM_AnyVecReg:$dst);
   let assemblyFormat = "$a `,` $b `,` $acc `,` $a_scale `,` $b_scale attr-dict `:` type($a) `,` type($b) `,` type($acc) `,` type($a_scale) `,` type($b_scale) `->` type($dst)";
 
   // Tied operand: result 0 is tied to operand 2 (accumulator) when acc is VGPR

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMTypes.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Dialect/WaveASMTypes.td
@@ -114,6 +114,34 @@ def WaveASM_SRegType : WAVEASMType<"SReg", "sreg"> {
   }];
 }
 
+def WaveASM_ARegType : WAVEASMType<"AReg", "areg"> {
+  let summary = "Virtual AGPR";
+  let description = [{
+    Represents a virtual accumulator register that will be assigned to a
+    physical AGPR during register allocation.
+
+    Parameters:
+    - size: Number of consecutive registers
+    - alignment: Required physical alignment (default = size)
+  }];
+
+  let parameters = (ins
+    DefaultValuedParameter<"int64_t", "1">:$size,
+    DefaultValuedParameter<"int64_t", "1">:$alignment
+  );
+
+  let assemblyFormat = "(`<` $size^ (`,` $alignment^)? `>`)?";
+
+  let builders = [
+    TypeBuilder<(ins), [{
+      return $_get($_ctxt, 1, 1);
+    }]>,
+    TypeBuilder<(ins "int64_t":$size), [{
+      return $_get($_ctxt, size, size);
+    }]>
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Physical Register Types (Post-Allocation / Precolored)
 //===----------------------------------------------------------------------===//
@@ -182,6 +210,25 @@ def WaveASM_PSRegType : WAVEASMType<"PSReg", "psreg"> {
   }];
 }
 
+def WaveASM_PARegType : WAVEASMType<"PAReg", "pareg"> {
+  let summary = "Physical AGPR";
+  let description = [{
+    Represents a physical accumulator register at a specific hardware index.
+    Used after register allocation and for precolored AGPR values.
+  }];
+
+  let parameters = (ins
+    "int64_t":$index,
+    DefaultValuedParameter<"int64_t", "1">:$size
+  );
+
+  let assemblyFormat = "`<` $index (`,` $size^)? `>`";
+
+  let extraClassDeclaration = [{
+    int64_t getEndIndex() const { return getIndex() + getSize(); }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Immediate Value Type
 //===----------------------------------------------------------------------===//
@@ -228,22 +275,28 @@ def WaveASM_ImmType : WAVEASMType<"Imm", "imm"> {
 def WaveASM_AnyVReg : AnyTypeOf<[WaveASM_VRegType], "virtual VGPR">;
 def WaveASM_AnySReg : AnyTypeOf<[WaveASM_SRegType], "virtual SGPR">;
 def WaveASM_AnyVirtualReg : AnyTypeOf<[WaveASM_VRegType, WaveASM_SRegType], "virtual register">;
+def WaveASM_AnyAReg : AnyTypeOf<[WaveASM_ARegType], "virtual AGPR">;
+def WaveASM_AnyVirtualVecReg : AnyTypeOf<[WaveASM_VRegType, WaveASM_ARegType], "virtual vector register">;
 
 // Any physical register
 def WaveASM_AnyPVReg : AnyTypeOf<[WaveASM_PVRegType], "physical VGPR">;
 def WaveASM_AnyPSReg : AnyTypeOf<[WaveASM_PSRegType], "physical SGPR">;
-def WaveASM_AnyPhysicalReg : AnyTypeOf<[WaveASM_PVRegType, WaveASM_PSRegType], "physical register">;
+def WaveASM_AnyPAReg : AnyTypeOf<[WaveASM_PARegType], "physical AGPR">;
+def WaveASM_AnyPhysicalReg : AnyTypeOf<[WaveASM_PVRegType, WaveASM_PSRegType, WaveASM_PARegType], "physical register">;
+def WaveASM_AnyPhysicalVecReg : AnyTypeOf<[WaveASM_PVRegType, WaveASM_PARegType], "physical vector register">;
 
 // Any VGPR (virtual or physical)
 def WaveASM_AnyVGPR : AnyTypeOf<[WaveASM_VRegType, WaveASM_PVRegType], "any VGPR">;
+def WaveASM_AnyAGPR : AnyTypeOf<[WaveASM_ARegType, WaveASM_PARegType], "any AGPR">;
+def WaveASM_AnyVecReg : AnyTypeOf<[WaveASM_VRegType, WaveASM_ARegType, WaveASM_PVRegType, WaveASM_PARegType], "any vector register">;
 
 // Any SGPR (virtual or physical)
 def WaveASM_AnySGPR : AnyTypeOf<[WaveASM_SRegType, WaveASM_PSRegType], "any SGPR">;
 
 // Any register
 def WaveASM_AnyReg : AnyTypeOf<[
-  WaveASM_VRegType, WaveASM_SRegType,
-  WaveASM_PVRegType, WaveASM_PSRegType
+  WaveASM_VRegType, WaveASM_SRegType, WaveASM_ARegType,
+  WaveASM_PVRegType, WaveASM_PSRegType, WaveASM_PARegType
 ], "any register">;
 
 // Immediate
@@ -264,10 +317,17 @@ def WaveASM_VALUSrc : AnyTypeOf<[
   WaveASM_ImmType
 ], "VALU source operand">;
 
+// MFMA accumulator source: VGPR/AGPR or immediate
+def WaveASM_MFMAAccSrc : AnyTypeOf<[
+  WaveASM_VRegType, WaveASM_ARegType,
+  WaveASM_PVRegType, WaveASM_PARegType,
+  WaveASM_ImmType
+], "MFMA accumulator source">;
+
 // Any operand (register or immediate)
 def WaveASM_AnyOperand : AnyTypeOf<[
-  WaveASM_VRegType, WaveASM_SRegType,
-  WaveASM_PVRegType, WaveASM_PSRegType,
+  WaveASM_VRegType, WaveASM_SRegType, WaveASM_ARegType,
+  WaveASM_PVRegType, WaveASM_PSRegType, WaveASM_PARegType,
   WaveASM_ImmType
 ], "any operand">;
 

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/AssemblyEmitter.h
@@ -66,17 +66,23 @@ public:
   llvm::SmallVector<std::string> emitPrologue();
 
   /// Emit assembly epilogue (kernel symbol info, metadata YAML)
-  llvm::SmallVector<std::string>
-  emitEpilogue(int64_t peakVGPRs, int64_t peakSGPRs, int64_t ldsSize);
+  llvm::SmallVector<std::string> emitEpilogue(int64_t peakVGPRs,
+                                              int64_t peakSGPRs,
+                                              int64_t peakAGPRs,
+                                              int64_t ldsSize);
 
 private:
   /// Emit .amdhsa_kernel directive and its fields
-  llvm::SmallVector<std::string>
-  emitKernelDescriptor(int64_t peakVGPRs, int64_t peakSGPRs, int64_t ldsSize);
+  llvm::SmallVector<std::string> emitKernelDescriptor(int64_t peakVGPRs,
+                                                      int64_t peakSGPRs,
+                                                      int64_t peakAGPRs,
+                                                      int64_t ldsSize);
 
   /// Emit .amdgpu_metadata section
-  llvm::SmallVector<std::string>
-  emitMetadataYAML(int64_t peakVGPRs, int64_t peakSGPRs, int64_t ldsSize);
+  llvm::SmallVector<std::string> emitMetadataYAML(int64_t peakVGPRs,
+                                                  int64_t peakSGPRs,
+                                                  int64_t peakAGPRs,
+                                                  int64_t ldsSize);
 
   ProgramOp program;
   TargetAttrInterface target;
@@ -100,6 +106,9 @@ public:
 
   /// Get peak SGPR usage from allocation
   int64_t getPeakSGPRs() const { return peakSGPRs; }
+
+  /// Get peak AGPR usage from allocation
+  int64_t getPeakAGPRs() const { return peakAGPRs; }
 
 private:
   /// Resolve an SSA Value to its physical register string
@@ -173,6 +182,7 @@ private:
 
   int64_t peakVGPRs = 0;
   int64_t peakSGPRs = 0;
+  int64_t peakAGPRs = 0;
 
   /// Counter for generating unique loop labels in assembly
   int loopLabelCounter = 0;

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Liveness.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Liveness.h
@@ -77,6 +77,9 @@ struct LivenessInfo {
   /// SGPR ranges sorted by start point (for linear scan)
   llvm::SmallVector<LiveRange> sregRanges;
 
+  /// AGPR ranges sorted by start point (for linear scan)
+  llvm::SmallVector<LiveRange> aregRanges;
+
   /// Definition points for each register
   llvm::DenseMap<mlir::Value, int64_t> defPoints;
 
@@ -88,6 +91,9 @@ struct LivenessInfo {
 
   /// Maximum SGPR pressure (peak overlapping SGPRs)
   int64_t maxSRegPressure = 0;
+
+  /// Maximum AGPR pressure (peak overlapping AGPRs)
+  int64_t maxARegPressure = 0;
 
   /// Get live range for a value
   const LiveRange *getRange(mlir::Value value) const {

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.h
@@ -25,7 +25,8 @@ std::unique_ptr<mlir::Pass> createWAVEASMLivenessPass();
 /// Create the linear scan register allocation pass
 std::unique_ptr<mlir::Pass> createWAVEASMLinearScanPass();
 std::unique_ptr<mlir::Pass> createWAVEASMLinearScanPass(int64_t maxVGPRs,
-                                                        int64_t maxSGPRs);
+                                                        int64_t maxSGPRs,
+                                                        int64_t maxAGPRs);
 
 /// Create the hazard mitigation pass
 std::unique_ptr<mlir::Pass> createWAVEASMHazardMitigationPass();

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.td
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Passes.td
@@ -134,7 +134,9 @@ def WAVEASMLinearScan : Pass<"waveasm-linear-scan"> {
     Option<"maxVGPRs", "max-vgprs", "int64_t", "256",
            "Maximum VGPRs available">,
     Option<"maxSGPRs", "max-sgprs", "int64_t", "104",
-           "Maximum SGPRs available">
+           "Maximum SGPRs available">,
+    Option<"maxAGPRs", "max-agprs", "int64_t", "256",
+           "Maximum AGPRs available">
   ];
 
   let statistics = [

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegAlloc.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/RegAlloc.h
@@ -27,8 +27,10 @@ namespace waveasm {
 struct AllocationStats {
   int64_t peakVGPRs = 0;
   int64_t peakSGPRs = 0;
+  int64_t peakAGPRs = 0;
   int64_t totalVRegs = 0;
   int64_t totalSRegs = 0;
+  int64_t totalARegs = 0;
   int64_t rangesAllocated = 0;
   int64_t rangesExpired = 0;
 };
@@ -194,11 +196,13 @@ private:
 /// Linear scan register allocator for pure SSA IR
 class LinearScanRegAlloc {
 public:
-  LinearScanRegAlloc(int64_t maxVGPRs, int64_t maxSGPRs,
+  LinearScanRegAlloc(int64_t maxVGPRs, int64_t maxSGPRs, int64_t maxAGPRs,
                      const llvm::DenseSet<int64_t> &reservedVGPRs,
-                     const llvm::DenseSet<int64_t> &reservedSGPRs)
-      : maxVGPRs(maxVGPRs), maxSGPRs(maxSGPRs), reservedVGPRs(reservedVGPRs),
-        reservedSGPRs(reservedSGPRs) {}
+                     const llvm::DenseSet<int64_t> &reservedSGPRs,
+                     const llvm::DenseSet<int64_t> &reservedAGPRs)
+      : maxVGPRs(maxVGPRs), maxSGPRs(maxSGPRs), maxAGPRs(maxAGPRs),
+        reservedVGPRs(reservedVGPRs), reservedSGPRs(reservedSGPRs),
+        reservedAGPRs(reservedAGPRs) {}
 
   /// Precolor a Value to a specific physical register (for ABI args)
   void precolorValue(mlir::Value value, int64_t physIdx) {
@@ -226,8 +230,10 @@ private:
 
   int64_t maxVGPRs;
   int64_t maxSGPRs;
+  int64_t maxAGPRs;
   llvm::DenseSet<int64_t> reservedVGPRs;
   llvm::DenseSet<int64_t> reservedSGPRs;
+  llvm::DenseSet<int64_t> reservedAGPRs;
   llvm::DenseMap<mlir::Value, int64_t> precoloredValues;
   llvm::DenseMap<mlir::Value, mlir::Value> tiedOperands; // result -> operand
 };

--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -252,6 +252,9 @@ public:
   /// Create a virtual SGPR type
   SRegType createSRegType(int64_t size = 1, int64_t alignment = 1);
 
+  /// Create a virtual AGPR type
+  ARegType createARegType(int64_t size = 1, int64_t alignment = 1);
+
   /// Create an immediate type with a value
   ImmType createImmType(int64_t value);
 

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/LinearScanRegAlloc.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/LinearScanRegAlloc.cpp
@@ -88,11 +88,13 @@ static std::optional<int64_t> tryAllocate(RegPool &pool, int64_t size,
 
 /// Allocate registers for a single register class (VGPR or SGPR).
 /// This is the core linear scan algorithm, parameterized by register class.
-static LogicalResult allocateRegClass(
-    ArrayRef<LiveRange> ranges, RegPool &pool, PhysicalMapping &mapping,
-    AllocationStats &stats, const llvm::DenseMap<Value, Value> &tiedOperands,
-    const llvm::DenseMap<Value, int64_t> &precoloredValues, bool isVGPR,
-    ProgramOp program, int64_t maxRegs, int64_t maxPressure) {
+static LogicalResult
+allocateRegClass(ArrayRef<LiveRange> ranges, RegPool &pool,
+                 PhysicalMapping &mapping, AllocationStats &stats,
+                 const llvm::DenseMap<Value, Value> &tiedOperands,
+                 const llvm::DenseMap<Value, int64_t> &precoloredValues,
+                 llvm::StringRef regClassName, ProgramOp program,
+                 int64_t maxRegs, int64_t maxPressure) {
 
   llvm::SmallVector<ActiveRange> active;
 
@@ -170,7 +172,7 @@ static LogicalResult allocateRegClass(
 
     if (!physReg) {
       return program.emitOpError()
-             << "Failed to allocate " << (isVGPR ? "VGPR" : "SGPR")
+             << "Failed to allocate " << regClassName
              << " for value. Peak pressure: " << maxPressure
              << ", limit: " << maxRegs;
     }
@@ -206,16 +208,21 @@ LinearScanRegAlloc::allocate(ProgramOp program) {
 
   stats.totalVRegs = liveness.vregRanges.size();
   stats.totalSRegs = liveness.sregRanges.size();
+  stats.totalARegs = liveness.aregRanges.size();
 
   // Step 3: Create register pools with reserved registers
   RegPool vgprPool(RegClass::VGPR, maxVGPRs, reservedVGPRs);
   RegPool sgprPool(RegClass::SGPR, maxSGPRs, reservedSGPRs);
+  RegPool agprPool(RegClass::AGPR, maxAGPRs, reservedAGPRs);
 
   // Step 4: Handle precolored values (from ABI args like tid, kernarg)
   for (const auto &[value, physIdx] : precoloredValues) {
     if (isVGPRType(value.getType())) {
       mapping.valueToPhysReg[value] = physIdx;
       vgprPool.reserve(physIdx, getRegSize(value.getType()));
+    } else if (isAGPRType(value.getType())) {
+      mapping.valueToPhysReg[value] = physIdx;
+      agprPool.reserve(physIdx, getRegSize(value.getType()));
     } else if (isSGPRType(value.getType())) {
       mapping.valueToPhysReg[value] = physIdx;
       sgprPool.reserve(physIdx, getRegSize(value.getType()));
@@ -224,21 +231,27 @@ LinearScanRegAlloc::allocate(ProgramOp program) {
 
   // Step 5: Allocate VGPRs using linear scan
   if (failed(allocateRegClass(liveness.vregRanges, vgprPool, mapping, stats,
-                              tiedOperands, precoloredValues,
-                              /*isVGPR=*/true, program, maxVGPRs,
-                              liveness.maxVRegPressure))) {
+                              tiedOperands, precoloredValues, "VGPR", program,
+                              maxVGPRs, liveness.maxVRegPressure))) {
     return failure();
   }
   stats.peakVGPRs = vgprPool.getPeakUsage();
 
   // Step 6: Allocate SGPRs using linear scan
   if (failed(allocateRegClass(liveness.sregRanges, sgprPool, mapping, stats,
-                              tiedOperands, precoloredValues,
-                              /*isVGPR=*/false, program, maxSGPRs,
-                              liveness.maxSRegPressure))) {
+                              tiedOperands, precoloredValues, "SGPR", program,
+                              maxSGPRs, liveness.maxSRegPressure))) {
     return failure();
   }
   stats.peakSGPRs = sgprPool.getPeakUsage();
+
+  // Step 7: Allocate AGPRs using linear scan
+  if (failed(allocateRegClass(liveness.aregRanges, agprPool, mapping, stats,
+                              tiedOperands, precoloredValues, "AGPR", program,
+                              maxAGPRs, liveness.maxARegPressure))) {
+    return failure();
+  }
+  stats.peakAGPRs = agprPool.getPeakUsage();
 
   return std::make_pair(mapping, stats);
 }

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/MemoryOffsetOptimization.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/MemoryOffsetOptimization.cpp
@@ -265,6 +265,38 @@ static AddrAnalysis extractConstant(Value addr, OpBuilder &builder,
     // Try src1 as shifted, src0 as other
     if (auto result = tryShiftOperand(addLike->src1, addLike->src0))
       return *result;
+
+    // Recursive case: neither operand is a direct constant or shift, but one
+    // may contain an extractable constant deeper in its expression tree.
+    // V_ADD_U32(X, Y) where extractConstant(X) = (X_base, K), K != 0
+    //   -> V_ADD_U32(X_base, Y) + K
+    // This handles patterns like:
+    //   V_ADD_U32(V_ADD_U32(V_LSHLREV_B32(N, base+K), col), loop_offset)
+    // where the constant K is inside a nested shift within an add chain.
+    auto trySrcRecurse = [&](Value src,
+                             Value other) -> std::optional<AddrAnalysis> {
+      // Only recurse into add-like ops to avoid infinite recursion on
+      // non-add trees (shifts are already handled above).
+      if (!getAddLikeOp(src))
+        return std::nullopt;
+      auto srcAnalysis = extractConstant(src, builder, loc);
+      if (srcAnalysis.constOffset == 0)
+        return std::nullopt;
+      // Also recurse on the other operand
+      auto otherAnalysis = extractConstant(other, builder, loc);
+      auto totalConst =
+          safeAdd(srcAnalysis.constOffset, otherAnalysis.constOffset);
+      if (!totalConst)
+        return std::nullopt;
+      Value newBase = V_ADD_U32::create(builder, loc, addLike->resultType,
+                                        srcAnalysis.base, otherAnalysis.base);
+      return AddrAnalysis{newBase, *totalConst};
+    };
+
+    if (auto result = trySrcRecurse(addLike->src0, addLike->src1))
+      return *result;
+    if (auto result = trySrcRecurse(addLike->src1, addLike->src0))
+      return *result;
   }
 
   // Pattern 2: V_LSHLREV_B32(N, add_like(base, K))

--- a/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/AMDGPUHandlers.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/lib/Transforms/handlers/AMDGPUHandlers.cpp
@@ -294,16 +294,27 @@ LogicalResult handleAMDGPUScaledMfma(Operation *op, TranslationContext &ctx) {
     accSize = 16;
   }
 
-  auto vregType = ctx.createVRegType(accSize, 4);
+  // Use the accumulator input's type to determine the output type.
+  // When the accumulator comes from a loop iter_arg initialized as an AGPR
+  // (by RegionBuilder for gfx950 ScaledMFMA patterns), the MFMA result
+  // should also be an AGPR to maintain the loop-carried type. Otherwise,
+  // use VGPRs. This avoids unnecessarily forcing AGPRs on standalone MFMAs
+  // (not inside a loop) where they cause accum_offset overhead.
+  Type accRegType;
+  if (isAGPRType(srcC->getType())) {
+    accRegType = ctx.createARegType(accSize, 4);
+  } else {
+    accRegType = ctx.createVRegType(accSize, 4);
+  }
   Value result;
 
   // Generate the appropriate scaled MFMA instruction based on dimensions
   if (m == 16 && n == 16 && k == 128) {
     result = V_MFMA_SCALE_F32_16X16X128_F8F6F4::create(
-        builder, loc, vregType, *srcA, *srcB, *srcC, *scaleA, *scaleB);
+        builder, loc, accRegType, *srcA, *srcB, *srcC, *scaleA, *scaleB);
   } else if (m == 32 && n == 32 && k == 64) {
     result = V_MFMA_SCALE_F32_32X32X64_F8F6F4::create(
-        builder, loc, vregType, *srcA, *srcB, *srcC, *scaleA, *scaleB);
+        builder, loc, accRegType, *srcA, *srcB, *srcC, *scaleA, *scaleB);
   } else {
     return op->emitError("Unsupported scaled MFMA dimensions: ")
            << m << "x" << n << "x" << k;
@@ -635,7 +646,28 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
           if (auto immType = dyn_cast<ImmType>(rowContrib.getType())) {
             rowConstBytes = immType.getValue() * ldsRowStride;
             rowIsConst = true;
+          } else if (!isVGPRType(rowContrib.getType())) {
+            // Row index is an SGPR (e.g., from subgroup_broadcast via
+            // v_readfirstlane). Keep computation in SALU to avoid
+            // unnecessary VGPR pressure.
+            auto sregType = ctx.createSRegType();
+            if (llvm::isPowerOf2_64(ldsRowStride)) {
+              int64_t shiftAmt = llvm::Log2_64(ldsRowStride);
+              auto shiftImm = ctx.createImmType(shiftAmt);
+              auto shiftConst =
+                  ConstantOp::create(builder, loc, shiftImm, shiftAmt);
+              rowContrib = S_LSHL_B32::create(builder, loc, sregType,
+                                              rowContrib, shiftConst);
+            } else {
+              auto strideImm = ctx.createImmType(ldsRowStride);
+              auto strideConst =
+                  ConstantOp::create(builder, loc, strideImm, ldsRowStride);
+              rowContrib = S_MUL_I32::create(builder, loc, sregType, rowContrib,
+                                             strideConst);
+            }
+            rowIsConst = false;
           } else {
+            // Row index is a VGPR: use VALU multiply
             auto strideImm = ctx.createImmType(ldsRowStride);
             auto strideConst =
                 ConstantOp::create(builder, loc, strideImm, ldsRowStride);
@@ -731,17 +763,45 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
                                         m0Val, colConst);
             }
           } else if (colDynamic) {
-            m0Val = convertToVgpr(m0Val);
-            Value colVgpr = convertToVgpr(colDynamic);
-            if (ldsElemBytes > 1) {
-              auto scaleImm = ctx.createImmType(ldsElemBytes);
-              auto scaleConst =
-                  ConstantOp::create(builder, loc, scaleImm, ldsElemBytes);
-              colVgpr = V_MUL_LO_U32::create(builder, loc, ctx.createVRegType(),
-                                             colVgpr, scaleConst);
+            bool colIsSgpr = !isVGPRType(colDynamic.getType()) &&
+                             !isa<ImmType>(colDynamic.getType());
+            bool m0IsSgpr = m0Val && !isVGPRType(m0Val.getType());
+            if (colIsSgpr && m0IsSgpr) {
+              // Both SGPR: stay in SALU domain
+              Value colVal = colDynamic;
+              if (ldsElemBytes > 1) {
+                auto sregType = ctx.createSRegType();
+                if (llvm::isPowerOf2_64(ldsElemBytes)) {
+                  int64_t shiftAmt = llvm::Log2_64(ldsElemBytes);
+                  auto shiftImm = ctx.createImmType(shiftAmt);
+                  auto shiftConst =
+                      ConstantOp::create(builder, loc, shiftImm, shiftAmt);
+                  colVal = S_LSHL_B32::create(builder, loc, sregType, colVal,
+                                              shiftConst);
+                } else {
+                  auto scaleImm = ctx.createImmType(ldsElemBytes);
+                  auto scaleConst =
+                      ConstantOp::create(builder, loc, scaleImm, ldsElemBytes);
+                  colVal = S_MUL_I32::create(builder, loc, sregType, colVal,
+                                             scaleConst);
+                }
+              }
+              auto sregType = ctx.createSRegType();
+              m0Val = S_ADD_U32::create(builder, loc, sregType, m0Val, colVal);
+            } else {
+              // At least one is VGPR: fall back to VALU
+              m0Val = convertToVgpr(m0Val);
+              Value colVgpr = convertToVgpr(colDynamic);
+              if (ldsElemBytes > 1) {
+                auto scaleImm = ctx.createImmType(ldsElemBytes);
+                auto scaleConst =
+                    ConstantOp::create(builder, loc, scaleImm, ldsElemBytes);
+                colVgpr = V_MUL_LO_U32::create(
+                    builder, loc, ctx.createVRegType(), colVgpr, scaleConst);
+              }
+              m0Val = V_ADD_U32::create(builder, loc, ctx.createVRegType(),
+                                        m0Val, colVgpr);
             }
-            m0Val = V_ADD_U32::create(builder, loc, ctx.createVRegType(), m0Val,
-                                      colVgpr);
           }
         }
 

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/linear-scan-ifop-bug.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/linear-scan-ifop-bug.mlir
@@ -1,0 +1,145 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// BUG: IfOp yield type mismatch after register allocation.
+//
+// The LinearScanPass updates IfOp result types using the then-branch's
+// YieldOp operand types (LinearScanPass.cpp lines 352-361), but does NOT
+// update the else-branch's YieldOp operand types. When the then-branch
+// and else-branch yield values allocated to DIFFERENT physical registers,
+// MLIR verification fails because the IfOp's result type doesn't match
+// the else-branch's yield type.
+//
+// Root cause: LinearScanPass.cpp only walks then-branch:
+//   program.walk([&](IfOp ifOp) {
+//     auto &thenBlock = ifOp.getThenBlock();
+//     if (auto yieldOp = dyn_cast<YieldOp>(thenBlock.getTerminator())) {
+//       for (unsigned i = 0; i < ifOp->getNumResults(); ++i) {
+//         ifOp->getResult(i).setType(yieldOp.getResults()[i].getType());
+//       }
+//     }
+//   });
+//
+// The fix should ensure both branches' yield types are consistent, either by:
+// (a) Also updating the else-branch yield types, or
+// (b) The allocator ensuring both branches yield the same physical register
+//     (inserting copies if needed), or
+// (c) Using the allocation mapping to determine the IfOp result type
+//     independently of which branch's yield types we look at.
+
+// Each of these tests triggers the verification error.
+// We check that the error message appears.
+
+// CHECK: error: 'waveasm.if' op along control flow edge from Operation waveasm.yield to parent
+// CHECK: error: 'waveasm.if' op along control flow edge from Operation waveasm.yield to parent
+// CHECK: error: 'waveasm.if' op along control flow edge from Operation waveasm.yield to parent
+
+//===----------------------------------------------------------------------===//
+// Test 1: Minimal reproduction -- standalone IfOp
+//
+// Then-branch computes v_add_u32 (gets pvreg<X>), else-branch passes
+// through %val (keeps pvreg<Y>). X != Y -> verification failure.
+//===----------------------------------------------------------------------===//
+
+waveasm.program @if_yield_type_mismatch
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+  %s_zero = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+
+  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+    %added = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+    waveasm.yield %added : !waveasm.vreg
+  } else {
+    waveasm.yield %val : !waveasm.vreg
+  }
+
+  %use = waveasm.v_add_u32 %result, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: IfOp inside loop body -- affects loop back-edge consistency
+//===----------------------------------------------------------------------===//
+
+waveasm.program @if_in_loop_type_mismatch
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    %cmp = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+
+    %new_val = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+      %added = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+      waveasm.yield %added : !waveasm.vreg
+    } else {
+      waveasm.yield %val : !waveasm.vreg
+    }
+
+    %new_sum = waveasm.v_add_u32 %new_val, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i, %new_sum) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 3: Multiple IfOps in sequence -- compound type propagation failure
+//===----------------------------------------------------------------------===//
+
+waveasm.program @multiple_ifs_compound
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    %cmp1 = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %if1_result = waveasm.if %cmp1 : !waveasm.sreg -> !waveasm.vreg {
+      %a1 = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+      waveasm.yield %a1 : !waveasm.vreg
+    } else {
+      waveasm.yield %val : !waveasm.vreg
+    }
+
+    %cmp2 = waveasm.s_cmp_lt_u32 %i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    %if2_result = waveasm.if %cmp2 : !waveasm.sreg -> !waveasm.vreg {
+      %b1 = waveasm.v_add_u32 %if1_result, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+      waveasm.yield %b1 : !waveasm.vreg
+    } else {
+      waveasm.yield %if1_result : !waveasm.vreg
+    }
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i, %if2_result) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/linear-scan-stress.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/linear-scan-stress.mlir
@@ -1,0 +1,550 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// Stress tests for the linear scan register allocator.
+// These tests all PASS -- they verify correct behavior under various
+// pressure scenarios. See linear-scan-ifop-bug.mlir for known bugs.
+
+//===----------------------------------------------------------------------===//
+// Test 1: Register reuse after expiry
+//
+// When a value dies and its register is freed, a later value should reuse it.
+// Verifies expireRanges() correctly returns registers to the pool.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @reuse_after_expiry
+// CHECK-NOT: Failed to allocate
+waveasm.program @reuse_after_expiry
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  // First chain: values die before second chain starts
+  %a1 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+  %a2 = waveasm.v_add_u32 %a1, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %a3 = waveasm.v_add_u32 %a2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %a4 = waveasm.v_add_u32 %a3, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+  // Second chain: should reuse registers freed from first chain
+  %b1 = waveasm.v_add_u32 %a4, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %b2 = waveasm.v_add_u32 %b1, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %b3 = waveasm.v_add_u32 %b2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %b4 = waveasm.v_add_u32 %b3, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: Fragmented multi-register ranges
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @fragmented_multi_reg
+// CHECK-NOT: Failed to allocate
+waveasm.program @fragmented_multi_reg
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  // CHECK: -> !waveasm.pvreg<{{[0-9]+}}, 4>
+  %vec1 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %s1 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+  %s2 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+  %s3 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+  %kill_s = waveasm.v_add_u32 %s1, %s2 : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+  %kill_s2 = waveasm.v_add_u32 %kill_s, %s3 : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+  // CHECK: -> !waveasm.pvreg<{{[0-9]+}}, 4>
+  %vec2 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %use1 = waveasm.v_add_u32 %vec1, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %use2 = waveasm.v_add_u32 %vec2, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %use3 = waveasm.v_add_u32 %kill_s2, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 3: Loop with ds_read results competing with accumulators
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @loop_dsread_acc_competition
+// CHECK-NOT: Failed to allocate
+waveasm.program @loop_dsread_acc_competition
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %a = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %b = waveasm.precolored.vreg 8, 4 : !waveasm.pvreg<8, 4>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc0 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %init_acc1 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %init_acc2 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %init_acc3 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  // CHECK: waveasm.loop
+  %ri, %r0, %r1, %r2, %r3 = waveasm.loop(
+      %i = %init_i,
+      %acc0 = %init_acc0, %acc1 = %init_acc1,
+      %acc2 = %init_acc2, %acc3 = %init_acc3)
+      : (!waveasm.sreg,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>)
+      -> (!waveasm.sreg,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>) {
+
+    %lds_data0 = waveasm.ds_read_b128 %v0 : !waveasm.pvreg<0> -> !waveasm.vreg<4, 4>
+    %lds_data1 = waveasm.ds_read_b128 %v0 : !waveasm.pvreg<0> -> !waveasm.vreg<4, 4>
+
+    %n0 = waveasm.v_mfma_f32_16x16x16_f16 %lds_data0, %lds_data1, %acc0
+        : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n1 = waveasm.v_mfma_f32_16x16x16_f16 %lds_data0, %lds_data1, %acc1
+        : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n2 = waveasm.v_mfma_f32_16x16x16_f16 %lds_data0, %lds_data1, %acc2
+        : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n3 = waveasm.v_mfma_f32_16x16x16_f16 %lds_data0, %lds_data1, %acc3
+        : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %n0, %n1, %n2, %n3)
+        : !waveasm.sreg,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
+  }
+
+  %use0 = waveasm.v_add_u32 %r0, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %use1 = waveasm.v_add_u32 %r3, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 4: Value defined before loop, used inside and after
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @value_live_across_loop
+// CHECK-NOT: Failed to allocate
+waveasm.program @value_live_across_loop
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  // CHECK: -> !waveasm.pvreg<[[OUTSIDE:[0-9]+]]>
+  %outside_val = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_sum = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %sum_out = waveasm.loop(%i = %init_i, %sum = %init_sum)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[OUTSIDE]]>
+    %tmp = waveasm.v_add_u32 %sum, %outside_val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+    %tmp2 = waveasm.v_add_u32 %tmp, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+    %tmp3 = waveasm.v_add_u32 %tmp2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %tmp3) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[OUTSIDE]]>
+  %post = waveasm.v_add_u32 %sum_out, %outside_val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 5: Nested loops
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @nested_loops
+// CHECK-NOT: Failed to allocate
+waveasm.program @nested_loops
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c4 = waveasm.constant 4 : !waveasm.imm<4>
+  %c8 = waveasm.constant 8 : !waveasm.imm<8>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %outer_init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %outer_init_sum = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.loop
+  %oi_out, %osum_out = waveasm.loop(%oi = %outer_init_i, %osum = %outer_init_sum)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    %inner_init_j = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+    // CHECK: waveasm.loop
+    %ij_out, %inner_result = waveasm.loop(%ij = %inner_init_j, %inner_acc = %osum)
+        : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+      %inner_tmp = waveasm.v_add_u32 %inner_acc, %v0
+          : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+      %next_j = waveasm.s_add_u32 %ij, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+      %inner_cond = waveasm.s_cmp_lt_u32 %next_j, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+      waveasm.condition %inner_cond : !waveasm.sreg iter_args(%next_j, %inner_tmp) : !waveasm.sreg, !waveasm.vreg
+    }
+
+    %outer_new_sum = waveasm.v_add_u32 %inner_result, %c1
+        : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+    %next_i = waveasm.s_add_u32 %oi, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %outer_cond = waveasm.s_cmp_lt_u32 %next_i, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %outer_cond : !waveasm.sreg iter_args(%next_i, %outer_new_sum) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 6: 8 MFMA chains in loop with ds_read data
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @multi_mfma_chain_loop
+// CHECK-NOT: Failed to allocate
+waveasm.program @multi_mfma_chain_loop
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c16 = waveasm.constant 16 : !waveasm.imm<16>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %z0 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z1 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z2 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z3 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z4 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z5 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z6 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z7 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  // CHECK: waveasm.loop
+  %ri, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7 = waveasm.loop(
+      %i = %init_i,
+      %acc0 = %z0, %acc1 = %z1, %acc2 = %z2, %acc3 = %z3,
+      %acc4 = %z4, %acc5 = %z5, %acc6 = %z6, %acc7 = %z7)
+      : (!waveasm.sreg,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>)
+      -> (!waveasm.sreg,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>) {
+
+    %lds_a = waveasm.ds_read_b128 %v0 : !waveasm.pvreg<0> -> !waveasm.vreg<4, 4>
+    %lds_b = waveasm.ds_read_b128 %v0 : !waveasm.pvreg<0> -> !waveasm.vreg<4, 4>
+
+    %n0 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc0 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n1 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc1 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n2 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc2 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n3 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc3 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n4 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc4 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n5 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc5 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n6 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc6 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n7 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc7 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7)
+        : !waveasm.sreg,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
+  }
+
+  %use0 = waveasm.v_add_u32 %r0, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+  %use7 = waveasm.v_add_u32 %r7, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 7: MFMA result reuse as generic source
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @mfma_result_reuse
+// CHECK-NOT: Failed to allocate
+waveasm.program @mfma_result_reuse
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %v8 = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
+
+  // CHECK: -> !waveasm.pvreg<[[ACC:[0-9]+]], 4>
+  %acc0 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  // CHECK: -> !waveasm.pvreg<[[ACC]], 4>
+  %acc1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc0
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[ACC]], 4>
+  %readback = waveasm.v_add_u32 %acc1, %v8
+      : !waveasm.vreg<4, 4>, !waveasm.pvreg<8> -> !waveasm.vreg
+  // CHECK: -> !waveasm.pvreg<[[ACC]], 4>
+  %acc2 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc1
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+  %use = waveasm.v_add_u32 %readback, %v8 : !waveasm.vreg, !waveasm.pvreg<8> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 8: Block arg used only as MFMA accumulator (late use)
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @blockarg_only_mfma_use
+// CHECK-NOT: Failed to allocate
+waveasm.program @blockarg_only_mfma_use
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c8 = waveasm.constant 8 : !waveasm.imm<8>
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: -> !waveasm.pvreg<[[BA_ACC:[0-9]+]], 4>
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %i_out, %acc_out = waveasm.loop(%i = %init_i, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+
+    // Pressure-creating work before MFMA
+    %t1 = waveasm.v_add_u32 %a, %c1 : !waveasm.pvreg<0, 4>, !waveasm.imm<1> -> !waveasm.vreg
+    %t2 = waveasm.v_add_u32 %t1, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+    %t3 = waveasm.v_add_u32 %t2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+    %t4 = waveasm.v_add_u32 %t3, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+    %t5 = waveasm.v_add_u32 %t4, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+    // MFMA at end -- block arg must still be alive
+    // CHECK: v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pvreg<[[BA_ACC]], 4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  %v8 = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[BA_ACC]], 4>
+  %final = waveasm.v_add_u32 %acc_out, %v8 : !waveasm.vreg<4, 4>, !waveasm.pvreg<8> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 9: Two sequential loops -- register reuse
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @sequential_loops
+// CHECK-NOT: Failed to allocate
+waveasm.program @sequential_loops
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c8 = waveasm.constant 8 : !waveasm.imm<8>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %a = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %b = waveasm.precolored.vreg 8, 4 : !waveasm.pvreg<8, 4>
+
+  // First loop
+  %init_i1 = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc1 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %i1_out, %acc1_out = waveasm.loop(%i1 = %init_i1, %loop1_acc = %init_acc1)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+    %n1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %loop1_acc
+        : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %next_i1 = waveasm.s_add_u32 %i1, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond1 = waveasm.s_cmp_lt_u32 %next_i1, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %cond1 : !waveasm.sreg iter_args(%next_i1, %n1) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  %use1 = waveasm.v_add_u32 %acc1_out, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // Second loop -- should reuse registers
+  %init_i2 = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc2 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %i2_out, %acc2_out = waveasm.loop(%i2 = %init_i2, %loop2_acc = %init_acc2)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+    %n2 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %loop2_acc
+        : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %next_i2 = waveasm.s_add_u32 %i2, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond2 = waveasm.s_cmp_lt_u32 %next_i2, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %cond2 : !waveasm.sreg iter_args(%next_i2, %n2) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  %use2 = waveasm.v_add_u32 %acc2_out, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 10: Unused block arg forwarded through condition
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @blockarg_cond_only
+// CHECK-NOT: Failed to allocate
+waveasm.program @blockarg_cond_only
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+  // CHECK: -> !waveasm.pvreg<[[FWD:[0-9]+]]>
+  %init_sum = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %val_out, %sum_out = waveasm.loop(%i = %init_i, %val = %init_val, %sum = %init_sum)
+      : (!waveasm.sreg, !waveasm.vreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg, !waveasm.vreg) {
+
+    %new_val = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %new_val, %sum) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
+  }
+
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[FWD]]>
+  %final = waveasm.v_add_u32 %sum_out, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 11: Long epilogue -- loop result survives
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @long_epilogue
+// CHECK-NOT: Failed to allocate
+waveasm.program @long_epilogue
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c8 = waveasm.constant 8 : !waveasm.imm<8>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: -> !waveasm.pvreg<[[EPIL_ACC:[0-9]+]], 4>
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %i_out, %acc_out = waveasm.loop(%i = %init_i, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+    %la = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+    %lb = waveasm.precolored.vreg 8, 4 : !waveasm.pvreg<8, 4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %la, %lb, %acc
+        : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  // Long epilogue chain
+  %e1 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+  %e2 = waveasm.v_add_u32 %e1, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e3 = waveasm.v_add_u32 %e2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e4 = waveasm.v_add_u32 %e3, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e5 = waveasm.v_add_u32 %e4, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e6 = waveasm.v_add_u32 %e5, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e7 = waveasm.v_add_u32 %e6, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+  %e8 = waveasm.v_add_u32 %e7, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+  // Loop result used AFTER long epilogue -- must not be clobbered
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[EPIL_ACC]], 4>
+  %final = waveasm.v_add_u32 %acc_out, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 12: Large 16-register MFMA with fragmented precoloring
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @large_alignment
+// CHECK-NOT: Failed to allocate
+waveasm.program @large_alignment
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %v0 = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %v4 = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %v8 = waveasm.precolored.vreg 8, 4 : !waveasm.pvreg<8, 4>
+  %v12 = waveasm.precolored.vreg 12, 4 : !waveasm.pvreg<12, 4>
+
+  // CHECK: -> !waveasm.pvreg<[[BIG:[0-9]+]], 16>
+  %big_vec = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<16>
+  // CHECK: -> !waveasm.pvreg<[[BIG]], 16>
+  %mfma_result = waveasm.v_mfma_f32_32x32x8_f16 %v0, %v4, %big_vec
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<16> -> !waveasm.vreg<16>
+
+  // CHECK: waveasm.s_endpgm
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 13: AGPR allocation smoke test
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: waveasm.program @agpr_pressure_smoke
+// CHECK-NOT: Failed to allocate
+waveasm.program @agpr_pressure_smoke
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %acc0 = waveasm.precolored.areg 16, 4 : !waveasm.pareg<16, 4>
+  %acc1 = waveasm.precolored.areg 20, 4 : !waveasm.pareg<20, 4>
+
+  // CHECK: -> !waveasm.pareg<16, 4>
+  %r0 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc0
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.pareg<16, 4> -> !waveasm.areg<4, 4>
+  // CHECK: -> !waveasm.pareg<20, 4>
+  %r1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc1
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.pareg<20, 4> -> !waveasm.areg<4, 4>
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-assembly-emit.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-assembly-emit.mlir
@@ -1,0 +1,21 @@
+// RUN: waveasm-translate --emit-assembly %s | FileCheck %s
+
+// CHECK-LABEL: accvgpr_emit_test:
+// CHECK: v_accvgpr_read_b32 v2, a0
+// CHECK: v_accvgpr_write_b32 v2, a0
+// CHECK: v_mfma_f32_16x16x16_f16 a[4:7], v[0:3], v[0:3], a[4:7]
+// CHECK: .amdhsa_accum_offset
+// CHECK: .amdhsa_next_free_vgpr
+waveasm.program @accvgpr_emit_test target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %v0 = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %v2 = waveasm.precolored.vreg 2 : !waveasm.pvreg<2>
+  %a0 = waveasm.precolored.areg 0 : !waveasm.pareg<0>
+  %acc = waveasm.precolored.areg 4, 4 : !waveasm.pareg<4, 4>
+
+  %r = waveasm.v_accvgpr_read_b32 %a0 : !waveasm.pareg<0> -> !waveasm.pvreg<2>
+  waveasm.v_accvgpr_write_b32 %r, %a0 : !waveasm.pvreg<2>, !waveasm.pareg<0>
+  %next = waveasm.v_mfma_f32_16x16x16_f16 %v0, %v0, %acc
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<0, 4>, !waveasm.pareg<4, 4> -> !waveasm.pareg<4, 4>
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-data-movement.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-data-movement.mlir
@@ -1,0 +1,14 @@
+// RUN: waveasm-translate --emit-assembly %s | FileCheck %s
+
+// CHECK-LABEL: accvgpr_move_test:
+// CHECK: v_accvgpr_read_b32 v10, a12
+// CHECK: v_accvgpr_write_b32 v10, a12
+waveasm.program @accvgpr_move_test target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %v10 = waveasm.precolored.vreg 10 : !waveasm.pvreg<10>
+  %a12 = waveasm.precolored.areg 12 : !waveasm.pareg<12>
+
+  %tmp = waveasm.v_accvgpr_read_b32 %a12 : !waveasm.pareg<12> -> !waveasm.pvreg<10>
+  waveasm.v_accvgpr_write_b32 %tmp, %a12 : !waveasm.pvreg<10>, !waveasm.pareg<12>
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-negative.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-negative.mlir
@@ -1,0 +1,16 @@
+// RUN: not waveasm-translate --waveasm-linear-scan --max-agprs=4 %s 2>&1 | FileCheck %s
+
+waveasm.program @accvgpr_limit_fail target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  // Reserve all available AGPRs (limit is 4 in RUN line).
+  %acc0 = waveasm.precolored.areg 0, 4 : !waveasm.pareg<0, 4>
+
+  // Any new 4-wide AGPR allocation must fail.
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %r0 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %zero
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.imm<0> -> !waveasm.areg<4, 4>
+  waveasm.s_endpgm
+}
+
+// CHECK: Failed to allocate AGPR

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-regalloc.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/lit-accvgpr-regalloc.mlir
@@ -1,0 +1,34 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+
+// CHECK-LABEL: waveasm.program @mfma_agpr_tied
+waveasm.program @mfma_agpr_tied target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  // CHECK: waveasm.precolored.areg 32, 4 : !waveasm.pareg<32, 4>
+  %acc0 = waveasm.precolored.areg 32, 4 : !waveasm.pareg<32, 4>
+
+  // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pareg<32, 4>
+  %acc1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc0
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.pareg<32, 4> -> !waveasm.areg<4, 4>
+
+  // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pareg<32, 4>
+  %acc2 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc1
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.areg<4, 4> -> !waveasm.areg<4, 4>
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: waveasm.program @scaled_mfma_agpr_tied
+waveasm.program @scaled_mfma_agpr_tied target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %as = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
+  %bs = waveasm.precolored.vreg 9 : !waveasm.pvreg<9>
+  %acc0 = waveasm.precolored.areg 40, 4 : !waveasm.pareg<40, 4>
+
+  // CHECK: waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 {{.*}} -> !waveasm.pareg<40, 4>
+  %acc1 = waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 %a, %b, %acc0, %as, %bs
+      : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.pareg<40, 4>, !waveasm.pvreg<8>, !waveasm.pvreg<9> -> !waveasm.areg<4, 4>
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/loop-pressure-regression.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/loop-pressure-regression.mlir
@@ -1,0 +1,151 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// Regression test: Verify that loop results do not inflate peak VGPR pressure.
+//
+// This test creates a reduced double-buffered GEMM pattern with enough
+// accumulator iter_args and loop body data to exceed 256 VGPRs if loop
+// results incorrectly overlap the loop body. With the fix (loop result
+// def points after the loop), the accumulators are only counted once
+// and regalloc succeeds.
+//
+// Without the fix: 30 vreg<4,4> loop results (120 VGPRs) + 30 vreg<4,4>
+// block args (120 VGPRs) + body data (~40 VGPRs) = ~280 peak > 256 limit.
+// With the fix: 30 vreg<4,4> block args (120 VGPRs) + body data (~40 VGPRs)
+// = ~160 peak < 256 limit.
+
+// CHECK-LABEL: waveasm.program @double_buffer_pressure
+// CHECK-NOT: Failed to allocate
+waveasm.program @double_buffer_pressure
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c16 = waveasm.constant 16 : !waveasm.imm<16>
+
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %v8 = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
+
+  // Initialize 30 accumulator vreg<4,4> = 120 VGPRs
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %z0 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z1 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z2 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z3 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z4 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z5 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z6 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z7 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z8 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z9 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z10 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z11 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z12 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z13 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z14 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z15 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z16 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z17 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z18 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z19 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z20 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z21 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z22 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z23 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z24 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z25 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z26 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z27 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z28 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %z29 = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  // CHECK: waveasm.loop
+  %ri, %r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9, %r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17, %r18, %r19, %r20, %r21, %r22, %r23, %r24, %r25, %r26, %r27, %r28, %r29 = waveasm.loop(
+      %i = %init_i,
+      %acc0 = %z0, %acc1 = %z1, %acc2 = %z2, %acc3 = %z3,
+      %acc4 = %z4, %acc5 = %z5, %acc6 = %z6, %acc7 = %z7,
+      %acc8 = %z8, %acc9 = %z9, %acc10 = %z10, %acc11 = %z11,
+      %acc12 = %z12, %acc13 = %z13, %acc14 = %z14, %acc15 = %z15,
+      %acc16 = %z16, %acc17 = %z17, %acc18 = %z18, %acc19 = %z19,
+      %acc20 = %z20, %acc21 = %z21, %acc22 = %z22, %acc23 = %z23,
+      %acc24 = %z24, %acc25 = %z25, %acc26 = %z26, %acc27 = %z27,
+      %acc28 = %z28, %acc29 = %z29)
+      : (!waveasm.sreg,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>)
+      -> (!waveasm.sreg,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+         !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>) {
+
+    // MFMA chains: accumulate into each accumulator
+    %n0 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc0 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc1 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n2 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc2 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n3 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc3 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n4 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc4 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n5 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc5 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n6 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc6 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n7 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc7 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n8 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc8 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n9 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc9 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n10 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc10 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n11 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc11 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n12 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc12 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n13 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc13 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n14 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc14 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n15 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc15 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n16 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc16 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n17 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc17 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n18 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc18 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n19 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc19 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n20 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc20 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n21 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc21 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n22 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc22 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n23 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc23 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n24 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc24 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n25 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc25 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n26 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc26 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n27 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc27 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n28 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc28 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+    %n29 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc29 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    // Loop counter
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i,
+        %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7,
+        %n8, %n9, %n10, %n11, %n12, %n13, %n14, %n15,
+        %n16, %n17, %n18, %n19, %n20, %n21, %n22, %n23,
+        %n24, %n25, %n26, %n27, %n28, %n29)
+        : !waveasm.sreg,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
+          !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
+  }
+
+  // Use a few loop results after the loop (forces them to be live in epilogue)
+  // CHECK: waveasm.v_add_u32
+  %use0 = waveasm.v_add_u32 %r0, %v8 : !waveasm.vreg<4, 4>, !waveasm.pvreg<8> -> !waveasm.vreg
+  %use1 = waveasm.v_add_u32 %r15, %v8 : !waveasm.vreg<4, 4>, !waveasm.pvreg<8> -> !waveasm.vreg
+  %use2 = waveasm.v_add_u32 %r29, %v8 : !waveasm.vreg<4, 4>, !waveasm.pvreg<8> -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/loop-result-liveness.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/loop-result-liveness.mlir
@@ -1,0 +1,106 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// Test that loop results do NOT inflate register pressure inside the loop body.
+// Loop results are only available after the loop exits, so their live ranges
+// should start after the loop, not at the LoopOp itself.
+
+//===----------------------------------------------------------------------===//
+// Test 1: Loop results should not inflate body pressure
+//===----------------------------------------------------------------------===//
+
+// This test creates a loop with vreg<4,4> iter_args (accumulators) plus
+// additional vreg values inside the loop body. If loop results incorrectly
+// have their def point at the LoopOp index, they would double-count the
+// accumulator VGPRs during the loop body, inflating pressure.
+//
+// The key check is that regalloc succeeds (no "Failed to allocate" error)
+// and that the loop result gets a physical register via tying.
+
+// CHECK-LABEL: waveasm.program @loop_result_no_body_pressure
+waveasm.program @loop_result_no_body_pressure
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %v4 = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+
+  // Initialize loop counter and accumulator
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: waveasm.v_mov_b32 {{.*}} -> !waveasm.pvreg<[[ACC:[0-9]+]], 4>
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  // Loop: iter_args carry (counter, accumulator)
+  // CHECK: waveasm.loop
+  %i_out, %acc_out = waveasm.loop(%i = %init_i, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+
+    // Some work inside the loop body using VGPRs
+    %tmp1 = waveasm.v_add_u32 %v0, %c1 : !waveasm.pvreg<0>, !waveasm.imm<1> -> !waveasm.vreg
+    %tmp2 = waveasm.v_add_u32 %tmp1, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
+
+    // MFMA: result tied to accumulator iter_arg
+    // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pvreg<[[ACC]], 4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %v4, %v4, %acc
+        : !waveasm.pvreg<4, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    // Loop bookkeeping
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  // Use the loop result after the loop -- should get same phys reg as accumulator
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[ACC]], 4>{{.*}} -> !waveasm.pvreg<
+  %use = waveasm.v_add_u32 %acc_out, %v0
+      : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: Loop result tied to block arg (MFMA accumulator chain)
+//===----------------------------------------------------------------------===//
+
+// Verify the full tying chain: init_acc -> block_arg -> MFMA result ->
+// condition iter_arg -> loop result all share the same physical register.
+
+// CHECK-LABEL: waveasm.program @loop_result_tied_to_block_arg
+waveasm.program @loop_result_tied_to_block_arg
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c8 = waveasm.constant 8 : !waveasm.imm<8>
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+
+  // Init accumulator
+  // CHECK: waveasm.v_mov_b32 {{.*}} -> !waveasm.pvreg<[[TIED_ACC:[0-9]+]], 4>
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  // Loop with MFMA accumulator
+  %i_out, %acc_out = waveasm.loop(%i = %init_i, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+
+    // MFMA with tied accumulator -- result MUST get same phys reg
+    // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pvreg<[[TIED_ACC]], 4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
+
+    %next_i = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  // Post-loop use of accumulator result -- same physical register
+  // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[TIED_ACC]], 4>{{.*}} -> !waveasm.pvreg<
+  %final = waveasm.v_add_u32 %acc_out, %a
+      : !waveasm.vreg<4, 4>, !waveasm.pvreg<0, 4> -> !waveasm.vreg
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/mfma-tied-operands.mlir
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/Transforms/mfma-tied-operands.mlir
@@ -82,3 +82,17 @@ waveasm.program @mfma_16x16 target = #waveasm.target<#waveasm.gfx942, 5> abi = #
 
   waveasm.s_endpgm
 }
+
+// Test 5: MFMA with AGPR accumulator - result tied to AGPR.
+// CHECK-LABEL: waveasm.program @mfma_agpr_tied
+waveasm.program @mfma_agpr_tied target = #waveasm.target<#waveasm.gfx950, 5> abi = #waveasm.abi<> {
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  // CHECK: waveasm.precolored.areg 24, 4 : !waveasm.pareg<24, 4>
+  %acc0 = waveasm.precolored.areg 24, 4 : !waveasm.pareg<24, 4>
+
+  // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pareg<24, 4>
+  %acc1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc0 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.pareg<24, 4> -> !waveasm.areg<4, 4>
+
+  waveasm.s_endpgm
+}

--- a/wave_lang/kernel/wave/asm/wave_asm/test/e2e/waveasm_e2e.py
+++ b/wave_lang/kernel/wave/asm/wave_asm/test/e2e/waveasm_e2e.py
@@ -198,6 +198,8 @@ class WaveASMCompiler:
             "--waveasm-peephole",  # Run peephole optimizations (fuse lshl+add, etc.)
             "--waveasm-memory-offset-opt",  # Fold constant addresses into offset fields
             "--waveasm-linear-scan",  # Run register allocation
+            "--max-vgprs=512",  # Allow up to 512 VGPRs (4-wave occupancy)
+            "--max-agprs=512",  # Allow up to 512 AGPRs (accumulators)
             "--waveasm-insert-waitcnt",  # Insert wait instructions
             "--waveasm-hazard-mitigation",  # Handle hazards
             "--emit-assembly",  # Emit AMDGCN assembly

--- a/wave_lang/kernel/wave/asm/wave_asm/tools/waveasm-translate/waveasm-translate.cpp
+++ b/wave_lang/kernel/wave/asm/wave_asm/tools/waveasm-translate/waveasm-translate.cpp
@@ -135,6 +135,11 @@ static llvm::cl::opt<int64_t>
              llvm::cl::desc("Maximum SGPRs for register allocation"),
              llvm::cl::init(104));
 
+static llvm::cl::opt<int64_t>
+    maxAGPRs("max-agprs",
+             llvm::cl::desc("Maximum AGPRs for register allocation"),
+             llvm::cl::init(256));
+
 //===----------------------------------------------------------------------===//
 // Main Function
 //===----------------------------------------------------------------------===//
@@ -248,7 +253,8 @@ int main(int argc, char **argv) {
   // see the final register assignments.  Matches compare_backends.py order:
   // LinearScan -> Waitcnt -> Hazard.
   if (runLinearScan) {
-    pm.addPass(waveasm::createWAVEASMLinearScanPass(maxVGPRs, maxSGPRs));
+    pm.addPass(
+        waveasm::createWAVEASMLinearScanPass(maxVGPRs, maxSGPRs, maxAGPRs));
     // After register allocation, physical register types (pvreg/psreg) replace
     // virtual types (vreg/sreg). The MLIR RegionBranchOpInterface verifier
     // checks exact type equality between entry operands and block arguments,

--- a/wave_lang/kernel/wave/perf/bench_mxfp4_comparison.py
+++ b/wave_lang/kernel/wave/perf/bench_mxfp4_comparison.py
@@ -1,0 +1,2399 @@
+#!/usr/bin/env python3
+"""MXFP4 4-Wave Parity Benchmark: aiter vs LLVM vs C++ ASM Backend.
+
+Compares performance (TFLOPS), assembly quality (instruction counts),
+and loop structure between the hand-tuned aiter kernel and the wave
+compiler backends.  Serves as the single source of truth for tracking
+parity between Wave C++ ASM and aiter codegen.
+
+Usage:
+    cd /dockerx/wave
+    WAVEASM_TRANSLATE=... python bench_mxfp4_comparison.py
+    WAVEASM_TRANSLATE=... python bench_mxfp4_comparison.py --output-dir /tmp/mxfp4_bench
+    WAVEASM_TRANSLATE=... python bench_mxfp4_comparison.py --check-correctness
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+os.environ["WAVE_CACHE_ON"] = "0"
+
+# ============================================================
+# Parity Configuration (Phase 2 -- single source of truth)
+# ============================================================
+
+
+@dataclass
+class ParityConfig:
+    """Canonical configuration bundle for parity comparisons.
+
+    Every comparison / benchmark run should use the *same* ParityConfig so
+    that performance deltas are attributable to codegen, not config drift.
+    """
+
+    M: int = 1024
+    N: int = 1024
+    K: int = 8192
+    BLOCK_M: int = 256
+    BLOCK_N: int = 256
+    BLOCK_K: int = 256
+    num_waves: int = 4
+    # Wave tile sizes (derived: WAVE_M = BLOCK_M / sqrt(num_waves), etc.)
+    wave_m: int = 128
+    wave_n: int = 128
+    # Schedule variant
+    schedule_name: str = "aiter_style"
+    use_stagger: bool = False
+    # Datatype / preshuffle
+    dtype: str = "mxfp4"
+    preshuffle: bool = True
+    # Architecture
+    arch: str = "gfx950"
+
+    @property
+    def shape(self) -> Tuple[int, int, int]:
+        return (self.M, self.N, self.K)
+
+    @property
+    def block_shape(self) -> Tuple[int, int, int]:
+        return (self.BLOCK_M, self.BLOCK_N, self.BLOCK_K)
+
+    @property
+    def waves_per_wg(self) -> int:
+        return (self.BLOCK_M // self.wave_m) * (self.BLOCK_N // self.wave_n)
+
+    @property
+    def flops(self) -> int:
+        return 2 * self.M * self.N * self.K
+
+    def to_manifest(self) -> dict:
+        """Serialisable manifest for reproducibility."""
+        return {
+            "shape": list(self.shape),
+            "block_shape": list(self.block_shape),
+            "num_waves": self.num_waves,
+            "wave_m": self.wave_m,
+            "wave_n": self.wave_n,
+            "waves_per_wg": self.waves_per_wg,
+            "schedule": self.schedule_name,
+            "use_stagger": self.use_stagger,
+            "dtype": self.dtype,
+            "preshuffle": self.preshuffle,
+            "arch": self.arch,
+        }
+
+
+# ============================================================
+# Instruction metrics (reused from compare_backends.py logic)
+# ============================================================
+
+
+@dataclass
+class InstructionMetrics:
+    total: int = 0
+    salu: int = 0
+    valu: int = 0
+    vmem: int = 0
+    smem: int = 0
+    ds: int = 0
+    mfma: int = 0
+    branch: int = 0
+    wait: int = 0
+    barrier: int = 0
+    nop: int = 0
+    other: int = 0
+    buffer_load_lds: int = 0
+    ds_read: int = 0
+    ds_write: int = 0
+    accvgpr_read: int = 0
+    accvgpr_write: int = 0
+    buffer_store: int = 0
+    global_store: int = 0
+    scratch_spill: int = 0
+    m0_setup: int = 0
+    readfirstlane: int = 0
+
+
+@dataclass
+class LoopStructure:
+    """Per-loop structural analysis of assembly."""
+
+    loop_count: int = 0
+    loop_body_instructions: int = 0
+    prologue_instructions: int = 0
+    epilogue_instructions: int = 0
+    # Per-loop breakdown
+    loop_mfma: int = 0
+    loop_vmem: int = 0
+    loop_ds: int = 0
+    loop_salu: int = 0
+    loop_valu: int = 0
+    loop_wait: int = 0
+    loop_barrier: int = 0
+    loop_nop: int = 0
+    # Derived
+    mfma_density: float = 0.0  # mfma / loop_body_instructions
+    prefetch_loads_before_first_mfma: int = 0
+    waitcnt_per_barrier: float = 0.0  # wait / barrier in loop
+
+
+def classify_instruction(line: str) -> Optional[str]:
+    """Classify an assembly instruction line into a category."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith(";") or stripped.startswith("//"):
+        return None
+    if stripped.startswith(".") or stripped.endswith(":"):
+        return None
+
+    parts = stripped.split()
+    if not parts:
+        return None
+    mnemonic = parts[0]
+
+    if mnemonic.startswith("s_"):
+        if "barrier" in mnemonic:
+            return "barrier"
+        if "waitcnt" in mnemonic:
+            return "wait"
+        if "nop" in mnemonic:
+            return "nop"
+        if "branch" in mnemonic or "jump" in mnemonic:
+            return "branch"
+        if "load" in mnemonic:
+            return "smem"
+        if "endpgm" in mnemonic or "setprio" in mnemonic:
+            return "branch"
+        return "salu"
+    if mnemonic.startswith("v_"):
+        if "mfma" in mnemonic:
+            return "mfma"
+        return "valu"
+    if mnemonic.startswith("ds_"):
+        return "ds"
+    if (
+        mnemonic.startswith("buffer_")
+        or mnemonic.startswith("global_")
+        or mnemonic.startswith("flat_")
+    ):
+        return "vmem"
+    if mnemonic.startswith("scratch_"):
+        return "vmem"
+    return None
+
+
+def compute_metrics(asm_text: str) -> InstructionMetrics:
+    """Compute instruction metrics from assembly text."""
+    m = InstructionMetrics()
+    if not asm_text:
+        return m
+
+    for line in asm_text.splitlines():
+        cat = classify_instruction(line)
+        if cat is None:
+            continue
+        m.total += 1
+        stripped = line.strip()
+
+        if cat == "salu":
+            m.salu += 1
+        elif cat == "valu":
+            m.valu += 1
+            if "v_accvgpr_read" in stripped:
+                m.accvgpr_read += 1
+            if "v_accvgpr_write" in stripped:
+                m.accvgpr_write += 1
+            if "v_readfirstlane" in stripped:
+                m.readfirstlane += 1
+        elif cat == "vmem":
+            m.vmem += 1
+            if "buffer_load" in stripped and "lds" in stripped:
+                m.buffer_load_lds += 1
+            if "buffer_store" in stripped:
+                m.buffer_store += 1
+            if "global_store" in stripped:
+                m.global_store += 1
+            if "scratch_" in stripped:
+                m.scratch_spill += 1
+        elif cat == "smem":
+            m.smem += 1
+        elif cat == "ds":
+            m.ds += 1
+            if "ds_read" in stripped:
+                m.ds_read += 1
+            if "ds_write" in stripped:
+                m.ds_write += 1
+        elif cat == "mfma":
+            m.mfma += 1
+        elif cat == "branch":
+            m.branch += 1
+        elif cat == "wait":
+            m.wait += 1
+        elif cat == "barrier":
+            m.barrier += 1
+        elif cat == "nop":
+            m.nop += 1
+        else:
+            m.other += 1
+
+        if "s_mov_b32 m0" in stripped or "s_mov_b32\tm0" in stripped:
+            m.m0_setup += 1
+
+    return m
+
+
+def analyze_loop_structure(asm_text: str) -> LoopStructure:
+    """Analyse assembly for loop boundaries and per-loop instruction mix.
+
+    Heuristic: the *main* loop is identified by a backward branch
+    (``s_cbranch_scc1`` / ``s_cbranch_scc0`` targeting a label that
+    appeared earlier, or any ``s_cbranch`` whose target label appears
+    before the branch in the listing).  In disassembly output from
+    ``llvm-objdump``, loop back-edges show up as branches to lower
+    addresses (detected by hex-address comparison).
+
+    Returns a ``LoopStructure`` summarising the dominant (largest) loop
+    body and surrounding prologue / epilogue.
+    """
+    ls = LoopStructure()
+    if not asm_text:
+        return ls
+
+    lines = asm_text.splitlines()
+
+    # Detect whether this is llvm-objdump disassembly (hex addr lines) or
+    # raw assembly (.rocmasm / C++ ASM with text labels).
+    # llvm-objdump lines look like:  "  2c00: 8601FF01 ..."  or have
+    # "<label>:" function headers.
+    is_disasm = any(re.match(r"^\s+[0-9a-f]+:", l) for l in lines[:200])
+
+    # ------------------------------------------------------------------
+    # Unified label / branch detection
+    #
+    # Handles three formats:
+    #   1. Raw asm labels:   "BB0_1:"  or  ".LBB0_1:"
+    #   2. Objdump labels:   "000000000000355c <label_0257>:"
+    #   3. Hex-address-only: no labels, branches use literal addresses
+    #
+    # We build a label_positions map (label_name -> line index), then
+    # scan for backward branches (s_cbranch_* or s_branch targeting an
+    # earlier label).
+    # ------------------------------------------------------------------
+
+    label_positions: Dict[str, int] = {}
+    instruction_lines: List[Tuple[int, str, str]] = []  # (line_idx, cat, text)
+
+    # Label patterns
+    # "BB0_1:" or ".LBB0_1:" (raw asm)
+    raw_label_re = re.compile(r"^(\.?[A-Za-z_]\w*):")
+    # "00000000002c00 <label_0257>:" (llvm-objdump function/label headers)
+    objdump_label_re = re.compile(r"^[0-9a-f]+\s+<(\w+)>:")
+
+    for idx, raw_line in enumerate(lines):
+        stripped = raw_line.strip()
+
+        # Try to detect a label definition
+        m_raw = raw_label_re.match(stripped)
+        if m_raw:
+            label_positions[m_raw.group(1)] = idx
+            continue
+        m_obj = objdump_label_re.match(stripped)
+        if m_obj:
+            label_positions[m_obj.group(1)] = idx
+            continue
+
+        # For disassembly, extract the instruction text after hex bytes
+        if is_disasm:
+            # Lines look like: "\ts_load_dwordx2 ... // HEX"
+            # or              "  2c00:\t8601FF01\ts_and_b32 ..."
+            parts = stripped.split("\t")
+            if len(parts) >= 2:
+                inst_text = parts[-1].split("//")[0].strip()
+                if not inst_text:
+                    # Try second-to-last (some formats put hex in middle)
+                    for p in reversed(parts):
+                        t = p.split("//")[0].strip()
+                        if t and not re.match(r"^[0-9a-fA-F]+$", t.replace(" ", "")):
+                            inst_text = t
+                            break
+            else:
+                inst_text = stripped
+        else:
+            inst_text = stripped
+
+        cat = classify_instruction(inst_text)
+        if cat is not None:
+            instruction_lines.append((idx, cat, inst_text))
+
+    # Find backward branches (loop back-edges)
+    # Match both s_cbranch_* and s_branch (unconditional) targeting an
+    # earlier label.
+    loop_ranges: List[Tuple[int, int]] = []  # (header_line, branch_line)
+    for inst_idx, (line_idx, cat, text) in enumerate(instruction_lines):
+        if cat == "branch" and (
+            "cbranch" in text.lower() or "s_branch " in text.lower()
+        ):
+            # Strip trailing // comments before extracting the target
+            text_no_comment = text.split("//")[0].strip()
+            parts = text_no_comment.split()
+            if len(parts) >= 2:
+                target = parts[-1].strip()
+                if target in label_positions and label_positions[target] < line_idx:
+                    loop_ranges.append((label_positions[target], line_idx))
+
+    if not loop_ranges:
+        # No loops found -- everything is prologue
+        ls.prologue_instructions = len(instruction_lines)
+        return ls
+
+    # Use the largest loop body
+    best = max(loop_ranges, key=lambda r: r[1] - r[0])
+    header, back_edge = best
+    ls.loop_count = len(loop_ranges)
+
+    # Count instructions in prologue / loop / epilogue
+    for inst_idx, (line_idx, cat, text) in enumerate(instruction_lines):
+        if line_idx < header:
+            ls.prologue_instructions += 1
+        elif line_idx <= back_edge:
+            ls.loop_body_instructions += 1
+            _accumulate_loop_cat(ls, cat, text)
+        else:
+            ls.epilogue_instructions += 1
+
+    # Derived metrics
+    if ls.loop_body_instructions > 0:
+        ls.mfma_density = ls.loop_mfma / ls.loop_body_instructions
+    if ls.loop_barrier > 0:
+        ls.waitcnt_per_barrier = ls.loop_wait / ls.loop_barrier
+
+    # Prefetch depth: count VMEM/DS loads before the first MFMA in loop
+    if loop_ranges:
+        ls.prefetch_loads_before_first_mfma = _count_prefetch_loads(
+            asm_text, loop_header_line=best[0]
+        )
+    else:
+        ls.prefetch_loads_before_first_mfma = 0
+
+    return ls
+
+
+def _accumulate_loop_cat(ls: LoopStructure, cat: str, text: str):
+    """Accumulate a classified instruction into the loop structure."""
+    if cat == "mfma":
+        ls.loop_mfma += 1
+    elif cat == "vmem":
+        ls.loop_vmem += 1
+    elif cat == "ds":
+        ls.loop_ds += 1
+    elif cat == "salu":
+        ls.loop_salu += 1
+    elif cat == "valu":
+        ls.loop_valu += 1
+    elif cat == "wait":
+        ls.loop_wait += 1
+    elif cat == "barrier":
+        ls.loop_barrier += 1
+    elif cat == "nop":
+        ls.loop_nop += 1
+
+
+def _count_prefetch_loads(asm_text: str, loop_header_line: int = 0) -> int:
+    """Count load instructions before the first MFMA inside the main loop.
+
+    If loop_header_line is provided, scans from that line to the first MFMA.
+    Otherwise falls back to scanning from the first label.
+    """
+    lines = asm_text.splitlines()
+    in_loop = False
+    count = 0
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if idx >= loop_header_line and loop_header_line > 0:
+            in_loop = True
+        elif not in_loop:
+            # Detect any label as potential loop header
+            if stripped.endswith(":") or re.match(r"^[0-9a-f]+\s+<\w+>:", stripped):
+                in_loop = True
+            continue
+        if in_loop:
+            cat = classify_instruction(line)
+            if cat is None:
+                continue
+            if cat == "mfma":
+                break
+            if cat in ("vmem", "ds"):
+                count += 1
+    return count
+
+
+@dataclass
+class LoopSignature:
+    """Detailed instruction-level signature of a loop body for diffing."""
+
+    # Ordered list of instruction categories in the loop body
+    category_sequence: List[str] = field(default_factory=list)
+    # Waitcnt values encountered, ordered: [(position_in_loop, vmcnt, lgkmcnt)]
+    waitcnt_sequence: List[Tuple[int, Optional[int], Optional[int]]] = field(
+        default_factory=list
+    )
+    # Number of NOPs adjacent to each barrier (within 3 instructions)
+    barrier_adjacent_nops: List[int] = field(default_factory=list)
+    # MFMA-to-load interleave ratio: loads interspersed among MFMAs / total loads
+    interleave_ratio: float = 0.0
+    # Runs: consecutive instructions of same type [(category, count)]
+    runs: List[Tuple[str, int]] = field(default_factory=list)
+    # Max consecutive MFMAs without an intervening load
+    max_consecutive_mfma: int = 0
+    # Max consecutive loads (vmem+ds) without an intervening MFMA
+    max_consecutive_loads: int = 0
+
+
+def extract_loop_signature(asm_text: str) -> LoopSignature:
+    """Extract a detailed loop-body signature for comparison.
+
+    Uses the same loop-detection heuristic as analyze_loop_structure,
+    then builds a fine-grained instruction sequence for diffing.
+    """
+    sig = LoopSignature()
+    if not asm_text:
+        return sig
+
+    lines = asm_text.splitlines()
+
+    # Detect format
+    is_disasm = any(re.match(r"^\s+[0-9a-f]+:", l) for l in lines[:200])
+
+    label_positions: Dict[str, int] = {}
+    instruction_lines: List[Tuple[int, str, str]] = []
+
+    raw_label_re = re.compile(r"^(\.?[A-Za-z_]\w*):")
+    objdump_label_re = re.compile(r"^[0-9a-f]+\s+<(\w+)>:")
+
+    for idx, raw_line in enumerate(lines):
+        stripped = raw_line.strip()
+        m_raw = raw_label_re.match(stripped)
+        if m_raw:
+            label_positions[m_raw.group(1)] = idx
+            continue
+        m_obj = objdump_label_re.match(stripped)
+        if m_obj:
+            label_positions[m_obj.group(1)] = idx
+            continue
+
+        if is_disasm:
+            parts = stripped.split("\t")
+            if len(parts) >= 2:
+                inst_text = parts[-1].split("//")[0].strip()
+                if not inst_text:
+                    for p in reversed(parts):
+                        t = p.split("//")[0].strip()
+                        if t and not re.match(r"^[0-9a-fA-F]+$", t.replace(" ", "")):
+                            inst_text = t
+                            break
+            else:
+                inst_text = stripped
+        else:
+            inst_text = stripped
+
+        cat = classify_instruction(inst_text)
+        if cat is not None:
+            instruction_lines.append((idx, cat, inst_text))
+
+    # Find largest loop
+    loop_ranges: List[Tuple[int, int]] = []
+    for inst_idx, (line_idx, cat, text) in enumerate(instruction_lines):
+        if cat == "branch" and (
+            "cbranch" in text.lower() or "s_branch " in text.lower()
+        ):
+            text_no_comment = text.split("//")[0].strip()
+            parts = text_no_comment.split()
+            if len(parts) >= 2:
+                target = parts[-1].strip()
+                if target in label_positions and label_positions[target] < line_idx:
+                    loop_ranges.append((label_positions[target], line_idx))
+
+    if not loop_ranges:
+        return sig
+
+    best = max(loop_ranges, key=lambda r: r[1] - r[0])
+    header, back_edge = best
+
+    # Extract loop body instructions
+    loop_cats: List[str] = []
+    loop_texts: List[str] = []
+    for line_idx, cat, text in instruction_lines:
+        if header <= line_idx <= back_edge:
+            loop_cats.append(cat)
+            loop_texts.append(text)
+
+    sig.category_sequence = loop_cats
+
+    # Extract waitcnt values
+    waitcnt_re = re.compile(r"vmcnt\((\d+)\)")
+    lgkmcnt_re = re.compile(r"lgkmcnt\((\d+)\)")
+    for pos, (cat, text) in enumerate(zip(loop_cats, loop_texts)):
+        if cat == "wait":
+            vm = waitcnt_re.search(text)
+            lg = lgkmcnt_re.search(text)
+            vmcnt_val = int(vm.group(1)) if vm else None
+            lgkmcnt_val = int(lg.group(1)) if lg else None
+            sig.waitcnt_sequence.append((pos, vmcnt_val, lgkmcnt_val))
+
+    # Barrier-adjacent NOP count (within 3 instructions after each barrier)
+    for pos, cat in enumerate(loop_cats):
+        if cat == "barrier":
+            nop_count = 0
+            for j in range(1, 4):
+                if pos + j < len(loop_cats) and loop_cats[pos + j] == "nop":
+                    nop_count += 1
+                else:
+                    break
+            sig.barrier_adjacent_nops.append(nop_count)
+
+    # Compute runs of consecutive same-category instructions
+    if loop_cats:
+        runs = []
+        cur_cat = loop_cats[0]
+        cur_count = 1
+        for cat in loop_cats[1:]:
+            if cat == cur_cat:
+                cur_count += 1
+            else:
+                runs.append((cur_cat, cur_count))
+                cur_cat = cat
+                cur_count = 1
+        runs.append((cur_cat, cur_count))
+        sig.runs = runs
+
+    # Max consecutive MFMAs and loads
+    max_mfma_run = 0
+    max_load_run = 0
+    cur_mfma = 0
+    cur_load = 0
+    for cat in loop_cats:
+        if cat == "mfma":
+            cur_mfma += 1
+            cur_load = 0
+            max_mfma_run = max(max_mfma_run, cur_mfma)
+        elif cat in ("vmem", "ds"):
+            cur_load += 1
+            cur_mfma = 0
+            max_load_run = max(max_load_run, cur_load)
+        else:
+            cur_mfma = 0
+            cur_load = 0
+    sig.max_consecutive_mfma = max_mfma_run
+    sig.max_consecutive_loads = max_load_run
+
+    # Interleave ratio: count loads that appear between MFMAs
+    loads_between_mfma = 0
+    total_loads = sum(1 for c in loop_cats if c in ("vmem", "ds"))
+    in_mfma_region = False
+    for cat in loop_cats:
+        if cat == "mfma":
+            in_mfma_region = True
+        elif cat in ("vmem", "ds"):
+            if in_mfma_region:
+                loads_between_mfma += 1
+        elif cat not in ("nop", "salu", "wait", "barrier"):
+            in_mfma_region = False
+    sig.interleave_ratio = loads_between_mfma / total_loads if total_loads > 0 else 0.0
+
+    return sig
+
+
+def format_loop_signature_diff(
+    name_a: str,
+    sig_a: LoopSignature,
+    name_b: str,
+    sig_b: LoopSignature,
+) -> str:
+    """Format a human-readable diff between two loop signatures."""
+    lines = []
+    w = 80
+    lines.append("=" * w)
+    lines.append(f"Loop Body Signature Diff: {name_a} vs {name_b}")
+    lines.append("=" * w)
+
+    lines.append(f"{'Metric':<40s} {name_a:>18s} {name_b:>18s}")
+    lines.append("-" * w)
+
+    lines.append(
+        f"{'Loop body length':<40s} {len(sig_a.category_sequence):>18d} {len(sig_b.category_sequence):>18d}"
+    )
+    lines.append(
+        f"{'Waitcnt count':<40s} {len(sig_a.waitcnt_sequence):>18d} {len(sig_b.waitcnt_sequence):>18d}"
+    )
+    lines.append(
+        f"{'Max consecutive MFMAs':<40s} {sig_a.max_consecutive_mfma:>18d} {sig_b.max_consecutive_mfma:>18d}"
+    )
+    lines.append(
+        f"{'Max consecutive loads':<40s} {sig_a.max_consecutive_loads:>18d} {sig_b.max_consecutive_loads:>18d}"
+    )
+    lines.append(
+        f"{'Load interleave ratio':<40s} {sig_a.interleave_ratio:>18.2%} {sig_b.interleave_ratio:>18.2%}"
+    )
+    lines.append(
+        f"{'Barrier count':<40s} {sig_a.barrier_adjacent_nops.__len__():>18d} {sig_b.barrier_adjacent_nops.__len__():>18d}"
+    )
+
+    # Barrier-adjacent NOPs
+    if sig_a.barrier_adjacent_nops or sig_b.barrier_adjacent_nops:
+        avg_a = (
+            sum(sig_a.barrier_adjacent_nops) / len(sig_a.barrier_adjacent_nops)
+            if sig_a.barrier_adjacent_nops
+            else 0
+        )
+        avg_b = (
+            sum(sig_b.barrier_adjacent_nops) / len(sig_b.barrier_adjacent_nops)
+            if sig_b.barrier_adjacent_nops
+            else 0
+        )
+        lines.append(f"{'Avg NOPs after barrier':<40s} {avg_a:>18.1f} {avg_b:>18.1f}")
+
+    lines.append("-" * w)
+
+    # Waitcnt sequence comparison
+    lines.append("Waitcnt sequences:")
+    max_show = max(len(sig_a.waitcnt_sequence), len(sig_b.waitcnt_sequence))
+    for i in range(min(max_show, 20)):
+        a_str = ""
+        b_str = ""
+        if i < len(sig_a.waitcnt_sequence):
+            pos, vm, lg = sig_a.waitcnt_sequence[i]
+            parts = []
+            if vm is not None:
+                parts.append(f"vmcnt({vm})")
+            if lg is not None:
+                parts.append(f"lgkmcnt({lg})")
+            a_str = f"@{pos}: {' '.join(parts)}"
+        if i < len(sig_b.waitcnt_sequence):
+            pos, vm, lg = sig_b.waitcnt_sequence[i]
+            parts = []
+            if vm is not None:
+                parts.append(f"vmcnt({vm})")
+            if lg is not None:
+                parts.append(f"lgkmcnt({lg})")
+            b_str = f"@{pos}: {' '.join(parts)}"
+        match = " ==" if a_str == b_str and a_str else ""
+        lines.append(f"  [{i:2d}] {a_str:<35s} {b_str:<35s}{match}")
+
+    if max_show > 20:
+        lines.append(f"  ... ({max_show - 20} more)")
+
+    # Run-length summary (top 10 longest runs per side)
+    lines.append("-" * w)
+    lines.append("Top instruction runs (category, length):")
+    top_a = sorted(sig_a.runs, key=lambda r: -r[1])[:10]
+    top_b = sorted(sig_b.runs, key=lambda r: -r[1])[:10]
+    for i in range(max(len(top_a), len(top_b))):
+        a_str = f"{top_a[i][0]}x{top_a[i][1]}" if i < len(top_a) else ""
+        b_str = f"{top_b[i][0]}x{top_b[i][1]}" if i < len(top_b) else ""
+        lines.append(f"  {a_str:<35s} {b_str:<35s}")
+
+    lines.append("=" * w)
+    return "\n".join(lines)
+
+
+def extract_resource_usage(asm_text: str) -> dict:
+    """Extract VGPRs, SGPRs, LDS from assembly metadata."""
+    resources = {"vgprs": 0, "sgprs": 0, "lds": 0, "agprs": 0}
+    for line in asm_text.splitlines():
+        if "amdhsa_next_free_vgpr" in line or ".vgpr_count" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["vgprs"] = max(resources["vgprs"], int(nums[-1]))
+        if "amdhsa_next_free_sgpr" in line or ".sgpr_count" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["sgprs"] = max(resources["sgprs"], int(nums[-1]))
+        if "group_segment_fixed_size" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["lds"] = max(resources["lds"], int(nums[-1]))
+        if ".agpr_count" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["agprs"] = max(resources["agprs"], int(nums[-1]))
+        if "amdhsa_accum_offset" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                offset = int(nums[-1])
+                if resources["vgprs"] > offset:
+                    resources["agprs"] = resources["vgprs"] - offset
+    return resources
+
+
+def disassemble_co(co_path: str) -> str:
+    """Disassemble a .co file using llvm-objdump."""
+    objdump = "/opt/rocm/llvm/bin/llvm-objdump"
+    if not os.path.exists(objdump):
+        objdump = "llvm-objdump"
+    cmd = [objdump, "-d", "--mcpu=gfx950", co_path]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    return result.stdout if result.returncode == 0 else ""
+
+
+def extract_co_resources(co_path: str) -> dict:
+    """Extract resource usage from a .co file's ELF notes via llvm-readelf."""
+    resources = {"vgprs": 0, "sgprs": 0, "lds": 0, "agprs": 0}
+    readelf = "/opt/rocm/llvm/bin/llvm-readelf"
+    if not os.path.exists(readelf):
+        readelf = "llvm-readelf"
+    cmd = [readelf, "--notes", co_path]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    if result.returncode != 0:
+        return resources
+    for line in result.stdout.splitlines():
+        if ".vgpr_count:" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["vgprs"] = int(nums[-1])
+        if ".sgpr_count:" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["sgprs"] = int(nums[-1])
+        if ".group_segment_fixed_size:" in line:
+            nums = re.findall(r"\d+", line)
+            if nums:
+                resources["lds"] = int(nums[-1])
+        if ".wavefront_size:" in line:
+            pass  # informational only
+    # On gfx9, vgpr_count includes AGPRs. Infer AGPR count from accvgpr_write
+    # in the disassembly (done separately). For now, if vgpr_count > 256,
+    # the upper half are AGPRs.
+    if resources["vgprs"] > 256:
+        resources["agprs"] = resources["vgprs"] - 256
+    return resources
+
+
+def format_comparison(backends: dict, pcfg: Optional[ParityConfig] = None) -> str:
+    """Format a multi-backend comparison table with loop structure analysis."""
+    names = list(backends.keys())
+    lines = []
+
+    # Header
+    w = 90 + 14 * max(0, len(names) - 2)
+    lines.append("=" * w)
+    lines.append("Instruction Metrics Comparison")
+    lines.append("=" * w)
+    hdr = f"{'Category':<30s}"
+    for n in names:
+        hdr += f" {n:>14s}"
+    lines.append(hdr)
+    lines.append("-" * w)
+
+    metrics_list = [backends[n]["metrics"] for n in names]
+    resources_list = [backends[n]["resources"] for n in names]
+
+    def row(label, getter):
+        r = f"{label:<30s}"
+        for m in metrics_list:
+            r += f" {getter(m):>14d}"
+        return r
+
+    lines.append(row("Total Instructions", lambda m: m.total))
+    lines.append("-" * w)
+    lines.append(row("Scalar ALU (SALU)", lambda m: m.salu))
+    lines.append(row("Vector ALU (VALU)", lambda m: m.valu))
+    lines.append(row("Vector Memory (VMEM)", lambda m: m.vmem))
+    lines.append(row("Scalar Memory (SMEM)", lambda m: m.smem))
+    lines.append(row("LDS/GDS (DS)", lambda m: m.ds))
+    lines.append(row("Matrix Ops (MFMA)", lambda m: m.mfma))
+    lines.append(row("Branch/Control", lambda m: m.branch))
+    lines.append(row("Waits (s_waitcnt)", lambda m: m.wait))
+    lines.append(row("Barriers (s_barrier)", lambda m: m.barrier))
+    lines.append(row("NOPs (s_nop)", lambda m: m.nop))
+    lines.append(row("Other", lambda m: m.other))
+    lines.append("-" * w)
+    lines.append(row("  buffer_load...lds", lambda m: m.buffer_load_lds))
+    lines.append(row("  ds_read*", lambda m: m.ds_read))
+    lines.append(row("  ds_write*", lambda m: m.ds_write))
+    lines.append(row("  buffer_store*", lambda m: m.buffer_store))
+    lines.append(row("  global_store*", lambda m: m.global_store))
+    lines.append(row("  accvgpr_read", lambda m: m.accvgpr_read))
+    lines.append(row("  accvgpr_write", lambda m: m.accvgpr_write))
+    lines.append(row("  scratch spills", lambda m: m.scratch_spill))
+    lines.append(row("  M0 setup", lambda m: m.m0_setup))
+    lines.append(row("  v_readfirstlane", lambda m: m.readfirstlane))
+    lines.append("=" * w)
+
+    # ---- Resource Usage ----
+    lines.append("")
+    lines.append("=" * w)
+    lines.append("Resource Usage")
+    lines.append("=" * w)
+    rhdr = f"{'Resource':<30s}"
+    for n in names:
+        rhdr += f" {n:>14s}"
+    lines.append(rhdr)
+    lines.append("-" * w)
+    for key in ["vgprs", "sgprs", "agprs", "lds"]:
+        r = f"{key.upper():<30s}"
+        for res in resources_list:
+            r += f" {res.get(key, 0):>14d}"
+        lines.append(r)
+    lines.append("=" * w)
+
+    # ---- Loop Structure Analysis ----
+    loop_list = [backends[n].get("loop_structure") for n in names]
+    if any(ls is not None and ls.loop_body_instructions > 0 for ls in loop_list):
+        lines.append("")
+        lines.append("=" * w)
+        lines.append("Loop Structure Analysis")
+        lines.append("=" * w)
+        lhdr = f"{'Metric':<30s}"
+        for n in names:
+            lhdr += f" {n:>14s}"
+        lines.append(lhdr)
+        lines.append("-" * w)
+
+        def lrow(label, getter, fmt="d"):
+            r = f"{label:<30s}"
+            for ls in loop_list:
+                if ls is None:
+                    r += f" {'N/A':>14s}"
+                else:
+                    val = getter(ls)
+                    if fmt == "d":
+                        r += f" {int(val):>14d}"
+                    elif fmt == ".2f":
+                        r += f" {val:>14.2f}"
+                    elif fmt == ".1%":
+                        r += f" {val:>13.1%} "
+            return r
+
+        lines.append(lrow("Loop count", lambda ls: ls.loop_count))
+        lines.append(
+            lrow("Loop body instructions", lambda ls: ls.loop_body_instructions)
+        )
+        lines.append(lrow("Prologue instructions", lambda ls: ls.prologue_instructions))
+        lines.append(lrow("Epilogue instructions", lambda ls: ls.epilogue_instructions))
+        lines.append("-" * w)
+        lines.append(lrow("  Loop MFMA", lambda ls: ls.loop_mfma))
+        lines.append(lrow("  Loop VMEM", lambda ls: ls.loop_vmem))
+        lines.append(lrow("  Loop DS", lambda ls: ls.loop_ds))
+        lines.append(lrow("  Loop SALU", lambda ls: ls.loop_salu))
+        lines.append(lrow("  Loop VALU", lambda ls: ls.loop_valu))
+        lines.append(lrow("  Loop waits", lambda ls: ls.loop_wait))
+        lines.append(lrow("  Loop barriers", lambda ls: ls.loop_barrier))
+        lines.append(lrow("  Loop NOPs", lambda ls: ls.loop_nop))
+        lines.append("-" * w)
+        lines.append(lrow("MFMA density", lambda ls: ls.mfma_density, ".2f"))
+        lines.append(
+            lrow(
+                "Prefetch loads before MFMA",
+                lambda ls: ls.prefetch_loads_before_first_mfma,
+            )
+        )
+        lines.append(
+            lrow("waitcnt/barrier ratio", lambda ls: ls.waitcnt_per_barrier, ".2f")
+        )
+        lines.append("=" * w)
+
+    # ---- Normalised per-wave metrics (requires ParityConfig) ----
+    if pcfg is not None:
+        wpg = pcfg.waves_per_wg
+        lines.append("")
+        lines.append("=" * w)
+        lines.append(f"Normalised Metrics (waves_per_wg={wpg})")
+        lines.append("=" * w)
+        nhdr = f"{'Metric':<30s}"
+        for n in names:
+            nhdr += f" {n:>14s}"
+        lines.append(nhdr)
+        lines.append("-" * w)
+
+        def nrow(label, getter, fmt=".1f"):
+            r = f"{label:<30s}"
+            for m in metrics_list:
+                val = getter(m) / wpg if wpg > 0 else 0
+                r += f" {val:>14{fmt}}"
+            return r
+
+        lines.append(nrow("Instructions / wave", lambda m: m.total))
+        lines.append(nrow("MFMA / wave", lambda m: m.mfma))
+        lines.append(nrow("VMEM / wave", lambda m: m.vmem))
+        lines.append(nrow("DS / wave", lambda m: m.ds))
+        lines.append(nrow("SALU / wave", lambda m: m.salu))
+        lines.append(nrow("VALU / wave", lambda m: m.valu))
+        lines.append("=" * w)
+
+    return "\n".join(lines)
+
+
+# ============================================================
+# Regression gates (Phase 4)
+# ============================================================
+
+
+@dataclass
+class RegressionResult:
+    """Result of a regression gate check."""
+
+    passed: bool = True
+    regressions: List[str] = field(default_factory=list)
+    improvements: List[str] = field(default_factory=list)
+
+
+def check_regression_gates(
+    baseline: dict,
+    candidate: dict,
+    *,
+    max_vgpr_regression: int = 4,
+    max_instruction_overhead: float = 1.05,
+    min_mfma_density_ratio: float = 0.95,
+) -> RegressionResult:
+    """Compare a candidate backend result against a baseline.
+
+    Returns RegressionResult with pass/fail and detail messages.
+    The baseline is typically aiter (the reference) or a previous C++ run.
+    """
+    result = RegressionResult()
+    b_res = baseline.get("resources", {})
+    c_res = candidate.get("resources", {})
+    b_met = baseline.get("metrics", InstructionMetrics())
+    c_met = candidate.get("metrics", InstructionMetrics())
+    b_loop = baseline.get("loop_structure", LoopStructure())
+    c_loop = candidate.get("loop_structure", LoopStructure())
+
+    # VGPR regression
+    vgpr_delta = c_res.get("vgprs", 0) - b_res.get("vgprs", 0)
+    if vgpr_delta > max_vgpr_regression:
+        result.passed = False
+        result.regressions.append(
+            f"VGPR regression: +{vgpr_delta} (limit: +{max_vgpr_regression})"
+        )
+    elif vgpr_delta < 0:
+        result.improvements.append(f"VGPR improvement: {vgpr_delta}")
+
+    # Instruction count overhead
+    if b_met.total > 0:
+        ratio = c_met.total / b_met.total
+        if ratio > max_instruction_overhead:
+            result.passed = False
+            result.regressions.append(
+                f"Instruction overhead: {ratio:.2f}x (limit: {max_instruction_overhead:.2f}x)"
+            )
+        elif ratio < 1.0:
+            result.improvements.append(f"Instruction reduction: {ratio:.2f}x")
+
+    # MFMA density
+    if b_loop and c_loop and b_loop.mfma_density > 0:
+        density_ratio = c_loop.mfma_density / b_loop.mfma_density
+        if density_ratio < min_mfma_density_ratio:
+            result.passed = False
+            result.regressions.append(
+                f"MFMA density drop: {density_ratio:.2f}x (limit: {min_mfma_density_ratio:.2f}x)"
+            )
+        elif density_ratio > 1.0:
+            result.improvements.append(f"MFMA density gain: {density_ratio:.2f}x")
+
+    # TFLOPS regression (if present)
+    b_tflops = baseline.get("tflops", 0)
+    c_tflops = candidate.get("tflops", 0)
+    if b_tflops > 0 and c_tflops > 0:
+        perf_ratio = c_tflops / b_tflops
+        if perf_ratio < 0.90:
+            result.passed = False
+            result.regressions.append(
+                f"TFLOPS regression: {perf_ratio:.2f}x of baseline ({c_tflops:.2f} vs {b_tflops:.2f})"
+            )
+        elif perf_ratio > 1.0:
+            result.improvements.append(
+                f"TFLOPS improvement: {perf_ratio:.2f}x ({c_tflops:.2f} vs {b_tflops:.2f})"
+            )
+
+    return result
+
+
+def generate_mxfp4_inputs_and_reference(shape):
+    """Generate MXFP4 inputs and compute reference output for correctness checks.
+
+    Uses the same input generation as test_asm_backend_e2e.py: properly packed
+    MXFP4 data via generate_gemm_afp4wfp4_inputs and torchScaledGemmMXFP4 as
+    the software reference.
+
+    Returns:
+        (x, w, x_scales, w_scales, torch_ref) - all on CPU
+    """
+    from wave_lang.kernel.wave.utils.mxfp_utils import (
+        generate_gemm_afp4wfp4_inputs,
+        torchScaledGemmMXFP4,
+    )
+
+    x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+    torch_ref = torchScaledGemmMXFP4(x, w, x_scales, w_scales)
+    return x, w, x_scales, w_scales, torch_ref
+
+
+def check_correctness(name, output_gpu, torch_ref):
+    """Check numerical correctness of a backend's output against reference.
+
+    Uses torch.testing.assert_close with the same tolerance as the e2e test
+    (default tolerances, which are strict for f32 MXFP4 GEMM).
+    """
+    output_cpu = output_gpu.cpu()
+    ref_cpu = torch_ref.cpu() if torch_ref.is_cuda else torch_ref
+    try:
+        torch.testing.assert_close(ref_cpu, output_cpu, check_dtype=False)
+        print(f"  Correctness: PASS")
+        return True
+    except AssertionError as e:
+        max_err = (output_cpu - ref_cpu).abs().max().item()
+        mean_err = (output_cpu - ref_cpu).abs().mean().item()
+        print(f"  Correctness: FAIL (max_err={max_err:.6f}, mean_err={mean_err:.6f})")
+        return False
+
+
+# ============================================================
+# ATT Thread Trace Analysis
+# ============================================================
+
+
+@dataclass
+class ATTInstructionEntry:
+    """One row from an ATT stats_ui CSV."""
+
+    vaddr: int = 0
+    instruction: str = ""
+    hitcount: int = 0
+    latency: int = 0
+    stall: int = 0
+    idle: int = 0
+    source: str = ""
+
+
+@dataclass
+class ATTStallRegion:
+    """A contiguous region of instructions with high stall/idle cycles."""
+
+    start_idx: int = 0
+    end_idx: int = 0
+    total_stall: int = 0
+    total_idle: int = 0
+    total_latency: int = 0
+    dominant_instruction: str = ""
+    category: str = ""  # "waitcnt", "barrier", "ds_read", "vmem", etc.
+    instructions: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ATTAnalysis:
+    """Summary of an ATT trace for one kernel."""
+
+    backend_name: str = ""
+    total_instructions: int = 0
+    total_latency: int = 0
+    total_stall: int = 0
+    total_idle: int = 0
+    # Per-category stall breakdowns
+    stall_by_category: Dict[str, int] = field(default_factory=dict)
+    idle_by_category: Dict[str, int] = field(default_factory=dict)
+    latency_by_category: Dict[str, int] = field(default_factory=dict)
+    # Top stall instructions
+    top_stall_instructions: List[Tuple[int, str]] = field(default_factory=list)
+    top_idle_instructions: List[Tuple[int, str]] = field(default_factory=list)
+    # Stall regions (clusters of stalls)
+    stall_regions: List[ATTStallRegion] = field(default_factory=list)
+    # Efficiency metrics
+    mfma_latency: int = 0
+    mfma_stall: int = 0
+    mfma_count: int = 0
+    useful_compute_pct: float = 0.0  # mfma_latency / total_latency
+
+
+def _classify_att_instruction(inst: str) -> str:
+    """Classify an ATT instruction into a category for aggregation."""
+    inst_lower = inst.strip().strip('"').lower()
+    if inst_lower.startswith(";") or not inst_lower:
+        return "comment"
+    if "waitcnt" in inst_lower:
+        return "waitcnt"
+    if "s_barrier" in inst_lower:
+        return "barrier"
+    if "s_nop" in inst_lower:
+        return "nop"
+    if "mfma" in inst_lower:
+        return "mfma"
+    if "ds_read" in inst_lower or "ds_write" in inst_lower:
+        return "ds"
+    if "buffer_load" in inst_lower:
+        if "lds" in inst_lower:
+            return "buffer_load_lds"
+        return "buffer_load"
+    if "buffer_store" in inst_lower or "global_store" in inst_lower:
+        return "store"
+    if "accvgpr_read" in inst_lower:
+        return "accvgpr_read"
+    if "accvgpr_write" in inst_lower:
+        return "accvgpr_write"
+    if inst_lower.startswith("v_"):
+        return "valu"
+    if inst_lower.startswith("s_"):
+        return "salu"
+    return "other"
+
+
+def parse_att_csv(csv_path: Path) -> List[ATTInstructionEntry]:
+    """Parse an ATT stats_ui CSV into instruction entries."""
+    import csv
+
+    entries = []
+    with open(csv_path, "r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            inst = row.get("Instruction", "").strip().strip('"')
+            if not inst or inst.startswith(";"):
+                continue
+            entries.append(
+                ATTInstructionEntry(
+                    vaddr=int(row.get("Vaddr", 0)),
+                    instruction=inst,
+                    hitcount=int(row.get("Hitcount", 0)),
+                    latency=int(row.get("Latency", 0)),
+                    stall=int(row.get("Stall", 0)),
+                    idle=int(row.get("Idle", 0)),
+                    source=row.get("Source", "").strip().strip('"'),
+                )
+            )
+    return entries
+
+
+def analyze_att_trace(
+    backend_name: str,
+    csv_path: Path,
+    top_n: int = 15,
+) -> ATTAnalysis:
+    """Analyze an ATT trace CSV and produce a stall analysis summary.
+
+    Columns: CodeObj, Vaddr, Instruction, Hitcount, Latency, Stall, Idle, Source
+
+    - Hitcount: how many times this instruction was sampled
+    - Latency: total cycles spent on this instruction across all hits
+    - Stall: cycles the wavefront was stalled (waiting on dependency)
+    - Idle: cycles the CU was idle (no wavefronts scheduled -- pipeline bubble)
+    """
+    analysis = ATTAnalysis(backend_name=backend_name)
+    entries = parse_att_csv(csv_path)
+    if not entries:
+        return analysis
+
+    analysis.total_instructions = len(entries)
+
+    for e in entries:
+        cat = _classify_att_instruction(e.instruction)
+        analysis.total_latency += e.latency
+        analysis.total_stall += e.stall
+        analysis.total_idle += e.idle
+
+        # Per-category aggregation
+        analysis.stall_by_category[cat] = (
+            analysis.stall_by_category.get(cat, 0) + e.stall
+        )
+        analysis.idle_by_category[cat] = analysis.idle_by_category.get(cat, 0) + e.idle
+        analysis.latency_by_category[cat] = (
+            analysis.latency_by_category.get(cat, 0) + e.latency
+        )
+
+        # MFMA stats
+        if cat == "mfma":
+            analysis.mfma_latency += e.latency
+            analysis.mfma_stall += e.stall
+            analysis.mfma_count += 1
+
+    # Useful compute percentage
+    if analysis.total_latency > 0:
+        analysis.useful_compute_pct = analysis.mfma_latency / analysis.total_latency
+
+    # Top stall instructions (sorted by stall cycles)
+    stall_sorted = sorted(entries, key=lambda e: e.stall, reverse=True)
+    analysis.top_stall_instructions = [
+        (e.stall, e.instruction) for e in stall_sorted[:top_n] if e.stall > 0
+    ]
+
+    # Top idle instructions (sorted by idle cycles)
+    idle_sorted = sorted(entries, key=lambda e: e.idle, reverse=True)
+    analysis.top_idle_instructions = [
+        (e.idle, e.instruction) for e in idle_sorted[:top_n] if e.idle > 0
+    ]
+
+    # Find stall regions: contiguous sequences of instructions with high
+    # stall or idle. A "region" starts when stall+idle > threshold and
+    # ends when it drops below.
+    threshold = max(100, analysis.total_stall // (len(entries) or 1))
+    current_region: Optional[ATTStallRegion] = None
+    for idx, e in enumerate(entries):
+        cost = e.stall + e.idle
+        if cost > threshold:
+            if current_region is None:
+                current_region = ATTStallRegion(start_idx=idx)
+            current_region.end_idx = idx
+            current_region.total_stall += e.stall
+            current_region.total_idle += e.idle
+            current_region.total_latency += e.latency
+            current_region.instructions.append(e.instruction)
+            if e.stall > current_region.total_stall // 2:
+                current_region.dominant_instruction = e.instruction
+                current_region.category = _classify_att_instruction(e.instruction)
+        else:
+            if current_region is not None and (
+                current_region.total_stall + current_region.total_idle > threshold * 3
+            ):
+                if not current_region.dominant_instruction:
+                    # Pick the highest-stall instruction in the region
+                    max_e = max(
+                        entries[current_region.start_idx : current_region.end_idx + 1],
+                        key=lambda x: x.stall + x.idle,
+                    )
+                    current_region.dominant_instruction = max_e.instruction
+                    current_region.category = _classify_att_instruction(
+                        max_e.instruction
+                    )
+                analysis.stall_regions.append(current_region)
+            current_region = None
+
+    # Flush last region
+    if current_region is not None and (
+        current_region.total_stall + current_region.total_idle > threshold * 3
+    ):
+        if not current_region.dominant_instruction and current_region.instructions:
+            current_region.dominant_instruction = current_region.instructions[0]
+            current_region.category = _classify_att_instruction(
+                current_region.instructions[0]
+            )
+        analysis.stall_regions.append(current_region)
+
+    # Sort regions by total cost (stall + idle)
+    analysis.stall_regions.sort(
+        key=lambda r: r.total_stall + r.total_idle, reverse=True
+    )
+
+    return analysis
+
+
+def format_att_analysis(analyses: List[ATTAnalysis]) -> str:
+    """Format a side-by-side ATT stall analysis comparison."""
+    names = [a.backend_name for a in analyses]
+    lines = []
+    w = 90 + 18 * max(0, len(names) - 2)
+
+    lines.append("=" * w)
+    lines.append("ATT Thread Trace Stall Analysis")
+    lines.append("=" * w)
+
+    # --- Overview ---
+    hdr = f"{'Metric':<35s}"
+    for n in names:
+        hdr += f" {n:>18s}"
+    lines.append(hdr)
+    lines.append("-" * w)
+
+    def row(label, getter, fmt="d"):
+        r = f"{label:<35s}"
+        for a in analyses:
+            val = getter(a)
+            if fmt == "d":
+                r += f" {int(val):>18,}"
+            elif fmt == ".1f":
+                r += f" {val:>18.1f}"
+            elif fmt == ".1%":
+                r += f" {val:>17.1%} "
+        return r
+
+    lines.append(row("Total instructions traced", lambda a: a.total_instructions))
+    lines.append(row("Total latency (cycles)", lambda a: a.total_latency))
+    lines.append(row("Total stall (cycles)", lambda a: a.total_stall))
+    lines.append(row("Total idle (cycles)", lambda a: a.total_idle))
+    lines.append(row("MFMA count", lambda a: a.mfma_count))
+    lines.append(row("MFMA latency (cycles)", lambda a: a.mfma_latency))
+    lines.append(row("MFMA stall (cycles)", lambda a: a.mfma_stall))
+    lines.append(
+        row("Useful compute (MFMA/total)", lambda a: a.useful_compute_pct, ".1%")
+    )
+    lines.append("")
+
+    # --- Stall breakdown by category ---
+    lines.append("-" * w)
+    lines.append("Stall Cycles by Instruction Category")
+    lines.append("-" * w)
+    all_cats = sorted(set().union(*(a.stall_by_category.keys() for a in analyses)))
+    for cat in all_cats:
+        r = f"  {cat:<33s}"
+        for a in analyses:
+            val = a.stall_by_category.get(cat, 0)
+            total = a.total_stall or 1
+            pct = val / total * 100
+            r += f" {val:>12,} ({pct:4.1f}%)"
+        lines.append(r)
+    lines.append("")
+
+    # --- Idle breakdown by category ---
+    lines.append("-" * w)
+    lines.append("Idle Cycles by Instruction Category")
+    lines.append("-" * w)
+    all_idle_cats = sorted(set().union(*(a.idle_by_category.keys() for a in analyses)))
+    for cat in all_idle_cats:
+        r = f"  {cat:<33s}"
+        for a in analyses:
+            val = a.idle_by_category.get(cat, 0)
+            total = a.total_idle or 1
+            pct = val / total * 100
+            r += f" {val:>12,} ({pct:4.1f}%)"
+        lines.append(r)
+    lines.append("")
+
+    # --- Top stall instructions (per backend) ---
+    for a in analyses:
+        lines.append("-" * w)
+        lines.append(f"Top Stall Instructions: {a.backend_name}")
+        lines.append("-" * w)
+        lines.append(f"  {'Stall':>10s}  {'Instruction'}")
+        for stall_val, inst in a.top_stall_instructions[:10]:
+            # Truncate long instruction text
+            inst_short = inst[:70] + "..." if len(inst) > 70 else inst
+            lines.append(f"  {stall_val:>10,}  {inst_short}")
+        lines.append("")
+
+    # --- Top idle instructions (per backend) ---
+    for a in analyses:
+        lines.append("-" * w)
+        lines.append(f"Top Idle Instructions: {a.backend_name}")
+        lines.append("-" * w)
+        lines.append(f"  {'Idle':>10s}  {'Instruction'}")
+        for idle_val, inst in a.top_idle_instructions[:10]:
+            inst_short = inst[:70] + "..." if len(inst) > 70 else inst
+            lines.append(f"  {idle_val:>10,}  {inst_short}")
+        lines.append("")
+
+    # --- Stall regions ---
+    for a in analyses:
+        if a.stall_regions:
+            lines.append("-" * w)
+            lines.append(
+                f"High-Cost Regions: {a.backend_name} "
+                f"(contiguous instruction sequences with high stall+idle)"
+            )
+            lines.append("-" * w)
+            for i, region in enumerate(a.stall_regions[:8]):
+                span = region.end_idx - region.start_idx + 1
+                lines.append(
+                    f"  Region {i+1}: instructions [{region.start_idx}:{region.end_idx}] "
+                    f"({span} instructions)"
+                )
+                lines.append(
+                    f"    Stall={region.total_stall:,}  Idle={region.total_idle:,}  "
+                    f"Latency={region.total_latency:,}"
+                )
+                lines.append(f"    Dominant: {region.dominant_instruction[:80]}")
+                lines.append(f"    Category: {region.category}")
+            lines.append("")
+
+    lines.append("=" * w)
+    return "\n".join(lines)
+
+
+def find_best_att_csv(trace_dir: Path) -> Optional[Path]:
+    """Find the largest (most data) stats_ui CSV in a trace directory."""
+    csvs = list(trace_dir.glob("stats_ui_output_*.csv"))
+    if not csvs:
+        return None
+    # Pick the largest file (most instruction data)
+    return max(csvs, key=lambda f: f.stat().st_size)
+
+
+# ============================================================
+# ATT (Advanced Thread Trace) capture via rocprofv3
+# ============================================================
+
+
+def _find_rocprofv3(explicit_path: Optional[str] = None) -> str:
+    """Locate the rocprofv3 binary."""
+    if explicit_path and os.path.isfile(explicit_path):
+        return explicit_path
+    import shutil
+
+    p = shutil.which("rocprofv3")
+    if p:
+        return p
+    default = "/opt/rocm/bin/rocprofv3"
+    if os.path.isfile(default):
+        return default
+    raise FileNotFoundError(
+        "rocprofv3 not found. Install ROCm or pass --rocprofv3 /path/to/rocprofv3"
+    )
+
+
+def _write_att_json(
+    path: Path,
+    kernel_include_regex: str,
+    kernel_iteration: str = "[1]",
+    att_buffer_size: str = "0x60000000",
+) -> None:
+    """Write an ATT job config for rocprofv3."""
+    cfg = {
+        "jobs": [
+            {
+                "kernel_include_regex": kernel_include_regex,
+                "kernel_exclude_regex": "",
+                "kernel_iteration_range": kernel_iteration,
+                "advanced_thread_trace": True,
+                "att_parse": "trace",
+                "att_target_cu": 0,
+                "att_shader_engine_mask": "0xF",
+                "att_simd_select": "0xF",
+                "att_buffer_size": att_buffer_size,
+            }
+        ]
+    }
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=4)
+
+
+def _write_trace_script_aiter(path: Path, M: int, N: int, K: int) -> None:
+    """Write a standalone Python script that runs the aiter kernel once."""
+    path.write_text(
+        f"""\
+#!/usr/bin/env python3
+\"\"\"ATT trace runner for aiter MXFP4 kernel.\"\"\"
+import sys, os
+os.environ["WAVE_CACHE_ON"] = "0"
+# Ensure aiter is importable (installed at /dockerx/aiter)
+for p in ["/dockerx/aiter", "/dockerx/wave"]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import torch
+import aiter
+from aiter import dtypes
+from aiter.ops.shuffle import shuffle_weight
+
+M, N, K = {M}, {N}, {K}
+dtype = dtypes.bf16
+x_fp = torch.randn((M, K), dtype=dtype, device="cuda:0")
+w_fp = torch.randn((N, K), dtype=dtype, device="cuda:0")
+quant_func = aiter.get_triton_quant(aiter.QuantType.per_1x32)
+x_q, x_scales = quant_func(x_fp, shuffle=True)
+w_q, w_scales = quant_func(w_fp, shuffle=True)
+w_q = shuffle_weight(w_q)
+del x_fp, w_fp
+torch.cuda.empty_cache()
+
+# Warmup
+for _ in range(2):
+    out = aiter.gemm_a4w4(x_q, w_q, x_scales, w_scales, bpreshuffle=True)
+torch.cuda.synchronize()
+
+# Traced dispatch
+out = aiter.gemm_a4w4(x_q, w_q, x_scales, w_scales, bpreshuffle=True)
+torch.cuda.synchronize()
+print("aiter trace dispatch done")
+"""
+    )
+
+
+def _write_trace_script_llvm(
+    path: Path,
+    M: int,
+    N: int,
+    K: int,
+    block_shape: Tuple[int, int, int],
+    num_waves: int,
+) -> None:
+    """Write a standalone Python script that compiles + runs LLVM kernel once."""
+    bm, bn, bk = block_shape
+    path.write_text(
+        f"""\
+#!/usr/bin/env python3
+\"\"\"ATT trace runner for LLVM MXFP4 kernel.\"\"\"
+import sys, os
+os.environ["WAVE_CACHE_ON"] = "0"
+for p in ["/dockerx/wave", "/dockerx/aiter"]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import torch
+from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+from wave_lang.kernel.wave.schedules import get_mxfp4_aiter_style_schedule
+from wave_lang.kernel.wave.compile import wave_compile
+from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+from wave_lang.kernel.wave.utils.mxfp_utils import generate_gemm_afp4wfp4_inputs
+
+M, N, K = {M}, {N}, {K}
+shape = (M, N, K)
+block_shape = ({bm}, {bn}, {bk})
+
+gemm, options = get_tagged_mxfp4_gemm(shape, block_shape, num_waves={num_waves})
+schedule = get_mxfp4_aiter_style_schedule()
+options = set_default_run_config(options)
+
+print("Compiling LLVM...")
+compiled = wave_compile(options, gemm, schedule)
+
+x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+x, w = x.cuda(), w.cuda()
+x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+c = torch.zeros(M, N, dtype=torch.float32, device="cuda:0")
+
+# Warmup
+for _ in range(2):
+    c.zero_()
+    compiled(x, x_scales, w.T.contiguous(), w_scales, c)
+torch.cuda.synchronize()
+
+# Traced dispatch
+c.zero_()
+compiled(x, x_scales, w.T.contiguous(), w_scales, c)
+torch.cuda.synchronize()
+print("LLVM trace dispatch done")
+
+# Explicit cleanup to help rocprofv3 teardown
+del c, x, w, x_scales, w_scales, compiled
+torch.cuda.empty_cache()
+import gc; gc.collect()
+"""
+    )
+
+
+def _write_trace_script_cpp(
+    path: Path,
+    M: int,
+    N: int,
+    K: int,
+    block_shape: Tuple[int, int, int],
+    num_waves: int,
+) -> None:
+    """Write a standalone Python script that compiles + runs C++ ASM kernel once."""
+    bm, bn, bk = block_shape
+    path.write_text(
+        f"""\
+#!/usr/bin/env python3
+\"\"\"ATT trace runner for C++ ASM MXFP4 kernel.\"\"\"
+import sys, os
+os.environ["WAVE_CACHE_ON"] = "0"
+for p in ["/dockerx/wave", "/dockerx/aiter",
+          "/dockerx/wave/wave_lang/kernel/wave/asm/scripts",
+          "/dockerx/wave/wave_lang/kernel/wave/asm/wave_asm/test/e2e"]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import torch
+from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+from wave_lang.kernel.wave.schedules import get_mxfp4_aiter_style_schedule
+from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+from wave_lang.kernel.wave.utils.mxfp_utils import generate_gemm_afp4wfp4_inputs
+from compare_backends import get_default_arch
+from test_asm_backend_e2e import capture_wave_kernel_info
+from waveasm_e2e import WaveASMCompiler, run_with_wave_runtime
+
+M, N, K = {M}, {N}, {K}
+shape = (M, N, K)
+block_shape = ({bm}, {bn}, {bk})
+
+gemm, opts = get_tagged_mxfp4_gemm(shape, block_shape, num_waves={num_waves})
+schedule = get_mxfp4_aiter_style_schedule()
+opts = set_default_run_config(opts)
+opts.backend = "asm"
+opts.wave_runtime = True
+opts.compile_to_mlir = False
+
+print("Capturing MLIR...")
+kernel_info = capture_wave_kernel_info(opts, gemm, schedule=schedule)
+
+print("Compiling C++ backend...")
+compiler = WaveASMCompiler(target=get_default_arch(), keep_temp_files=True)
+cpp_result = compiler.compile_full(kernel_info.mlir_text, kernel_info.workgroup_size)
+assert cpp_result.success, f"C++ compile failed: {{cpp_result.error_message[:300]}}"
+
+x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+x, w = x.cuda(), w.cuda()
+x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+c = torch.zeros(M, N, dtype=torch.float32, device="cuda:0")
+kernel_name = cpp_result.get_kernel_name() or kernel_info.kernel_name
+
+# Warmup
+for _ in range(2):
+    c.zero_()
+    run_with_wave_runtime(
+        binary_path=cpp_result.binary_path,
+        inputs=[x, x_scales, w.T.contiguous(), w_scales],
+        outputs=[c],
+        grid=kernel_info.grid_size,
+        block=kernel_info.workgroup_size,
+        shared_memory_bytes=kernel_info.lds_size,
+        func_name=kernel_name,
+    )
+torch.cuda.synchronize()
+
+# Traced dispatch
+c.zero_()
+run_with_wave_runtime(
+    binary_path=cpp_result.binary_path,
+    inputs=[x, x_scales, w.T.contiguous(), w_scales],
+    outputs=[c],
+    grid=kernel_info.grid_size,
+    block=kernel_info.workgroup_size,
+    shared_memory_bytes=kernel_info.lds_size,
+    func_name=kernel_name,
+)
+torch.cuda.synchronize()
+print("C++ ASM trace dispatch done")
+
+# Explicit cleanup to help rocprofv3 teardown
+del c, x, w, x_scales, w_scales
+torch.cuda.empty_cache()
+import gc; gc.collect()
+"""
+    )
+
+
+def capture_att_trace(
+    backend_name: str,
+    kernel_regex: str,
+    trace_script: Path,
+    trace_output_dir: Path,
+    rocprofv3_path: str,
+    att_library_path: str,
+    working_dir: str = ".",
+) -> bool:
+    """Run a trace script under rocprofv3 --att and capture the thread trace.
+
+    Returns True on success, False on failure.
+    """
+    # Clean and create trace output directory (avoid stale files)
+    import shutil
+
+    if trace_output_dir.exists():
+        shutil.rmtree(trace_output_dir)
+    trace_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write ATT config
+    att_json = trace_output_dir / "att.json"
+    _write_att_json(att_json, kernel_include_regex=kernel_regex)
+
+    cmd = [
+        rocprofv3_path,
+        "--att",
+        "--att-activity",
+        "10",
+        "--att-library-path",
+        att_library_path,
+        "-i",
+        str(att_json),
+        "-d",
+        str(trace_output_dir),
+        "--",
+        sys.executable,
+        str(trace_script),
+    ]
+
+    print(f"  Running: {' '.join(cmd)}")
+    env = os.environ.copy()
+    env["WAVE_CACHE_ON"] = "0"
+    env.setdefault("ROCPROFILER_LOG_LEVEL", "error")
+    # Force all waves onto the target CU (att_target_cu=0) so the hardware
+    # trace buffer is guaranteed to capture data.  Without this, kernels
+    # that don't launch enough waves may never schedule on the target CU,
+    # producing an empty trace CSV.
+    # Syntax: GPU_ID:CU_ID  (GPU 0, CU 0 only)
+    env["HSA_CU_MASK"] = "0:0"
+    # Ensure Python can find wave_lang, aiter, and test helpers
+    extra_paths = [
+        working_dir,
+        os.path.join(working_dir, "wave_lang/kernel/wave/asm/scripts"),
+        os.path.join(working_dir, "wave_lang/kernel/wave/asm/wave_asm/test/e2e"),
+    ]
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = ":".join(extra_paths + ([existing] if existing else []))
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=working_dir,
+            env=env,
+        )
+
+        # Check for captured trace files (may exist even if process crashed
+        # during teardown -- common with PyTorch + rocprofv3 ATT)
+        trace_csvs = sorted(trace_output_dir.glob("stats_ui_output_*.csv"))
+        non_empty = [f for f in trace_csvs if f.stat().st_size > 200]
+
+        if proc.returncode != 0 and not non_empty:
+            print(f"  ATT trace FAILED (exit {proc.returncode})")
+            if proc.stderr:
+                err_lines = proc.stderr.strip().splitlines()
+                for line in err_lines[-10:]:
+                    print(f"    {line}")
+            return False
+
+        if proc.returncode != 0:
+            print(
+                f"  ATT trace: process exited {proc.returncode} "
+                f"(teardown crash) but trace data was captured"
+            )
+
+        # List captured trace files
+        trace_files = sorted(trace_output_dir.glob("*"))
+        print(f"  ATT trace captured: {len(trace_files)} files in {trace_output_dir}")
+        for tf in trace_files[:10]:
+            size = tf.stat().st_size if tf.is_file() else 0
+            print(f"    {tf.name} ({size:,} bytes)")
+        if len(trace_files) > 10:
+            print(f"    ... and {len(trace_files) - 10} more")
+
+        if non_empty:
+            print(f"  Trace CSVs with data: {len(non_empty)}")
+            for f in non_empty[:5]:
+                print(f"    {f.name} ({f.stat().st_size:,} bytes)")
+        else:
+            # Check for raw .att files (hardware trace captured but
+            # decoder produced empty CSV -- common on gfx950)
+            raw_att_files = list(trace_output_dir.rglob("*.att"))
+            if raw_att_files:
+                total_raw = sum(f.stat().st_size for f in raw_att_files)
+                print(
+                    f"  Raw ATT data captured: {len(raw_att_files)} .att files "
+                    f"({total_raw:,} bytes total)"
+                )
+                print(
+                    f"  NOTE: The ATT decoder produced empty CSVs but raw "
+                    f"trace data is available in the output directory."
+                )
+                print(
+                    f"  You can decode these traces with the UI tool or "
+                    f"re-run the ATT decoder manually."
+                )
+                return True
+            else:
+                print(
+                    f"  WARNING: No trace data captured. "
+                    f"The kernel regex '{kernel_regex}' may not match "
+                    f"the actual kernel symbol name."
+                )
+        return bool(non_empty) or bool(list(trace_output_dir.rglob("*.att")))
+
+    except subprocess.TimeoutExpired:
+        print(f"  ATT trace TIMEOUT (>600s)")
+        return False
+    except Exception as e:
+        print(f"  ATT trace ERROR: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="MXFP4 parity benchmark: aiter vs wave"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="/tmp/mxfp4_bench",
+        help="Directory to dump assembly files",
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument(
+        "--shape", type=str, default="1024,1024,8192", help="M,N,K shape"
+    )
+    parser.add_argument(
+        "--check-correctness",
+        action="store_true",
+        help="Check numerical correctness against torch reference",
+    )
+    parser.add_argument(
+        "--check-regression",
+        action="store_true",
+        help="Check C++ ASM against aiter regression gates",
+    )
+    parser.add_argument(
+        "--capture-trace",
+        action="store_true",
+        help="Capture ATT (Advanced Thread Trace) via rocprofv3 "
+        "for each backend kernel",
+    )
+    parser.add_argument(
+        "--att-library-path",
+        type=str,
+        default="/dockerx/rocprof-trace-decoder-therock-7.10/"
+        "releases/linux_glibc_2_28_x86_64/",
+        help="Path to ATT decoder shared library directory",
+    )
+    parser.add_argument(
+        "--rocprofv3",
+        type=str,
+        default=None,
+        help="Path to rocprofv3 binary (auto-detected if omitted)",
+    )
+    args = parser.parse_args()
+
+    M, N, K = [int(x) for x in args.shape.split(",")]
+    # Build parity config from args
+    pcfg = ParityConfig(M=M, N=N, K=K)
+    shape = pcfg.shape
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save parity manifest (Phase 2)
+    manifest = pcfg.to_manifest()
+    manifest_path = out_dir / "parity_manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"MXFP4 GEMM Parity Benchmark: {M}x{N}x{K}")
+    print(f"Warmup: {args.warmup}, Iterations: {args.iters}")
+    print(f"Correctness check: {args.check_correctness}")
+    print(f"Regression gates: {args.check_regression}")
+    print(f"Parity manifest: {manifest_path}")
+    print(f"Output: {out_dir}")
+    print("=" * 70)
+
+    # Generate shared MXFP4 inputs and reference for correctness checks
+    torch_ref = None
+    mxfp4_inputs = None
+    if args.check_correctness:
+        print("\n>>> Generating MXFP4 inputs and torch reference...")
+        x, w, x_scales, w_scales, torch_ref = generate_mxfp4_inputs_and_reference(shape)
+        mxfp4_inputs = (x, w, x_scales, w_scales)
+        print(
+            f"  Reference output: {torch_ref.shape}, "
+            f"range=[{torch_ref.min().item():.4f}, {torch_ref.max().item():.4f}]"
+        )
+
+    backends = {}
+
+    # ============================================================
+    # 1. aiter
+    # ============================================================
+    print("\n>>> aiter (preshuffle BF16 output)...")
+    try:
+        import aiter
+        from aiter import dtypes
+        from aiter.ops.shuffle import shuffle_weight
+
+        dtype = dtypes.bf16
+        x_fp = torch.randn((M, K), dtype=dtype, device="cuda:0")
+        w_fp = torch.randn((N, K), dtype=dtype, device="cuda:0")
+        quant_func = aiter.get_triton_quant(aiter.QuantType.per_1x32)
+        x_q, x_scales = quant_func(x_fp, shuffle=True)
+        w_q, w_scales = quant_func(w_fp, shuffle=True)
+        w_q = shuffle_weight(w_q)
+        del x_fp, w_fp
+        torch.cuda.empty_cache()
+
+        for _ in range(args.warmup):
+            out = aiter.gemm_a4w4(x_q, w_q, x_scales, w_scales, bpreshuffle=True)
+        torch.cuda.synchronize()
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(args.iters):
+            out = aiter.gemm_a4w4(x_q, w_q, x_scales, w_scales, bpreshuffle=True)
+        end.record()
+        torch.cuda.synchronize()
+        us = start.elapsed_time(end) * 1000 / args.iters
+        tflops = 2 * M * N * K / us / 1e6
+        print(f"  {us:.1f} us, {tflops:.2f} TFLOPS")
+
+        # Disassemble aiter .co
+        # Pick the 128x128 BpreShuffle kernel (closest to 4-wave config)
+        aiter_co = "/dockerx/aiter/hsa/gfx950/f4gemm/f4gemm_bf16_per1x32Fp4_BpreShuffle_128x128.co"
+        aiter_asm = disassemble_co(aiter_co)
+        # Extract resources from ELF notes (disassembly doesn't have metadata)
+        aiter_resources = extract_co_resources(aiter_co)
+        if aiter_asm:
+            asm_path = out_dir / "aiter_128x128.s"
+            asm_path.write_text(aiter_asm)
+            print(
+                f"  Assembly dumped: {asm_path} ({len(aiter_asm.splitlines())} lines)"
+            )
+            print(
+                f"  Resources: VGPRs={aiter_resources['vgprs']}, "
+                f"SGPRs={aiter_resources['sgprs']}, "
+                f"AGPRs={aiter_resources['agprs']}, "
+                f"LDS={aiter_resources['lds']}"
+            )
+            backends["aiter"] = {
+                "us": us,
+                "tflops": tflops,
+                "metrics": compute_metrics(aiter_asm),
+                "resources": aiter_resources,
+                "loop_structure": analyze_loop_structure(aiter_asm),
+                "asm_path": str(asm_path),
+            }
+        else:
+            backends["aiter"] = {
+                "us": us,
+                "tflops": tflops,
+                "metrics": InstructionMetrics(),
+                "resources": aiter_resources,
+                "loop_structure": LoopStructure(),
+                "asm_path": None,
+            }
+        del x_q, w_q, x_scales, w_scales, out
+        torch.cuda.empty_cache()
+    except Exception as e:
+        print(f"  ERROR: {e}")
+
+    # ============================================================
+    # 2. LLVM Backend (4-wave)
+    # ============================================================
+    print("\n>>> LLVM backend (4-wave, f32 output)...")
+    try:
+        from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+        from wave_lang.kernel.wave.schedules import get_mxfp4_aiter_style_schedule
+        from wave_lang.kernel.wave.compile import wave_compile
+        from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+        from wave_lang.kernel.wave.utils.mxfp_utils import generate_gemm_afp4wfp4_inputs
+
+        gemm, options = get_tagged_mxfp4_gemm(
+            shape, pcfg.block_shape, num_waves=pcfg.num_waves
+        )
+        schedule = get_mxfp4_aiter_style_schedule()
+        options = set_default_run_config(options)
+
+        # Enable dumping intermediates to capture assembly
+        llvm_dump_dir = out_dir / "llvm_intermediates"
+        llvm_dump_dir.mkdir(parents=True, exist_ok=True)
+        options.dump_intermediates = str(llvm_dump_dir)
+
+        print("  Compiling...")
+        compiled = wave_compile(options, gemm, schedule)
+
+        # Capture LLVM assembly from the compiled result or dump directory
+        llvm_asm = ""
+        llvm_resources = {}
+        llvm_loop = LoopStructure()
+
+        # Try to get raw assembly from .rocmasm file in intermediates
+        rocmasm_files = list(llvm_dump_dir.glob("*.rocmasm"))
+        if rocmasm_files:
+            llvm_asm = rocmasm_files[0].read_text()
+            print(
+                f"  Got LLVM assembly from .rocmasm ({len(llvm_asm.splitlines())} lines)"
+            )
+        else:
+            # Fallback: disassemble the HSACO binary
+            hsaco_path = getattr(compiled, "gpu_binary_path", None)
+            if hsaco_path and Path(hsaco_path).exists():
+                llvm_asm = disassemble_co(hsaco_path)
+                print(
+                    f"  Got LLVM assembly from HSACO disassembly ({len(llvm_asm.splitlines())} lines)"
+                )
+
+        if llvm_asm:
+            llvm_asm_path = out_dir / "llvm_4wave.s"
+            llvm_asm_path.write_text(llvm_asm)
+            llvm_resources = extract_resource_usage(llvm_asm)
+            # Also try ELF notes for more accurate data
+            hsaco_path = getattr(compiled, "gpu_binary_path", None)
+            if hsaco_path and Path(hsaco_path).exists():
+                elf_res = extract_co_resources(hsaco_path)
+                if elf_res.get("vgprs", 0) > 0:
+                    llvm_resources = elf_res
+            llvm_loop = analyze_loop_structure(llvm_asm)
+            print(
+                f"  VGPRs={llvm_resources.get('vgprs', 0)}, "
+                f"SGPRs={llvm_resources.get('sgprs', 0)}, "
+                f"AGPRs={llvm_resources.get('agprs', 0)}"
+            )
+
+        # Use shared inputs for correctness, or generate fresh for benchmark
+        if mxfp4_inputs is not None:
+            x, w, x_scales, w_scales = mxfp4_inputs
+            x, w = x.cuda(), w.cuda()
+            x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+        else:
+            x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+            x, w = x.cuda(), w.cuda()
+            x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+        c = torch.zeros(M, N, dtype=torch.float32, device="cuda:0")
+
+        for _ in range(args.warmup):
+            c.zero_()
+            compiled(x, x_scales, w.T.contiguous(), w_scales, c)
+        torch.cuda.synchronize()
+
+        # Correctness check (after warmup, before timed region)
+        if args.check_correctness and torch_ref is not None:
+            c.zero_()
+            compiled(x, x_scales, w.T.contiguous(), w_scales, c)
+            torch.cuda.synchronize()
+            check_correctness("LLVM 4-wave", c, torch_ref)
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(args.iters):
+            c.zero_()
+            compiled(x, x_scales, w.T.contiguous(), w_scales, c)
+        end.record()
+        torch.cuda.synchronize()
+        us = start.elapsed_time(end) * 1000 / args.iters
+        tflops = 2 * M * N * K / us / 1e6
+        print(f"  {us:.1f} us, {tflops:.2f} TFLOPS")
+
+        backends["LLVM 4-wave"] = {
+            "us": us,
+            "tflops": tflops,
+            "metrics": compute_metrics(llvm_asm) if llvm_asm else InstructionMetrics(),
+            "resources": llvm_resources,
+            "loop_structure": llvm_loop,
+            "asm_path": str(out_dir / "llvm_4wave.s") if llvm_asm else None,
+        }
+        del c
+        torch.cuda.empty_cache()
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+
+    # ============================================================
+    # 3. C++ ASM Backend (4-wave)
+    # ============================================================
+    print("\n>>> C++ ASM backend (4-wave, via waveasm-translate)...")
+    try:
+        from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm
+        from wave_lang.kernel.wave.schedules import get_mxfp4_aiter_style_schedule
+        from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+        from wave_lang.kernel.wave.utils.mxfp_utils import generate_gemm_afp4wfp4_inputs
+
+        sys.path.insert(0, "wave_lang/kernel/wave/asm/scripts")
+        from compare_backends import get_default_arch
+
+        sys.path.insert(0, "wave_lang/kernel/wave/asm/wave_asm/test/e2e")
+        from test_asm_backend_e2e import capture_wave_kernel_info
+        from waveasm_e2e import WaveASMCompiler, run_with_wave_runtime
+
+        gemm2, opts2 = get_tagged_mxfp4_gemm(
+            shape, pcfg.block_shape, num_waves=pcfg.num_waves
+        )
+        schedule2 = get_mxfp4_aiter_style_schedule()
+        opts2 = set_default_run_config(opts2)
+        opts2.backend = "asm"
+        opts2.wave_runtime = True
+        opts2.compile_to_mlir = False
+
+        print("  Capturing MLIR...")
+        kernel_info = capture_wave_kernel_info(opts2, gemm2, schedule=schedule2)
+
+        print("  Compiling with C++ backend...")
+        compiler = WaveASMCompiler(target=get_default_arch(), keep_temp_files=True)
+        cpp_result = compiler.compile_full(
+            kernel_info.mlir_text, kernel_info.workgroup_size
+        )
+
+        if not cpp_result.success:
+            print(f"  C++ compile failed: {cpp_result.error_message[:200]}")
+        else:
+            cpp_asm = cpp_result.asm_text
+            cpp_asm_path = out_dir / "cpp_4wave.s"
+            cpp_asm_path.write_text(cpp_asm)
+            print(
+                f"  Assembly dumped: {cpp_asm_path} ({len(cpp_asm.splitlines())} lines)"
+            )
+
+            cpp_metrics = compute_metrics(cpp_asm)
+            cpp_resources = extract_resource_usage(cpp_asm)
+            print(
+                f"  VGPRs={cpp_resources.get('vgprs', 0)}, "
+                f"SGPRs={cpp_resources.get('sgprs', 0)}, "
+                f"AGPRs={cpp_resources.get('agprs', 0)}"
+            )
+
+            # Run on GPU - use shared inputs for correctness if available
+            if mxfp4_inputs is not None:
+                x, w, x_scales, w_scales = mxfp4_inputs
+                x, w = x.cuda(), w.cuda()
+                x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+            else:
+                x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+                x, w = x.cuda(), w.cuda()
+                x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
+            c = torch.zeros(M, N, dtype=torch.float32, device="cuda:0")
+
+            kernel_name = cpp_result.get_kernel_name() or kernel_info.kernel_name
+
+            for _ in range(args.warmup):
+                c.zero_()
+                run_with_wave_runtime(
+                    binary_path=cpp_result.binary_path,
+                    inputs=[x, x_scales, w.T.contiguous(), w_scales],
+                    outputs=[c],
+                    grid=kernel_info.grid_size,
+                    block=kernel_info.workgroup_size,
+                    shared_memory_bytes=kernel_info.lds_size,
+                    func_name=kernel_name,
+                )
+            torch.cuda.synchronize()
+
+            # Correctness check (after warmup, before timed region)
+            if args.check_correctness and torch_ref is not None:
+                c.zero_()
+                run_with_wave_runtime(
+                    binary_path=cpp_result.binary_path,
+                    inputs=[x, x_scales, w.T.contiguous(), w_scales],
+                    outputs=[c],
+                    grid=kernel_info.grid_size,
+                    block=kernel_info.workgroup_size,
+                    shared_memory_bytes=kernel_info.lds_size,
+                    func_name=kernel_name,
+                )
+                torch.cuda.synchronize()
+                check_correctness("C++ ASM 4-wave", c, torch_ref)
+
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(args.iters):
+                c.zero_()
+                run_with_wave_runtime(
+                    binary_path=cpp_result.binary_path,
+                    inputs=[x, x_scales, w.T.contiguous(), w_scales],
+                    outputs=[c],
+                    grid=kernel_info.grid_size,
+                    block=kernel_info.workgroup_size,
+                    shared_memory_bytes=kernel_info.lds_size,
+                    func_name=kernel_name,
+                )
+            end.record()
+            torch.cuda.synchronize()
+            us = start.elapsed_time(end) * 1000 / args.iters
+            tflops = 2 * M * N * K / us / 1e6
+            print(f"  {us:.1f} us, {tflops:.2f} TFLOPS")
+
+            cpp_loop = analyze_loop_structure(cpp_asm)
+            backends["C++ ASM 4-wave"] = {
+                "us": us,
+                "tflops": tflops,
+                "metrics": cpp_metrics,
+                "resources": cpp_resources,
+                "loop_structure": cpp_loop,
+                "asm_path": str(cpp_asm_path),
+            }
+            del x, w, x_scales, w_scales, c
+            torch.cuda.empty_cache()
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+
+    # ============================================================
+    # Summary
+    # ============================================================
+    print("\n" + "=" * 70)
+    aiter_tflops = backends.get("aiter", {}).get("tflops", 0)
+    header = f"{'Backend':<25s} {'Time (us)':>12s} {'TFLOPS':>12s} {'vs aiter':>12s}"
+    print(header)
+    print("-" * 70)
+    for name, data in backends.items():
+        us_val = data["us"]
+        tf_val = data["tflops"]
+        ratio = tf_val / aiter_tflops if aiter_tflops > 0 else 0
+        print(f"{name:<25s} {us_val:12.1f} {tf_val:12.2f} {ratio:11.2f}x")
+    print("=" * 70)
+
+    # Assembly comparison (only backends with metrics)
+    asm_backends = {n: d for n, d in backends.items() if d["metrics"].total > 0}
+    if len(asm_backends) >= 2:
+        print("\n" + format_comparison(asm_backends, pcfg=pcfg))
+
+    # Regression gate checks (Phase 4)
+    if args.check_regression and "aiter" in backends and "C++ ASM 4-wave" in backends:
+        print("\n" + "=" * 70)
+        print("Regression Gate: C++ ASM vs aiter")
+        print("=" * 70)
+        rg = check_regression_gates(backends["aiter"], backends["C++ ASM 4-wave"])
+        if rg.improvements:
+            for imp in rg.improvements:
+                print(f"  [+] {imp}")
+        if rg.regressions:
+            for reg in rg.regressions:
+                print(f"  [-] {reg}")
+        print(f"  Result: {'PASS' if rg.passed else 'FAIL'}")
+        print("=" * 70)
+
+    # Loop signature diff: C++ ASM vs aiter reference kernel
+    aiter_ref_s = Path(
+        "/dockerx/aiter_kernels/f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.s"
+    )
+    if aiter_ref_s.exists() and "C++ ASM 4-wave" in backends:
+        cpp_asm_path = backends["C++ ASM 4-wave"].get("asm_path")
+        cpp_asm_text = (
+            Path(cpp_asm_path).read_text()
+            if cpp_asm_path and Path(cpp_asm_path).exists()
+            else ""
+        )
+        aiter_ref_text = aiter_ref_s.read_text()
+        if cpp_asm_text and aiter_ref_text:
+            sig_aiter = extract_loop_signature(aiter_ref_text)
+            sig_cpp = extract_loop_signature(cpp_asm_text)
+            sig_diff = format_loop_signature_diff(
+                "aiter-ref", sig_aiter, "C++ ASM", sig_cpp
+            )
+            print("\n" + sig_diff)
+            sig_path = out_dir / "loop_signature_diff.txt"
+            sig_path.write_text(sig_diff)
+            print(f"  Loop signature diff saved: {sig_path}")
+
+    # ============================================================
+    # ATT Thread Trace capture (optional)
+    # ============================================================
+    if args.capture_trace:
+        print("\n" + "=" * 70)
+        print("Capturing ATT Thread Traces")
+        print("=" * 70)
+
+        try:
+            rocprofv3_path = _find_rocprofv3(args.rocprofv3)
+        except FileNotFoundError as e:
+            print(f"  ERROR: {e}")
+            rocprofv3_path = None
+
+        if rocprofv3_path:
+            att_lib = args.att_library_path
+            print(f"  rocprofv3: {rocprofv3_path}")
+            print(f"  ATT library: {att_lib}")
+
+            # Determine working directory (repo root for wave imports)
+            # The script must be run from the wave repo root.
+            wave_root = str(Path(__file__).resolve().parent)
+
+            # --- aiter trace ---
+            if "aiter" in backends:
+                print("\n>>> Capturing aiter ATT trace...")
+                aiter_trace_dir = out_dir / "att_traces" / "aiter"
+                aiter_script = out_dir / "att_traces" / "trace_aiter.py"
+                aiter_script.parent.mkdir(parents=True, exist_ok=True)
+                _write_trace_script_aiter(aiter_script, M, N, K)
+                # aiter kernel name contains "f4gemm" and "BpreShuffle"
+                capture_att_trace(
+                    backend_name="aiter",
+                    kernel_regex="f4gemm.*BpreShuffle",
+                    trace_script=aiter_script,
+                    trace_output_dir=aiter_trace_dir,
+                    rocprofv3_path=rocprofv3_path,
+                    att_library_path=att_lib,
+                    working_dir=wave_root,
+                )
+
+            # --- LLVM trace ---
+            if "LLVM 4-wave" in backends:
+                print("\n>>> Capturing LLVM ATT trace...")
+                llvm_trace_dir = out_dir / "att_traces" / "llvm"
+                llvm_script = out_dir / "att_traces" / "trace_llvm.py"
+                llvm_script.parent.mkdir(parents=True, exist_ok=True)
+                _write_trace_script_llvm(
+                    llvm_script, M, N, K, pcfg.block_shape, pcfg.num_waves
+                )
+                # LLVM kernel name: "gemm" (from Wave/IREE runtime)
+                capture_att_trace(
+                    backend_name="LLVM",
+                    kernel_regex="gemm",
+                    trace_script=llvm_script,
+                    trace_output_dir=llvm_trace_dir,
+                    rocprofv3_path=rocprofv3_path,
+                    att_library_path=att_lib,
+                    working_dir=wave_root,
+                )
+
+            # --- C++ ASM trace ---
+            if "C++ ASM 4-wave" in backends:
+                print("\n>>> Capturing C++ ASM ATT trace...")
+                cpp_trace_dir = out_dir / "att_traces" / "cpp_asm"
+                cpp_script = out_dir / "att_traces" / "trace_cpp_asm.py"
+                cpp_script.parent.mkdir(parents=True, exist_ok=True)
+                _write_trace_script_cpp(
+                    cpp_script, M, N, K, pcfg.block_shape, pcfg.num_waves
+                )
+                # C++ ASM kernel name: "gemm" (from wave_runtime)
+                capture_att_trace(
+                    backend_name="C++ ASM",
+                    kernel_regex="gemm",
+                    trace_script=cpp_script,
+                    trace_output_dir=cpp_trace_dir,
+                    rocprofv3_path=rocprofv3_path,
+                    att_library_path=att_lib,
+                    working_dir=wave_root,
+                )
+
+            # ---- Analyze ATT traces ----
+            print("\n" + "=" * 70)
+            print("ATT Stall Analysis")
+            print("=" * 70)
+            att_analyses = []
+
+            for label, tdir in [
+                ("aiter", out_dir / "att_traces" / "aiter"),
+                ("C++ ASM", out_dir / "att_traces" / "cpp_asm"),
+            ]:
+                csv_path = find_best_att_csv(tdir)
+                if csv_path and csv_path.stat().st_size > 200:
+                    print(f"\n  Analyzing {label}: {csv_path.name}")
+                    analysis = analyze_att_trace(label, csv_path)
+                    att_analyses.append(analysis)
+                else:
+                    print(f"\n  {label}: No trace data available")
+
+            if att_analyses:
+                comparison = format_att_analysis(att_analyses)
+                print("\n" + comparison)
+
+                # Save ATT analysis to file
+                att_report = out_dir / "att_stall_analysis.txt"
+                att_report.write_text(comparison)
+                print(f"\n  ATT analysis saved: {att_report}")
+
+    # Save report
+    report_path = out_dir / "benchmark_report.txt"
+    with open(report_path, "w") as f:
+        f.write(f"MXFP4 GEMM Parity Benchmark: {M}x{N}x{K}\n")
+        f.write(f"Parity config: {json.dumps(manifest, indent=2)}\n\n")
+        f.write(header + "\n" + "-" * 70 + "\n")
+        for name, data in backends.items():
+            us_val = data["us"]
+            tf_val = data["tflops"]
+            ratio = tf_val / aiter_tflops if aiter_tflops > 0 else 0
+            f.write(f"{name:<25s} {us_val:12.1f} {tf_val:12.2f} {ratio:11.2f}x\n")
+        if len(asm_backends) >= 2:
+            f.write("\n" + format_comparison(asm_backends, pcfg=pcfg) + "\n")
+        # Include regression gate results in report
+        if (
+            args.check_regression
+            and "aiter" in backends
+            and "C++ ASM 4-wave" in backends
+        ):
+            rg = check_regression_gates(backends["aiter"], backends["C++ ASM 4-wave"])
+            f.write("\n" + "=" * 70 + "\n")
+            f.write("Regression Gate: C++ ASM vs aiter\n")
+            f.write("=" * 70 + "\n")
+            for imp in rg.improvements:
+                f.write(f"  [+] {imp}\n")
+            for reg in rg.regressions:
+                f.write(f"  [-] {reg}\n")
+            f.write(f"  Result: {'PASS' if rg.passed else 'FAIL'}\n")
+        # Include loop signature diff if available
+        sig_path = out_dir / "loop_signature_diff.txt"
+        if sig_path.exists():
+            f.write("\n" + sig_path.read_text() + "\n")
+        # Include ATT analysis if available
+        att_report = out_dir / "att_stall_analysis.txt"
+        if att_report.exists():
+            f.write("\n" + att_report.read_text() + "\n")
+    print(f"\nReport saved: {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wave_lang/kernel/wave/schedules/__init__.py
+++ b/wave_lang/kernel/wave/schedules/__init__.py
@@ -24,6 +24,6 @@ __all__ = [
     "get_two_pp_cluster_schedule",
     "get_async_two_pp_clusters",
     "get_mxfp4_dbuf_schedule",
-    "get_attention_prefetch_schedule",
     "get_mxfp4_asymmetric_schedule",
+    "get_attention_prefetch_schedule",
 ]


### PR DESCRIPTION
 Add AGPR (accumulator register) as a first-class register class and
    several register pressure / performance optimizations. With these
    changes the 4-wave MXFP4 double-buffered GEMM e2e test now passes
    correctness validation (was xfail due to VGPR pressure exceeding 256).

    AGPR support:

    - Add virtual (areg) and physical (pareg) AGPR types to the WaveASM
      dialect, with precolored.areg op and v_accvgpr_read/write_b32 ops
    - Third AGPR register pool in the linear scan allocator with
      independent allocation, tied operand support, and configurable
      --max-agprs limit
    - Assembly emission: a[N:M] register formatting, accum_offset in
      kernel descriptor, .agpr_count in metadata YAML
    - On gfx950, scaled MFMA accumulators placed in AGPRs when used as
      loop-carried iter_args, freeing VGPR budget for tile data
    - Fix AGPR type preservation through vector.extract_strided_slice

    Register pressure reduction:

    - Fix loop result liveness: set def point of LoopOp results to the
      next sibling op after the loop (not the loop op itself), preventing
      artificial VGPR pressure inflation across the entire loop body.
      8-wave: 481 -> fits in 256 VGPRs. 4-wave: 899 -> 643 VGPRs.
    - Fix SALUCmpOp result type to accept physical SGPRs

    Address computation optimization:

    - Fold nested constants into ds_read offset fields: recursive extraction
      through nested add/shift chains (e.g., (row+16)<<7 -> offset:2048).
      80/96 ds_reads use offset fields, loop v_add_u32: 108 -> 28.
    - Keep gather_to_lds M0 computation in SALU when row/col indices are
      SGPRs (from subgroup_broadcast). v_readfirstlane in loop: 20 -> 0.

    Peephole optimizations:

    - 5 new patterns: fold v_mov_b32(CONST) into consumer VALU ops
      (add, sub, lshl, lshr, and), eliminating the move instruction
    - Redundant M0 write elimination pass

    Also adds 12 stress tests and 3 IfOp bug tests for the linear scan
    register allocator, AGPR lit tests, and the aiter-style 4-wave schedule.

    72/72 lit tests pass, 74/74 e2e tests pass (1 skipped: 8-wave LDS limit).