### PR TITLE
[water] sideways type inference for write

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -570,7 +570,7 @@ def RegisterOp : WaveOp<"register", [
 }
 
 def WriteOp : WaveOp<"write", [
-    WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
+    DeclareOpInterfaceMethods<WaveInferTypeOpInterface>,
     DeclareOpInterfaceMethods<WaveElementsPerThreadOpInterface>,
     DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>,
     RequiresSidewaysBackwardPropagationOpTrait]> {

--- a/water/include/water/Dialect/Wave/IR/WaveUtils.h
+++ b/water/include/water/Dialect/Wave/IR/WaveUtils.h
@@ -10,6 +10,7 @@
 
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
 
+#include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -64,5 +65,17 @@ llvm::LogicalResult computeWavesPerBlockFromConstraints(
     llvm::SmallVectorImpl<unsigned> &wavesPerBlock);
 
 } // namespace wave
+
+namespace llvm {
+// Combine two potentially failing ChangeResults: if any of them failed, the
+// result of the combination is also failure.
+llvm::FailureOr<mlir::ChangeResult> static inline
+operator|(llvm::FailureOr<mlir::ChangeResult> lhs,
+          FailureOr<mlir::ChangeResult> rhs) {
+  if (llvm::failed(lhs) || llvm::failed(rhs))
+    return llvm::failure();
+  return *lhs | *rhs;
+}
+} // namespace llvm
 
 #endif // WATER_DIALECT_WAVE_IR_WAVEUTILS_H

--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -254,17 +254,6 @@ llvm::FailureOr<ChangeResult> wave::detail::identityTypeInferencePropagate(
   return changeResult;
 }
 
-namespace llvm {
-// Combine two potentially failing ChangeResults: if any of them failed, the
-// result of the combination is also failure.
-static FailureOr<ChangeResult> operator|(FailureOr<ChangeResult> lhs,
-                                         FailureOr<ChangeResult> rhs) {
-  if (failed(lhs) || failed(rhs))
-    return failure();
-  return *lhs | *rhs;
-}
-} // namespace llvm
-
 // Propagate type information from the reduction input type by removing the
 // reduction axis from it to the given type. Report errors to `errs` using
 // `toName` to identify the target type.

--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -2137,6 +2137,28 @@ LogicalResult WriteOp::verify() {
                            getMappingAttr());
 }
 
+FailureOr<ChangeResult>
+WriteOp::propagateForward(ArrayRef<wave::WaveTensorType>,
+                          MutableArrayRef<wave::WaveTensorType>,
+                          raw_ostream &) {
+  // WriteOp has no results; forward propagation only updates result types.
+  return ChangeResult::NoChange;
+}
+
+FailureOr<ChangeResult>
+WriteOp::propagateBackward(MutableArrayRef<wave::WaveTensorType> operandTypes,
+                           ArrayRef<wave::WaveTensorType> resultTypes,
+                           raw_ostream &errs) {
+  return propagateTypesWithMapping(operandTypes[1], operandTypes[0], "memory",
+                                   "value", /*fromIsMemory=*/true,
+                                   getMappingAttr(), errs) |
+         propagateTypesWithMapping(operandTypes[0], operandTypes[1], "value",
+                                   "memory", /*fromIsMemory=*/false,
+                                   getMappingAttr(), errs);
+}
+
+LogicalResult WriteOp::finalizeTypeInference() { return success(); }
+
 llvm::FailureOr<ChangeResult> wave::WriteOp::propagateElementsPerThreadForward(
     llvm::ArrayRef<wave::ElementsPerThreadLatticeValue> operandElements,
     llvm::MutableArrayRef<wave::ElementsPerThreadLatticeValue>,


### PR DESCRIPTION
When write op was added, we couldn't enable sideways (between operands) type inference because it isn't natively supported by the dataflow framework. A workaround for that was added to enable sideways index expression propagation, which we can now also use for type inference.