### PR TITLE
[water] make EPT propagation require full_types normal form

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -17,6 +17,7 @@
 #include "water/Dialect/Wave/IR/WaveDialect.h"
 #include "water/Dialect/Wave/IR/WaveInterfaces.h"
 #include "water/Dialect/Wave/IR/WaveOps.h"
+#include "water/Dialect/Wave/IR/WaveUtils.h"
 #include "water/Dialect/Wave/Transforms/DataFlowAnalyses.h"
 #include "water/Dialect/Wave/Transforms/Passes.h"
 #include "water/Dialect/Wave/Transforms/Utils.h"
@@ -1041,6 +1042,11 @@ public:
       WaterWavePropagateElementsPerThreadPassBase;
 
   void runOnOperation() override {
+    if (failed(wave::verifyNormalFormPassPrecondition(
+            wave::WaveNormalForm::AllTypesSpecified, getOperation(),
+            getArgument())))
+      return signalPassFailure();
+
     llvm::DenseMap<Operation *, Attribute> constraints;
     if (failed(wave::collectWaveConstraints(getOperation(), constraints)))
       return signalPassFailure();

--- a/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -147,15 +147,23 @@ func.func @unsupported_op() attributes {wave.hyperparameters = #wave.hyperparame
 }
 }
 
-
 // -----
 
-// CHECK: normalform.module [#wave.normal_form<memory_only_types>]
-normalform.module [] {
-  func.func @test_no_existing_normal_form_attr(%mem: !wave.tensor<[@M] of f32, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>, wave.constraints = []} {
+// CHECK: normalform.module [#wave.normal_form<full_types,memory_only_types>]
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @test_normal_form_conditions(%mem: !wave.tensor<[@M] of f32, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>, wave.constraints = []} {
     %0 = arith.constant 0.0 : f32
     %reg = wave.register %0 : !wave.tensor<[@M] of f32, <register>>
     wave.write %reg, %mem { elements_per_thread = 8 } : !wave.tensor<[@M] of f32, <register>>, !wave.tensor<[@M] of f32, <global>>
+    return
+  }
+}
+
+// -----
+
+// expected-error @below {{pass expects the root operation or its ancestor to guarantee the full_types normal form}}
+normalform.module [] {
+  func.func @normal_form_missing() {
     return
   }
 }


### PR DESCRIPTION
This has been a soft precondition anyway, but it wasn't checked.