### PR TITLE
Three-way index split for GatherToLDS uniform offset folding

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -2148,7 +2148,7 @@ def test_broadcast_scaled_add():
     # on the rhs before doing add.
 
     # CHECK-LABEL: func @broadcast_scaled_add
-    # CHECK: %[[RHS:.+]] = memref.load {{.*}} : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK: %[[RHS:.+]] = memref.load {{.*}} : memref<?xf16, {{.*}}#amdgpu.address_space<fat_raw_buffer>>
     # CHECK: %[[BROADCAST_RHS:.+]] = vector.broadcast %[[RHS]] : f16 to vector<2xf16>
     # CHECK: arith.addf %{{.*}}, %[[BROADCAST_RHS]] : vector<2xf16>
 


### PR DESCRIPTION
## Summary

- Introduces `_split_index_three_way()` in `read_write.py` to decompose index expressions into **workgroup**, **uniform (IV)**, and **thread-dependent** components
- Adds `_linearize_uniform_offset()` helper to linearize the IV part into a single scalar offset suitable for `buffer_load` soffset (SGPR)
- Updates `handle_gather_to_lds` to use the three-way split when induction variables are present, keeping the uniform IV offset as a separate `arith.addi` operand
- Updates `gather_to_shared.py` CHECK lines and adds a new `uniform_offset_split.py` lit test