### PR TITLE
Generalized affine expression decomposition for SGPR promotion

### DIFF
--- a/wave_lang/kernel/compiler/wave_codegen/emitter.py
+++ b/wave_lang/kernel/compiler/wave_codegen/emitter.py
@@ -75,7 +75,11 @@ from ...lang.wave_types import IndexSymbol
 from ...wave.compile_options import WaveCompileOptions
 from ...wave.constraints import Constraint, HardwareConstraint, TilingConstraint
 from ...wave.utils.general_utils import get_hardware_constraint
-from ...wave.utils.symbol_utils import subs_idxc, is_literal
+from ...wave.utils.symbol_utils import (
+    decompose_affine_by_uniformity,
+    subs_idxc,
+    is_literal,
+)
 
 logger = get_logger("wave.ops_location_check")
 
@@ -596,6 +600,103 @@ def add_emitter_subs(
     dynamics.update(dynamic_values)
     dynamics.update(emitter.dynamic_dims)
     return dynamics
+
+
+def get_uniformity_classes(
+    emitter: WaveEmitter,
+) -> list[set]:
+    """Return symbol sets ordered from most-uniform to least-uniform.
+
+    The returned list is suitable for passing to
+    :func:`decompose_affine_by_uniformity` or
+    :func:`gen_sympy_index_decomposed`.
+
+    Currently returns up to two classes:
+      * ``{WORKGROUP_0, WORKGROUP_1, WORKGROUP_2}``
+      * induction-variable symbols (if the emitter is inside a loop)
+
+    Thread-ID symbols and dynamic values are the implicit *remainder*
+    (most divergent) and need not be listed.
+    """
+    wg = {WORKGROUP_0, WORKGROUP_1, WORKGROUP_2}
+    classes: list[set] = [wg]
+    iv_syms = set(emitter.get_induction_vars_and_syms()[1])
+    if iv_syms:
+        classes.append(iv_syms)
+    return classes
+
+
+def gen_sympy_index_decomposed(
+    emitter: WaveEmitter,
+    expr: "sympy.Expr",
+    dynamic_values: dict = {},
+    uniform_sym_classes: list[set] | None = None,
+) -> tuple[Value, list[Value]]:
+    """Lower a sympy expression to MLIR with automatic uniformity decomposition.
+
+    Decomposes *expr* into additive components by uniformity class, emits
+    each component via :func:`gen_sympy_index`, and combines them so that
+    uniform (SGPR-eligible) contributions are separate ``arith.addi`` ops.
+    This lets the AMDGPU backend keep uniform parts in SGPRs and
+    potentially fold them into hardware instruction fields (e.g. soffset).
+
+    Args:
+        emitter: The current wave emitter (provides symbol bindings).
+        expr: Sympy expression to lower.
+        dynamic_values: Extra symbol-to-Value mappings.
+        uniform_sym_classes: Override for uniformity classes.  When
+            ``None``, uses :func:`get_uniformity_classes`.
+
+    Returns:
+        ``(combined, components)`` where *combined* is the final MLIR
+        Value (sum of all components) and *components* is a list of
+        per-class Values (one per class + remainder).
+    """
+    import sympy as _sympy
+
+    subs = add_emitter_subs(emitter, dynamic_values)
+    classes = uniform_sym_classes or get_uniformity_classes(emitter)
+    parts = decompose_affine_by_uniformity(expr, classes)
+
+    zero = _sympy.sympify(0)
+    component_values = [gen_sympy_index(subs, p) for p in parts]
+
+    # Combine: sum uniform components first (SGPR + SGPR stays SGPR),
+    # then add the divergent remainder last (VGPR + SGPR).
+    overflow_flags = (
+        arith_d.IntegerOverflowFlags.nsw | arith_d.IntegerOverflowFlags.nuw
+    )
+    uniform_sum = None
+    for cv in component_values[:-1]:
+        if _is_zero(cv):
+            continue
+        if uniform_sum is None:
+            uniform_sum = cv
+        else:
+            uniform_sum = arith_d.addi(uniform_sum, cv, overflow_flags=overflow_flags)
+
+    remainder = component_values[-1]
+
+    if uniform_sum is None:
+        combined = remainder
+    elif _is_zero(remainder):
+        combined = uniform_sum
+    else:
+        combined = arith_d.addi(remainder, uniform_sum, overflow_flags=overflow_flags)
+
+    return combined, component_values
+
+
+def _is_zero(val: Value) -> bool:
+    """Return True if *val* is a constant-zero index."""
+    if not hasattr(val, "owner") or not hasattr(val.owner, "opview"):
+        return False
+    op = val.owner.opview
+    if isinstance(op, arith_d.ConstantOp):
+        v = op.attributes["value"]
+        if isinstance(v, IntegerAttr) and int(v) == 0:
+            return True
+    return False
 
 
 _emulate_ceildiv = bool(int(environ.get("WAVE_EMULATE_CEILDIV", 0)))

--- a/wave_lang/kernel/wave/utils/symbol_utils.py
+++ b/wave_lang/kernel/wave/utils/symbol_utils.py
@@ -22,6 +22,80 @@ from ..._support.indexing import (
 
 
 ####################################################################
+# Affine-expression uniformity decomposition
+####################################################################
+
+
+def decompose_affine_by_uniformity(
+    expr: IndexExpr | int,
+    symbol_classes: list[set],
+) -> list[IndexExpr]:
+    """Decompose a polynomial expression into additive components by symbol uniformity.
+
+    Given symbol classes ``[C0, C1, ..., Cn]`` ordered from most-uniform
+    (e.g. workgroup IDs) to least-uniform (e.g. induction variables),
+    produces ``n + 1`` components ``[part_0, ..., part_n, remainder]``
+    such that ``sum(parts) == expr``.
+
+    *  ``part_k`` ideally depends only on symbols from ``C_k``.
+    *  ``remainder`` contains thread-dependent terms and constants.
+    *  Cross-class terms (e.g. ``WG * IV``) are cascaded to the next
+       less-uniform class during validation.
+
+    This generalises two-way (workgroup / thread) and three-way
+    (workgroup / induction-var / thread) index splits into a single
+    N-way routine.
+
+    Args:
+        expr: Sympy expression (or plain int) to decompose.
+        symbol_classes: Ordered list of symbol sets, most-uniform first.
+
+    Returns:
+        List of ``n + 1`` IndexExprs (one per class + remainder).
+    """
+    zero = sympy.sympify(0)
+    n = len(symbol_classes)
+
+    if isinstance(expr, (int, float)):
+        return [zero] * n + [sympy.sympify(expr)]
+
+    if not isinstance(expr, sympy.Basic):
+        expr = sympy.sympify(expr)
+
+    # Progressive remainders: r[k] = expr with classes 0..k-1 zeroed out.
+    zero_subs: dict = {}
+    remainders = [expr]
+    for cls in symbol_classes:
+        zero_subs.update({s: 0 for s in cls})
+        remainders.append(safe_subs(expr, zero_subs))
+
+    # component[k] = r[k] - r[k+1]: the part attributable to class k.
+    components: list[IndexExpr] = []
+    for k in range(n):
+        components.append(sympy.simplify(remainders[k] - remainders[k + 1]))
+    components.append(remainders[n])  # remainder
+
+    # Cascade validation: component[k] must only contain symbols from
+    # classes 0..k.  If it has symbols from "below", merge into the next
+    # less-uniform component.
+    allowed: set = set()
+    for k in range(n):
+        allowed = allowed | symbol_classes[k]
+        if components[k] == zero:
+            continue
+        actual = (
+            components[k].free_symbols
+            if isinstance(components[k], sympy.Basic)
+            else set()
+        )
+        if actual - allowed:
+            components[k + 1] = sympy.simplify(components[k + 1] + components[k])
+            components[k] = zero
+
+    return components
+
+
+####################################################################
 # Interval-arithmetic simplification for floor/Mod expressions.
 ####################################################################
 


### PR DESCRIPTION
Add an N-way uniformity decomposition pass that splits any affine expression into additive components by symbol class (workgroup, induction variable, thread). This allows the LLVM backend to keep uniform contributions in SGPRs and fold them into hardware instruction fields (e.g. buffer_load soffset), reducing VGPR pressure.

Key changes:
- symbol_utils.py: add decompose_affine_by_uniformity(), a general N-way decomposition with cascade validation for cross-class terms
- emitter.py: add get_uniformity_classes() and gen_sympy_index_decomposed() so any handler can decompose arbitrary affine maps at the emitter level
- read_write.py: replace _split_index_three_way with the general utility, add _compute_linear_offset/_apply_uniform_offsets helpers, and apply the decomposition to handle_read, handle_write, and handle_gather_to_lds