### PR TITLE
[water] EPT idenity propagation from trailing operands

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -495,8 +495,21 @@ llvm::FailureOr<ChangeResult> wave::detail::identityElementsPerThreadPropagate(
     llvm::StringRef fromName, llvm::StringRef toName, llvm::raw_ostream &errs) {
   assert(!from.empty());
   assert(!to.empty());
+  auto source = ElementsPerThreadLatticeValue::bottom();
+  unsigned sourcePos = 0;
+  for (auto &&[i, fromValue] : llvm::enumerate(from)) {
+    if (fromValue.isBottom())
+      continue;
+    source = fromValue;
+    sourcePos = i;
+    break;
+  }
+  if (source.isBottom())
+    return ChangeResult::NoChange;
+
   return checkAndPropagateElementsPerThreadFromConstant(
-      from[0], from, to, (fromName + " #0").str(), fromName, toName, errs);
+      source, from, to, (fromName + " #" + llvm::Twine(sourcePos)).str(),
+      fromName, toName, errs);
 }
 
 wave::ElementsPerThreadLatticeValue wave::ElementsPerThreadLatticeValue::join(


### PR DESCRIPTION
Existing implementaiton of EPT propagation was erroneously looking at
the first operand only, which means propagation did not happen if it
had the bottom EPT lattice but another operand had a concrete state.
Identify the non-bottom operand instead when possible.

Also add debug prints to EPT.