### PR TITLE
[asm] Replace getOperand calls with named accessors via OpInterfaces

### DIFF
--- a/waveasm/include/waveasm/Dialect/CMakeLists.txt
+++ b/waveasm/include/waveasm/Dialect/CMakeLists.txt
@@ -43,6 +43,8 @@ add_public_tablegen_target(MLIRWaveASMAttrsIncGen)
 set(LLVM_TARGET_DEFINITIONS WaveASMInterfaces.td)
 mlir_tablegen(WaveASMAttrInterfaces.h.inc -gen-attr-interface-decls)
 mlir_tablegen(WaveASMAttrInterfaces.cpp.inc -gen-attr-interface-defs)
+mlir_tablegen(WaveASMOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(WaveASMOpInterfaces.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(MLIRWaveASMInterfacesIncGen)
 
 #-------------------------------------------------------------------------------

--- a/waveasm/include/waveasm/Dialect/WaveASMInterfaces.h
+++ b/waveasm/include/waveasm/Dialect/WaveASMInterfaces.h
@@ -9,6 +9,9 @@
 
 #include "mlir/IR/OpDefinition.h"
 
+// Include generated op interfaces (MFMAOpInterface, etc.)
+#include "waveasm/Dialect/WaveASMOpInterfaces.h.inc"
+
 namespace mlir {
 namespace OpTrait {
 
@@ -25,9 +28,9 @@ namespace OpTrait {
 template <typename ConcreteType>
 class ArithmeticOp : public TraitBase<ConcreteType, ArithmeticOp> {};
 
-/// Trait for MFMA operations. This is orthogonal to CSE.
-template <typename ConcreteType>
-class MFMAOp : public TraitBase<ConcreteType, MFMAOp> {};
+// Note: MFMAOp is now an OpInterface (MFMAOpInterface) defined in
+// WaveASMInterfaces.td. The interface provides getA(), getB(), getAcc(),
+// getDst(), and getTiedOperandIndex() methods for MFMA operations.
 
 /// Trait for memory operations (loads/stores).
 /// These are NOT eligible for CSE.

--- a/waveasm/include/waveasm/Dialect/WaveASMInterfaces.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMInterfaces.td
@@ -134,8 +134,126 @@ def WaveASM_TargetAttrInterface : AttrInterface<"TargetAttrInterface"> {
 // Trait for arithmetic/ALU operations that are pure and CSE-eligible
 def WaveASM_ArithmeticOp : NativeOpTrait<"ArithmeticOp">;
 
-// Trait for MFMA operations
-def WaveASM_MFMAOp : NativeOpTrait<"MFMAOp">;
+// Interface for MFMA operations.
+// Method implementations are provided by ODS-generated accessors from the op
+// definitions (e.g., $a -> getA(), $acc -> getAcc()). No default
+// implementations needed - DeclareOpInterfaceMethods on the op class
+// causes ODS to reuse the generated accessors as interface method bodies.
+def WaveASM_MFMAOp : OpInterface<"MFMAOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for matrix fused multiply-add (MFMA) operations.
+    All MFMA ops have the same operand structure: a, b, acc -> dst.
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the first matrix operand (A).",
+      "::mlir::Value", "getA", (ins)>,
+    InterfaceMethod<"Get the second matrix operand (B).",
+      "::mlir::Value", "getB", (ins)>,
+    InterfaceMethod<"Get the accumulator operand.",
+      "::mlir::Value", "getAcc", (ins)>,
+    InterfaceMethod<"Get the destination/result value.",
+      "::mlir::Value", "getDst", (ins)>,
+    InterfaceMethod<
+      "Get the tied operand index (accumulator index for tying).",
+      "int", "getTiedOperandIndex", (ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return 2;
+      }]
+    >
+  ];
+}
+
+// Interface for VMEM load operations (buffer_load_*, global_load_*).
+// Implementations provided by ODS-generated accessors from $saddr, $voffset, $soffset.
+def WaveASM_VMEMLoadOp : OpInterface<"VMEMLoadOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for VMEM load operations (buffer and global loads).
+    Operands: saddr (SRD/pointer), voffset (per-lane offset), soffset (scalar offset).
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the buffer descriptor / address operand.",
+      "::mlir::Value", "getSaddr", (ins)>,
+    InterfaceMethod<"Get the vector offset operand.",
+      "::mlir::Value", "getVoffset", (ins)>,
+    InterfaceMethod<"Get the scalar offset operand.",
+      "::mlir::Value", "getSoffset", (ins)>
+  ];
+}
+
+// Interface for VMEM store operations (buffer_store_*, global_store_*).
+// Implementations provided by ODS-generated accessors from $data, $saddr, $voffset.
+def WaveASM_VMEMStoreOp : OpInterface<"VMEMStoreOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for VMEM store operations (buffer and global stores).
+    Operands: data (value to store), saddr (SRD/pointer), voffset (per-lane offset).
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the data operand (value to store).",
+      "::mlir::Value", "getData", (ins)>,
+    InterfaceMethod<"Get the buffer descriptor / address operand.",
+      "::mlir::Value", "getSaddr", (ins)>,
+    InterfaceMethod<"Get the vector offset operand.",
+      "::mlir::Value", "getVoffset", (ins)>
+  ];
+}
+
+// Interface for LDS load operations (ds_read_*).
+// Implementation provided by ODS-generated accessor from $vaddr.
+def WaveASM_LDSLoadOp : OpInterface<"LDSLoadOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for LDS load operations.
+    Operands: vaddr (LDS address).
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the LDS address operand.",
+      "::mlir::Value", "getVaddr", (ins)>
+  ];
+}
+
+// Interface for LDS store operations (ds_write_*).
+// Implementations provided by ODS-generated accessors from $data, $vaddr.
+def WaveASM_LDSStoreOp : OpInterface<"LDSStoreOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for LDS store operations.
+    Operands: data (value to store), vaddr (LDS address).
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the data operand (value to store).",
+      "::mlir::Value", "getData", (ins)>,
+    InterfaceMethod<"Get the LDS address operand.",
+      "::mlir::Value", "getVaddr", (ins)>
+  ];
+}
+
+// Interface for VMEM-to-LDS load operations (buffer_load_*_lds).
+// Implementations provided by ODS-generated accessors from $voffset, $srd, $soffset.
+def WaveASM_VMEMToLDSLoadOp : OpInterface<"VMEMToLDSLoadOpInterface"> {
+  let cppNamespace = "::waveasm";
+  let description = [{
+    Interface for VMEM-to-LDS (gather-to-LDS) load operations.
+    Operands: voffset (per-lane offset), srd (buffer descriptor), soffset (scalar offset).
+  }];
+
+  let methods = [
+    InterfaceMethod<"Get the vector offset operand.",
+      "::mlir::Value", "getVoffset", (ins)>,
+    InterfaceMethod<"Get the buffer descriptor operand.",
+      "::mlir::Value", "getSrd", (ins)>,
+    InterfaceMethod<"Get the scalar offset operand.",
+      "::mlir::Value", "getSoffset", (ins)>
+  ];
+}
 
 // Trait for memory operations (loads/stores)
 def WaveASM_MemoryOp : NativeOpTrait<"MemoryOp">;

--- a/waveasm/include/waveasm/Dialect/WaveASMOps.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMOps.td
@@ -133,7 +133,7 @@ class SALUCmpOp<string mnemonic, list<Trait> traits = []>
 // The result is tied to operand index 2 (the accumulator) when acc is a VGPR.
 // MFMA instructions support inline 0 for the accumulator (no tying needed).
 class MFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_MFMAOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([Pure, DeclareOpInterfaceMethods<WaveASM_MFMAOp>], traits)> {
   let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_MFMAAccSrc:$acc);
   let results = (outs WaveASM_AnyVecReg:$dst);
   let assemblyFormat = "$a `,` $b `,` $acc attr-dict `:` type($a) `,` type($b) `,` type($acc) `->` type($dst)";
@@ -152,7 +152,7 @@ class MFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
 // VMEM Load: results = load(saddr, voffset, soffset) with optional instruction offset.
 // effective_address = SRD_base + voffset + soffset.
 class VMEMLoadOp<string mnemonic, int numResults, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp, DeclareOpInterfaceMethods<WaveASM_VMEMLoadOp>], traits)> {
   // voffset can be VGPR or immediate (for constant offsets).
   // soffset is an SGPR or immediate scalar offset (default 0).
   // instOffset is an optional immediate offset added to voffset (emitted as "offset:N").
@@ -170,7 +170,7 @@ class VMEMLoadOp<string mnemonic, int numResults, list<Trait> traits = []>
 
 // VMEM Store: store(data, saddr, voffset) with optional instruction offset
 class VMEMStoreOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp, DeclareOpInterfaceMethods<WaveASM_VMEMStoreOp>], traits)> {
   // voffset can be VGPR or immediate (for constant offsets)
   // instOffset is an optional immediate offset added to voffset (emitted as "offset:N")
   let arguments = (ins WaveASM_AnyVGPR:$data, WaveASM_AnySGPR:$saddr, WaveASM_VRegOrImm:$voffset,
@@ -195,7 +195,7 @@ class SMEMLoadOp<string mnemonic, int numResults, list<Trait> traits = []>
 // vaddr can be VGPR or immediate offset
 // offset is an optional immediate byte offset (for ds_read offset:N syntax)
 class LDSLoadOp<string mnemonic, int numResults, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp, DeclareOpInterfaceMethods<WaveASM_LDSLoadOp>], traits)> {
   let arguments = (ins WaveASM_VRegOrImm:$vaddr,
                        OptionalAttr<I64Attr>:$offset);
   let results = (outs Variadic<WaveASM_AnyVGPR>:$results);
@@ -207,7 +207,7 @@ class LDSLoadOp<string mnemonic, int numResults, list<Trait> traits = []>
 // LDS Store: store(data, vaddr)
 // vaddr can be VGPR or immediate offset
 class LDSStoreOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp, DeclareOpInterfaceMethods<WaveASM_LDSStoreOp>], traits)> {
   let arguments = (ins WaveASM_AnyVGPR:$data, WaveASM_VRegOrImm:$vaddr);
   let assemblyFormat = "$data `,` $vaddr attr-dict `:` type($data) `,` type($vaddr)";
 }
@@ -817,7 +817,7 @@ def WaveASM_V_MFMA_F32_32X32X16_BF8_BF8 : MFMAOp<"v_mfma_f32_32x32x16_bf8_bf8", 
 // Scaled MFMA: Matrix multiply with per-group scale factors (gfx950+)
 // These instructions take additional scale operands for MXFP4/FP6/FP8 support
 class ScaledMFMAOp<string mnemonic, int accSize, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_MFMAOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([Pure, DeclareOpInterfaceMethods<WaveASM_MFMAOp>], traits)> {
   // Operands: a_data, b_data, acc, a_scale, b_scale
   let arguments = (ins WaveASM_VALUSrc:$a, WaveASM_VALUSrc:$b, WaveASM_MFMAAccSrc:$acc,
                        WaveASM_VALUSrc:$a_scale, WaveASM_VALUSrc:$b_scale);
@@ -878,7 +878,7 @@ def WaveASM_FLAT_LOAD_DWORDX4 : VMEMLoadOp<"flat_load_dwordx4", 4>;
 // VMEM-to-LDS Load: load from global to LDS (M0 contains LDS offset)
 // No VGPR result - data goes directly to LDS
 class VMEMToLDSLoadOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, traits> {
+    : WAVEASMOp<mnemonic, !listconcat([DeclareOpInterfaceMethods<WaveASM_VMEMToLDSLoadOp>], traits)> {
   let summary = "Load from global memory directly to LDS";
   let arguments = (ins
     WaveASM_VRegOrImm:$voffset,   // Global memory offset per lane
@@ -917,7 +917,7 @@ def WaveASM_S_MOV_B32_M0 : WAVEASMOp<"s_mov_b32_m0", [WaveASM_SpecialRegOp]> {
 // The instruction atomically adds both bf16 values to the corresponding
 // bf16 halves at the 32-bit aligned memory address.
 class VMEMAtomicOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp], traits)> {
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_MemoryOp, DeclareOpInterfaceMethods<WaveASM_VMEMStoreOp>], traits)> {
   let arguments = (ins WaveASM_AnyVGPR:$data, WaveASM_AnySGPR:$saddr, WaveASM_VRegOrImm:$voffset,
                        DefaultValuedAttr<I64Attr, "0">:$instOffset);
   let assemblyFormat = "$data `,` $saddr `,` $voffset (`offset` `:` $instOffset^)? attr-dict `:` type($data) `,` type($saddr) `,` type($voffset)";

--- a/waveasm/lib/Dialect/WaveASMDialect.cpp
+++ b/waveasm/lib/Dialect/WaveASMDialect.cpp
@@ -6,6 +6,7 @@
 
 #include "waveasm/Dialect/WaveASMDialect.h"
 #include "waveasm/Dialect/WaveASMAttrs.h"
+#include "waveasm/Dialect/WaveASMInterfaces.h"
 #include "waveasm/Dialect/WaveASMOps.h"
 #include "waveasm/Dialect/WaveASMTypes.h"
 
@@ -17,6 +18,9 @@ using namespace mlir;
 using namespace waveasm;
 
 #include "waveasm/Dialect/WaveASMDialect.cpp.inc"
+
+// Include OpInterface definitions
+#include "waveasm/Dialect/WaveASMOpInterfaces.cpp.inc"
 
 // Include full type and attribute definitions to make storage types complete
 #define GET_TYPEDEF_CLASSES

--- a/waveasm/lib/Transforms/BufferLoadStrengthReduction.cpp
+++ b/waveasm/lib/Transforms/BufferLoadStrengthReduction.cpp
@@ -40,6 +40,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "waveasm/Dialect/WaveASMDialect.h"
+#include "waveasm/Dialect/WaveASMInterfaces.h"
 #include "waveasm/Dialect/WaveASMOps.h"
 #include "waveasm/Dialect/WaveASMTypes.h"
 #include "waveasm/Transforms/Passes.h"
@@ -83,12 +84,28 @@ static bool isBufferLoadLDS(Operation *op) {
   return isa<BUFFER_LOAD_DWORD_LDS, BUFFER_LOAD_DWORDX4_LDS>(op);
 }
 
-// VMEMLoadOp:       (saddr=0, voffset=1, soffset=2).
-// VMEMToLDSLoadOp:  (voffset=0, srd=1, soffset=2).
+// Get voffset from load operation using interface.
+static Value getVoffset(Operation *op) {
+  if (auto vmemLoad = dyn_cast<VMEMLoadOpInterface>(op))
+    return vmemLoad.getVoffset();
+  if (auto ldsLoad = dyn_cast<VMEMToLDSLoadOpInterface>(op))
+    return ldsLoad.getVoffset();
+  return nullptr;
+}
+
+// Get SRD/saddr from load operation using interface.
+static Value getSrd(Operation *op) {
+  if (auto vmemLoad = dyn_cast<VMEMLoadOpInterface>(op))
+    return vmemLoad.getSaddr();
+  if (auto ldsLoad = dyn_cast<VMEMToLDSLoadOpInterface>(op))
+    return ldsLoad.getSrd();
+  return nullptr;
+}
+
+// Get voffset operand index for setOperand.
 static unsigned getVoffsetIdx(Operation *op) {
   return isBufferLoadLDS(op) ? 0 : 1;
 }
-static unsigned getSrdIdx(Operation *op) { return isBufferLoadLDS(op) ? 1 : 0; }
 
 static bool isDefinedInLoop(Value val, Region *loopRegion) {
   if (auto *defOp = val.getDefiningOp())
@@ -201,9 +218,9 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
       continue;
     }
 
-    if (isa<V_MOV_B32>(op)) {
+    if (auto movOp = dyn_cast<V_MOV_B32>(op)) {
       for (Value r : op->getResults())
-        delta[r] = getDelta(op->getOperand(0));
+        delta[r] = getDelta(movOp.getSrc());
       continue;
     }
 
@@ -214,44 +231,45 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
       return amt;
     };
 
-    if (isa<V_ADD_U32, V_LSHL_ADD_U32>(op)) {
-      // v_add_u32(a, b) = a + b.
+    if (auto lshlAddOp = dyn_cast<V_LSHL_ADD_U32>(op)) {
       // v_lshl_add_u32(a, b, c) = (a << b) + c.
       // For lshl_add: treat as add(lshl(a, b), c) — but b must be constant
       // and IV-independent for the shift to be linear.
-      if (isa<V_LSHL_ADD_U32>(op)) {
-        int64_t dSrc = getDelta(op->getOperand(0));
-        int64_t dShift = getDelta(op->getOperand(1));
-        int64_t dAdd = getDelta(op->getOperand(2));
-        if (dShift != 0)
-          return std::nullopt;
-        auto shiftAmt = validShift(getConstantValue(op->getOperand(1)));
-        if (!shiftAmt)
-          return std::nullopt;
-        for (Value r : op->getResults())
-          delta[r] = (dSrc << *shiftAmt) + dAdd;
-      } else {
-        int64_t d = getDelta(op->getOperand(0)) + getDelta(op->getOperand(1));
-        for (Value r : op->getResults())
-          delta[r] = d;
-      }
+      int64_t dSrc = getDelta(lshlAddOp.getSrc0());
+      int64_t dShift = getDelta(lshlAddOp.getSrc1());
+      int64_t dAdd = getDelta(lshlAddOp.getSrc2());
+      if (dShift != 0)
+        return std::nullopt;
+      auto shiftAmt = validShift(getConstantValue(lshlAddOp.getSrc1()));
+      if (!shiftAmt)
+        return std::nullopt;
+      for (Value r : op->getResults())
+        delta[r] = (dSrc << *shiftAmt) + dAdd;
       continue;
     }
 
-    if (isa<V_SUB_U32>(op)) {
-      int64_t d = getDelta(op->getOperand(0)) - getDelta(op->getOperand(1));
+    if (auto addOp = dyn_cast<V_ADD_U32>(op)) {
+      // v_add_u32(a, b) = a + b.
+      int64_t d = getDelta(addOp.getSrc0()) + getDelta(addOp.getSrc1());
       for (Value r : op->getResults())
         delta[r] = d;
       continue;
     }
 
-    if (isa<V_LSHLREV_B32>(op)) {
+    if (auto subOp = dyn_cast<V_SUB_U32>(op)) {
+      int64_t d = getDelta(subOp.getSrc0()) - getDelta(subOp.getSrc1());
+      for (Value r : op->getResults())
+        delta[r] = d;
+      continue;
+    }
+
+    if (auto lshlrevOp = dyn_cast<V_LSHLREV_B32>(op)) {
       // lshlrev(amt, src) = src << amt.
-      int64_t dAmt = getDelta(op->getOperand(0));
-      int64_t dSrc = getDelta(op->getOperand(1));
+      int64_t dAmt = getDelta(lshlrevOp.getSrc0());
+      int64_t dSrc = getDelta(lshlrevOp.getSrc1());
       if (dAmt != 0)
         return std::nullopt;
-      auto shiftAmt = validShift(getConstantValue(op->getOperand(0)));
+      auto shiftAmt = validShift(getConstantValue(lshlrevOp.getSrc0()));
       if (!shiftAmt)
         return std::nullopt;
       for (Value r : op->getResults())
@@ -259,16 +277,16 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
       continue;
     }
 
-    if (isa<V_LSHL_OR_B32>(op)) {
+    if (auto lshlOrOp = dyn_cast<V_LSHL_OR_B32>(op)) {
       // lshl_or(src, amt, or_val) = (src << amt) | or_val.
       // In address computation, OR always has disjoint bits (packed fields),
       // so delta = (dSrc << amt) + dOr — same as lshl_add.
-      int64_t dSrc = getDelta(op->getOperand(0));
-      int64_t dShift = getDelta(op->getOperand(1));
-      int64_t dOr = getDelta(op->getOperand(2));
+      int64_t dSrc = getDelta(lshlOrOp.getSrc0());
+      int64_t dShift = getDelta(lshlOrOp.getSrc1());
+      int64_t dOr = getDelta(lshlOrOp.getSrc2());
       if (dShift != 0)
         return std::nullopt;
-      auto shiftAmt = validShift(getConstantValue(op->getOperand(1)));
+      auto shiftAmt = validShift(getConstantValue(lshlOrOp.getSrc1()));
       if (!shiftAmt)
         return std::nullopt;
       for (Value r : op->getResults())
@@ -276,10 +294,10 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
       continue;
     }
 
-    if (isa<V_MUL_LO_U32>(op)) {
+    if (auto mulOp = dyn_cast<V_MUL_LO_U32>(op)) {
       // Linear only if exactly one operand depends on IV.
-      int64_t d0 = getDelta(op->getOperand(0));
-      int64_t d1 = getDelta(op->getOperand(1));
+      int64_t d0 = getDelta(mulOp.getSrc0());
+      int64_t d1 = getDelta(mulOp.getSrc1());
       if (d0 != 0 && d1 != 0)
         return std::nullopt;
       if (d0 == 0 && d1 == 0) {
@@ -288,7 +306,7 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
         continue;
       }
       // One is IV-dependent, the other must be a known constant.
-      Value constOperand = d0 == 0 ? op->getOperand(0) : op->getOperand(1);
+      Value constOperand = d0 == 0 ? mulOp.getSrc0() : mulOp.getSrc1();
       int64_t dVar = d0 != 0 ? d0 : d1;
       auto constVal = getConstantValue(constOperand);
       if (!constVal)
@@ -298,16 +316,16 @@ computeStaticStride(const llvm::SetVector<Operation *> &deps, Value voffset,
       continue;
     }
 
-    if (isa<V_LSHRREV_B32>(op)) {
+    if (auto lshrrevOp = dyn_cast<V_LSHRREV_B32>(op)) {
       // lshrrev(amt, src) = src >> amt.
       // Safe when delta(src) is exactly divisible by 2^amt — no bits lost.
       // Example: address chain does lshl 7 then lshr 8 with IV step 2:
       //   delta(src) = 2*128 = 256, shift = 8, 256 % 256 == 0 → delta = 1.
-      int64_t dAmt = getDelta(op->getOperand(0));
-      int64_t dSrc = getDelta(op->getOperand(1));
+      int64_t dAmt = getDelta(lshrrevOp.getSrc0());
+      int64_t dSrc = getDelta(lshrrevOp.getSrc1());
       if (dAmt != 0)
         return std::nullopt;
-      auto shiftAmt = validShift(getConstantValue(op->getOperand(0)));
+      auto shiftAmt = validShift(getConstantValue(lshrrevOp.getSrc0()));
       if (!shiftAmt)
         return std::nullopt;
       int64_t divisor = int64_t(1) << *shiftAmt;
@@ -368,8 +386,10 @@ static void applyStrengthReduction(LoopOp loopOp) {
     if (op.getNumOperands() < 3)
       continue;
 
-    Value voffset = op.getOperand(getVoffsetIdx(&op));
-    Value srd = op.getOperand(getSrdIdx(&op));
+    Value voffset = getVoffset(&op);
+    Value srd = getSrd(&op);
+    if (!voffset || !srd)
+      continue;
 
     if (!isDefinedInLoop(voffset, loopRegion))
       continue;

--- a/waveasm/lib/Transforms/LinearScanPass.cpp
+++ b/waveasm/lib/Transforms/LinearScanPass.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "waveasm/Dialect/WaveASMDialect.h"
+#include "waveasm/Dialect/WaveASMInterfaces.h"
 #include "waveasm/Dialect/WaveASMOps.h"
 #include "waveasm/Dialect/WaveASMTypes.h"
 #include "waveasm/Transforms/Liveness.h"
@@ -106,13 +107,13 @@ private:
     return nullptr;
   }
 
-  /// Get the accumulator operand from an MFMA op (always operand index 2).
-  /// Returns nullptr if the operation doesn't have enough operands.
+  /// Get the accumulator operand from an MFMA op using the interface.
+  /// Returns nullptr if the operation is not an MFMA.
   Value getMFMAAccumulator(Operation *op) {
-    if (op->getNumOperands() < 3) {
-      return nullptr;
+    if (auto mfmaOp = dyn_cast<MFMAOpInterface>(op)) {
+      return mfmaOp.getAcc();
     }
-    return op->getOperand(2); // acc is the third operand
+    return nullptr;
   }
 
   LogicalResult processProgram(ProgramOp program) {
@@ -162,9 +163,9 @@ private:
         for (int64_t i = 0; i < size; ++i) {
           reservedAGPRs.insert(physIdx + i);
         }
-      } else if (op->hasTrait<OpTrait::MFMAOp>() && op->getNumResults() > 0) {
+      } else if (auto mfmaOp = dyn_cast<MFMAOpInterface>(op)) {
         // For MFMA with VGPR accumulator, tie result to accumulator
-        Value acc = getMFMAAccumulator(op);
+        Value acc = mfmaOp.getAcc();
         if (!acc) {
           op->emitError() << "MFMA operation must have at least 3 operands "
                           << "(A, B, accumulator), but found "

--- a/waveasm/lib/Transforms/Peephole.cpp
+++ b/waveasm/lib/Transforms/Peephole.cpp
@@ -711,24 +711,14 @@ struct AddNegToSubPattern : public OpRewritePattern<V_ADD_U32> {
 // 2. Uses hardware's native inline constant support
 //===----------------------------------------------------------------------===//
 
-struct MFMAZeroAccumPattern : public RewritePattern {
-  MFMAZeroAccumPattern(MLIRContext *ctx)
-      : RewritePattern(MatchAnyOpTypeTag{}, /*benefit=*/1, ctx) {}
+struct MFMAZeroAccumPattern
+    : public OpInterfaceRewritePattern<MFMAOpInterface> {
+  using OpInterfaceRewritePattern<MFMAOpInterface>::OpInterfaceRewritePattern;
 
-  LogicalResult matchAndRewrite(Operation *op,
+  LogicalResult matchAndRewrite(MFMAOpInterface mfmaOp,
                                 PatternRewriter &rewriter) const override {
-    // Check if this is an MFMA operation (has TiedOperandIndex attribute)
-    // MFMA ops have 3 operands: a, b, acc
-    if (op->getNumOperands() != 3 || op->getNumResults() != 1)
-      return failure();
-
-    // Check for MFMA ops by name pattern
-    StringRef opName = op->getName().getStringRef();
-    if (!opName.contains("mfma"))
-      return failure();
-
-    // Get the accumulator operand (operand index 2)
-    Value accum = op->getOperand(2);
+    // Get the accumulator operand using the named accessor
+    Value accum = mfmaOp.getAcc();
 
     // Check if accumulator comes from a v_mov_b32 of zero
     auto movOp = accum.getDefiningOp<V_MOV_B32>();
@@ -750,12 +740,14 @@ struct MFMAZeroAccumPattern : public RewritePattern {
       return failure();
 
     // Replace the accumulator with an inline zero constant
+    Operation *op = mfmaOp.getOperation();
     auto loc = op->getLoc();
     auto immType = rewriter.getType<ImmType>(0);
     auto zeroConst = ConstantOp::create(rewriter, loc, immType, 0);
 
-    // Update the MFMA's accumulator operand
-    op->setOperand(2, zeroConst);
+    // Update the MFMA's accumulator operand (operand index from interface)
+    rewriter.modifyOpInPlace(
+        op, [&]() { op->setOperand(mfmaOp.getTiedOperandIndex(), zeroConst); });
 
     return success();
   }


### PR DESCRIPTION
Refactor waveasm dialect to use typed OpInterfaces instead of raw getOperand(N) calls, improving code readability and type safety.

Changes:
- Convert MFMAOp from NativeOpTrait to OpInterface with typed accessors (getA, getB, getAcc, getDst, getTiedOperandIndex)
- Add VMEMLoadOpInterface, VMEMStoreOpInterface for buffer/global ops
- Add LDSLoadOpInterface, LDSStoreOpInterface for LDS operations
- Add VMEMToLDSLoadOpInterface for buffer-to-LDS loads
- Update ops (MFMAOp, VMEMLoadOp, VMEMStoreOp, LDSLoadOp, LDSStoreOp, VMEMToLDSLoadOp, VMEMAtomicOp) to implement appropriate interfaces
- Refactor AssemblyEmitter.cpp to use interface accessors for all buffer/global/LDS load/store emitters
- Refactor BufferLoadStrengthReduction.cpp to use VALU op accessors (getSrc, getSrc0, getSrc1, getSrc2) and memory interfaces
- Refactor Peephole.cpp and LinearScanPass.cpp to use MFMAOpInterface