### PR TITLE
[asm] Fix liveness pressure, add op_sel support, preshuffle B integra…

### DIFF
--- a/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Liveness.h
+++ b/wave_lang/kernel/wave/asm/wave_asm/include/waveasm/Transforms/Liveness.h
@@ -125,6 +125,18 @@ LivenessInfo computeLiveness(ProgramOp program);
 /// Compute maximum register pressure using sweep algorithm
 int64_t computeMaxPressure(llvm::ArrayRef<LiveRange> ranges);
 
+/// Compute maximum register pressure and the instruction index where the
+/// peak occurs.  If \p peakPoint is non-null, the index is written there.
+int64_t computeMaxPressure(llvm::ArrayRef<LiveRange> ranges,
+                           int64_t *peakPoint);
+
+/// Dump detailed peak pressure information for diagnostics.
+/// Shows which values are live at the peak point, categorized by defining op.
+/// Output is gated behind LLVM_DEBUG (use -debug-only=waveasm-liveness).
+void dumpPeakPressureInfo(const LivenessInfo &info,
+                          llvm::ArrayRef<mlir::Operation *> ops,
+                          RegClass regClass);
+
 /// Validate that the program is in SSA form
 /// Each virtual register should be defined exactly once
 /// (with exceptions for loop control and accumulator registers)


### PR DESCRIPTION
…tion

Liveness tied-value coalescing:
- Zero sizes of loop results and condition iter_args in pressure sweep (they share physical registers with block args via tied operands). Reduces reported VGPR pressure by ~55.
- Add dumpPeakPressureInfo() diagnostic for peak pressure analysis.

op_sel support for scaled MFMA:
- Propagate scalesIdxA/scalesIdxB from amdgpu.scaled_mfma as op_sel and op_sel_hi modifiers in the assembly emitter.
- Run apply_opsel_scaled_mfma Python pass in capture_wave_kernel_info before handing MLIR to the C++ backend, eliminating B-scale extract+bitcast chains and setting scalesIdx correctly.

Preshuffle B template integration:
- Update 4-wave e2e test to use get_tagged_mxfp4_gemm_preshuffle_b with wave_shape=(1,4) and asymmetric schedule.
- Add b_preshuffle/e8m0_shuffle host transforms in benchmark.
- Always save cpp_4wave.s even on assembler failure.

72/72 lit tests pass. 4-wave kernel compiles to 256 VGPRs + 256 AGPRs with --max-vgprs=512 (max index v260). With --max-vgprs=256, peak pressure is 323 (67 over, from 3-stage pipeline iter_args).