### PR TITLE
[water] propagate EPT from index expressions

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -411,6 +411,7 @@ private:
 // Shared for elements per thread analyses, visible to every call but immutable.
 struct ElementsPerThreadInit {
   wave::WaveSymbolAttr threadXDimension;
+  wave::WaveHyperparameterAttr hyperparams;
 };
 
 namespace detail {

--- a/water/lib/Dialect/Wave/IR/WaveUtils.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveUtils.cpp
@@ -103,7 +103,9 @@ wave::evaluateMapWithHyperparams(AffineMap map, ArrayRef<Attribute> symbols,
     if (!symbol)
       return std::nullopt;
 
-    std::optional<int64_t> value = hyperparams.getSymbolValue(symbol.getName());
+    std::optional<int64_t> value =
+        hyperparams ? hyperparams.getSymbolValue(symbol.getName())
+                    : std::nullopt;
     if (!value)
       return std::nullopt;
     symReplacements.push_back(getAffineConstantExpr(*value, map.getContext()));

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -23,6 +23,7 @@
 #include "water/Dialect/Wave/Transforms/Utils.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -785,7 +786,105 @@ public:
     if (failed(AbstractSparseForwardDataFlowAnalysis::initialize(top)))
       return failure();
 
-    return success();
+    WalkResult walkResult = top->walk([&](Operation *op) {
+      auto indexArray = op->getAttrOfType<ArrayAttr>(
+          wave::WaveDialect::kIndexWaveExprListAttrName);
+      if (!indexArray)
+        return WalkResult::advance();
+
+      auto indexIface = dyn_cast<wave::WaveInferIndexExprsOpInterface>(op);
+      if (!indexIface)
+        return WalkResult::advance();
+
+      SmallVector<Value> valuesForIndexExpr;
+      std::function<void(raw_ostream &, unsigned)> descriptionGenerator =
+          indexIface.getIndexExprValuesAndDescriptions(valuesForIndexExpr);
+
+      assert(valuesForIndexExpr.size() == indexArray.size());
+      for (auto [i, value, index] :
+           llvm::enumerate(valuesForIndexExpr, indexArray)) {
+        ElementsPerThreadLattice *lattice = getLatticeElement(value);
+        auto indexDict = cast<DictionaryAttr>(index);
+        std::optional<int64_t> elementsPerThread = std::nullopt;
+        llvm::StringSet<> visitedSymbols;
+        for (const NamedAttribute &namedAttr : indexDict) {
+          visitedSymbols.insert(namedAttr.getName().strref());
+          auto mapping = cast<wave::WaveIndexMappingAttr>(namedAttr.getValue());
+          ArrayRef<Attribute> symbols = mapping.getSymbols();
+          AffineMap step = mapping.getStep();
+          if (!step)
+            continue;
+          std::optional<SmallVector<int64_t>> stepValues =
+              wave::evaluateMapWithHyperparams(step, symbols, init.hyperparams);
+          if (!stepValues)
+            continue;
+          // TODO(#1012): turn this into an assertion when the verifier is
+          // implemented.
+          int64_t stepValue = (*stepValues)[0];
+          if (stepValue <= 0) {
+            op->emitError() << "expected positive step in index expressions "
+                               "(missing verifier)";
+            return WalkResult::interrupt();
+          }
+
+          // Elements per thread may be 1 if _all_ dimensions have a unit step,
+          // otherwise it should be the one non-unit step.
+          // TODO(#1013): this logic can be reused in the verifier.
+          if (!elementsPerThread.has_value()) {
+            elementsPerThread = (*stepValues)[0];
+          } else if (*elementsPerThread == 1) {
+            elementsPerThread = (*stepValues)[0];
+          } else if (stepValue != 1) {
+            // TODO(#1013): turn this into an assertion when the verifier is
+            // implemented.
+            op->emitError() << "expected only one non-unit index step, found "
+                            << (*stepValues)[0] << " and " << *elementsPerThread
+                            << " (missing verifier)";
+            return WalkResult::interrupt();
+          }
+        }
+
+        llvm::SmallString<32> description;
+        llvm::raw_svector_ostream descriptionOs(description);
+        descriptionGenerator(descriptionOs, i);
+        auto resultType = cast<wave::WaveTensorType>(value.getType());
+        if (!llvm::all_of(resultType.getShape(), [&](wave::WaveSymbolAttr dim) {
+              return visitedSymbols.contains(dim.getName());
+            })) {
+          // TODO(#878): turn this into an assertion when the verifier is
+          // implemented. We may also consider a relaxation where we take the
+          // non-unit EPT if it was extracted even from an incomplete index
+          // expression.
+          op->emitError() << "expected index to contain entries for all "
+                          << description << " dimensions (missing verifier)";
+          return WalkResult::interrupt();
+        }
+
+        // If couldn't get a fixed value for EPT, bail.
+        if (!elementsPerThread.has_value()) {
+          return WalkResult::advance();
+        }
+
+        std::string errorMessage;
+        llvm::raw_string_ostream errs(errorMessage);
+        FailureOr<ChangeResult> result =
+            wave::detail::checkAndPropagateElementsPerThreadFromConstant(
+                wave::ElementsPerThreadLatticeValue(*elementsPerThread), {},
+                lattice->getValue(), "index expression", "",
+                descriptionOs.str(), errs);
+        if (failed(result)) {
+          op->emitError() << "failed to propagate elements per thread forward "
+                             "during initialization: "
+                          << errs.str();
+          return WalkResult::interrupt();
+        }
+        if (*result == ChangeResult::Change)
+          propagateIfChanged(lattice, *result);
+      }
+      return WalkResult::advance();
+    });
+
+    return success(!walkResult.wasInterrupted());
   }
 
   // Called by base class initialization and when the analysis fails to identify
@@ -1123,6 +1222,7 @@ public:
 
       wave::ElementsPerThreadInit init;
       init.threadXDimension = nullptr;
+      init.hyperparams = wave::getHyperparameters(parent);
       for (Attribute constraint : cast<ArrayAttr>(attr)) {
         auto workgroupConstraint =
             dyn_cast<wave::WorkgroupConstraintAttr>(constraint);

--- a/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -39,6 +39,143 @@ func.func @propagate_register_write(%mem: !wave.tensor<[@M] of f16, <global>>) a
 
 // -----
 
+// Register per thread is the non-unit second element of the index map,
+// propagate that in absence of explicit elements_per_thread.
+//
+// CHECK: #wave.normal_form<full_types,memory_only_types>
+normalform.module [#wave.normal_form<full_types>] {
+// CHECK-LABEL: @propagate_register_write_index_expr
+func.func @propagate_register_write_index_expr(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>, wave.constraints = []}  {
+  %cst = arith.constant 0.0 : f16
+  // CHECK: wave.register {{.*}} : vector<4xf16>
+  %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
+  // CHECK: wave.write {{.*}} : vector<4xf16>, !wave.tensor<[@M] of f16, <global>>
+  wave.write %reg, %mem index [{M : <[] -> (<NULL>, 4, <NULL>)>}]
+     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_types>] {
+func.func @propagate_register_write_index_expr_conflict(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>, wave.constraints = []}  {
+  %cst = arith.constant 0.0 : f16
+  %reg = wave.register %cst index [{M : <[] -> (<NULL>, 4, <NULL>)>}] : !wave.tensor<[@M] of f16, <register>>
+  // expected-error @below {{failed to propagate elements per thread backward: mismatch between elements_per_thread attribute (8) and operand #0 (4)}}
+  wave.write %reg, %mem { elements_per_thread = 8 }
+     : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+  return
+}
+}
+
+// -----
+
+// Check the error message during initialization from index expressions. In MMAs, unlike many other ops,
+// we have index expressions associated with operands and not only results. This means that the
+// initialization process may have assigned an EPT value to an operand when initializing dataflow for
+// its defining operation, making it the only scenario in which the conflict error may be seen
+// during initialization and not at some later point.
+normalform.module [#wave.normal_form<full_types>] {
+func.func @mma_operands_from_reads(
+    %mem_a: !wave.tensor<[@M, @K] of f16, <global>>,
+    %mem_b: !wave.tensor<[@N, @K] of f16, <global>>,
+    %mem_c: !wave.tensor<[@M, @N] of f32, <global>>,
+    %out: !wave.tensor<[@M, @N] of f32, <global>>)
+  attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 64, K = 32}>, wave.constraints = [#wave.hardware_constraint<threads_per_wave = 32, waves_per_block = [1, 1, 1], mma_type = #wave.mma_kind<f32_16x16x16_f16>, vector_shapes = {M = 1, N = 1, K = 16}, max_bits_per_load = 128>]} {
+
+  %a = wave.read %mem_a { elements_per_thread = 8 } : (!wave.tensor<[@M, @K] of f16, <global>>) -> !wave.tensor<[@M, @K] of f16, <register>>
+  %b = wave.read %mem_b { elements_per_thread = 8 } : (!wave.tensor<[@N, @K] of f16, <global>>) -> !wave.tensor<[@N, @K] of f16, <register>>
+  %c = wave.read %mem_c { elements_per_thread = 8 } : (!wave.tensor<[@M, @N] of f32, <global>>) -> !wave.tensor<[@M, @N] of f32, <register>>
+  // expected-error @below {{failed to propagate elements per thread forward during initialization: mismatch between index expression (1) and rhs #0 (8)}}
+  %result = wave.mma %a, %b, %c index [
+    {M : <[] -> (<NULL>, 8, <NULL>)>, K : <[] -> (<NULL>, 1, <NULL>)>},
+    {K : <[] -> (<NULL>, 1, <NULL>)>, N : <[] -> (<NULL>, 1, <NULL>)>},
+    {M : <[] -> (<NULL>, 8, <NULL>)>, N : <[] -> (<NULL>, 1, <NULL>)>},
+    {M : <[] -> (<NULL>, 8, <NULL>)>, N : <[] -> (<NULL>, 1, <NULL>)>}
+  ] {kind =  #wave.mma_kind<f32_16x16x16_f16> } : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
+  wave.write %result, %out { elements_per_thread = 8 } : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <global>>
+  return
+}
+}
+
+// -----
+
+// Null hyperparameters: step uses a symbol so it cannot be evaluated; pass must
+// not crash and should report that EPT could not be identified.
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @null_hyperparams_symbol_step(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.constraints = []} {
+    %cst = arith.constant 0.0 : f16
+    // expected-error @below {{couldn't identify elements per thread for result #0}}
+    %reg = wave.register %cst index [{M : <[#wave.symbol<"M">] -> (<NULL>, M, <NULL>)>}] : !wave.tensor<[@M] of f16, <register>>
+    wave.write %reg, %mem index [{M : <[#wave.symbol<"M">] -> (<NULL>, M, <NULL>)>}]
+      : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+    return
+  }
+}
+
+// -----
+
+// Null hyperparameters but constant step: step has no symbols so it is
+// evaluated without hyperparams and EPT is inferred.
+// CHECK: #wave.normal_form<full_types,memory_only_types>
+normalform.module [#wave.normal_form<full_types>] {
+// CHECK-LABEL: @null_hyperparams_constant_step
+  func.func @null_hyperparams_constant_step(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.constraints = []} {
+    %cst = arith.constant 0.0 : f16
+    // CHECK: wave.register {{.*}} : vector<4xf16>
+    %reg = wave.register %cst : !wave.tensor<[@M] of f16, <register>>
+    // CHECK: wave.write {{.*}} : vector<4xf16>, !wave.tensor<[@M] of f16, <global>>
+    wave.write %reg, %mem index [{M : <[] -> (<NULL>, 4, <NULL>)>}]
+      : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+    return
+  }
+}
+
+// -----
+
+// Step is zero; pass must report "expected positive step".
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @index_step_zero(%mem: !wave.tensor<[@M] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>, wave.constraints = []} {
+    %cst = arith.constant 0.0 : f16
+    // expected-error @below {{expected positive step in index expressions}}
+    %reg = wave.register %cst index [{M : <[] -> (<NULL>, 0, <NULL>)>}] : !wave.tensor<[@M] of f16, <register>>
+    wave.write %reg, %mem index [{M : <[] -> (<NULL>, 0, <NULL>)>}]
+      : !wave.tensor<[@M] of f16, <register>>, !wave.tensor<[@M] of f16, <global>>
+    return
+  }
+}
+
+// -----
+
+// Two dimensions with non-unit steps; pass must report "expected only one non-unit".
+// Use only register (write has its own verifier for multi-step index).
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @index_multi_non_unit_step(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 64}>, wave.constraints = []} {
+    %cst = arith.constant 0.0 : f16
+    // expected-error @below {{expected only one non-unit index step}}
+    %reg = wave.register %cst index [{M : <[] -> (<NULL>, 4, <NULL>)>, N : <[] -> (<NULL>, 8, <NULL>)>}] : !wave.tensor<[@M, @N] of f16, <register>>
+    wave.write %reg, %mem index [{M : <[] -> (<NULL>, 4, <NULL>)>, N : <[] -> (<NULL>, 1, <NULL>)>}]
+      : !wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@M, @N] of f16, <global>>
+    return
+  }
+}
+
+// -----
+
+// Index missing dimension N for result type [M, N]; pass must report missing dimensions.
+normalform.module [#wave.normal_form<full_types>] {
+  func.func @index_missing_dimension(%mem: !wave.tensor<[@M, @N] of f16, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 64}>, wave.constraints = []} {
+    %cst = arith.constant 0.0 : f16
+    // expected-error @below {{expected index to contain entries for all result #0 dimensions}}
+    %reg = wave.register %cst index [{M : <[] -> (<NULL>, 4, <NULL>)>}] : !wave.tensor<[@M, @N] of f16, <register>>
+    wave.write %reg, %mem { elements_per_thread = 4 } : !wave.tensor<[@M, @N] of f16, <register>>, !wave.tensor<[@M, @N] of f16, <global>>
+    return
+  }
+}
+
+// -----
+
 // CHECK: #wave.normal_form<full_types,memory_only_types>
 normalform.module [#wave.normal_form<full_types>] {
 // CHECK-LABEL: @propagate_backward_from_write


### PR DESCRIPTION
Use the index attribute when initializing forward pass of the elemenets-per-thread propagation. These should be consistent, which we will detect early thanks to this, and we can identify more cases where the explicit EPT is missing.