### PR TITLE
Optimized Preshuffle B schedule. 

### DIFF
--- a/examples/python/7.3_mxfp4_gemm_preshuffle_B.py
+++ b/examples/python/7.3_mxfp4_gemm_preshuffle_B.py
@@ -11,7 +11,6 @@ Usage:
     python 7.3_mxfp4_gemm_preshuffle_B.py --list_tests
 """
 
-
 import torch
 
 import wave_lang.kernel.wave as tkw


### PR DESCRIPTION
* s_waitcnt vmcnt(\*) lgkmcnt(\*) vs. s_waitcnt lgkmcnt(\*); waits for both global read and LDS vs only LDS
* 8-wave doesn't have enough VGPRs to hide the latency via double buffering. 
* 4-wave has enough vgpr to address the cost of moving to VGPR skipping LDS 

* Improved 4-wave preshuffled B schedule

| # | Shape (M × N × K) | 7.3sched TFLOP/s | 7.1sched TFLOP/s | Improvement |
|---|---|---|---|---|
| 1 | 2048 × 57344 × 16384 | 2534.71 | 2404.82 | +5.40% |
| 2 | 4096 × 57344 × 16384 | 2646.39 | 2539.03 | +4.23% |
| 3 | 8192 × 57344 × 16384 | 2676.57 | 2601.94 | +2.87% |
| 4 | 8192 × 57344 × 8192 | 2523.40 | 2478.33 | +1.82% |
| 5 | 16384 × 57344 × 16384 | 2686.42 | 2547.48 | +5.45% |
| 6 | 16384 × 16384 × 16384 | 2675.26 | 2547.38 | +5.02% |
| 7 | 32768 × 57344 × 16384 | 2432.45 | 2289.23 | +6.26% |
| 8 | 32768 × 57344 × 8192 | 2418.90 | 2300.86 | +5.13% |

* 8-wave results (regression)

| # | Shape (M × N × K) | 7.3sched TFLOP/s | 7.1sched TFLOP/s | Improvement |
|---|---|---|---|---|
| 1 | 2048 × 57344 × 16384 | 2428.00 | 2642.84 | -8.13% |
| 2 | 4096 × 57344 × 16384 | 2516.47 | 2737.80 | -8.08% |
| 3 | 8192 × 57344 × 16384 | 2587.79 | 2678.69 | -3.39% |
| 4 | 8192 × 57344 × 8192 | 2418.52 | 2579.07 | -6.22% |
| 5 | 16384 × 57344 × 16384 | 2559.66 | 2675.52 | -4.33% |
| 6 | 16384 × 16384 × 16384 | 2519.79 | 2699.00 | -6.64% |
| 7 | 32768 × 57344 × 16384 | 2325.84 | 2448.82 | -5.02% |
| 8 | 32768 × 57344 × 8192 | 2333.74 | 2426.39 | -3.82% |