### PR TITLE
[compiler] Support dynamic M, N, K dimensions in MXFP4 scaled GEMM test

### DIFF
--- a/wave_lang/kernel/compiler/wave_codegen/emitter.py
+++ b/wave_lang/kernel/compiler/wave_codegen/emitter.py
@@ -1102,8 +1102,11 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
             case _:
                 raise CodegenError(f"Can not handle {type(term)} : {term}")
 
-    if len(stack) != 1 or isinstance(stack[0], _Rational):
+    if len(stack) != 1:
         raise CodegenError(f"Expected single result, got {stack} for {expr}")
+
+    if isinstance(stack[0], _Rational):
+        stack[0] = _floor(stack[0])
 
     return _get_ir_value(stack[0])
 

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -253,8 +253,13 @@ class WaveKernel:
         def get_dynamic_dimension_actual(sym):
             if sym in debug_extra_dimensions:
                 return debug_extra_dimensions[sym]
-            arg_idx, dim = self.symbols_args_map[sym]
-            return args[arg_idx].shape[dim]
+            if sym in self.symbols_args_map:
+                arg_idx, dim = self.symbols_args_map[sym]
+                return args[arg_idx].shape[dim]
+            _, a_idx, d_idx, inv = host_codegen._find_symbol_in_compound_dim(
+                sym, self.symbols_args_map
+            )
+            return int(args[a_idx].shape[d_idx] * inv)
 
         # If there are debug_log uses with extra iteration dimensions, we need
         # to collect their sizes so that we can allocate the appropriate Torch


### PR DESCRIPTION
The MXFP4 kernel uses packed memory types (K/2, K/32) which produced unresolved _Rational expressions when K was a dynamic symbol. This fixes the codegen and host dispatch to handle compound symbolic dimension expressions, enabling fully dynamic M, N, K for MXFP4.

- emitter: resolve _Rational results via floor division in gen_sympy_index
- host_codegen: infer dynamic symbol values from compound buffer dims (e.g. K from K/2), compute compound dim runtime values for dispatch
- compile: extend get_dynamic_dimension_actual with the same inference
- test: add dynamic_dims param_bool to testScaledGemmMXFP4