### PR TITLE
option to disable hw transpose markings

### DIFF
--- a/wave_lang/kernel/wave/cache.py
+++ b/wave_lang/kernel/wave/cache.py
@@ -202,6 +202,7 @@ class WaveCacheManager(object):
             options.iree_preprocessing_pass_pipeline,
             options.override_mlir,
             options.optimization_level,
+            options.enable_mark_hardware_transpose_candidates,
             options.denorm_fp_math_f32,
             options.waves_per_eu,
             options.iree_launch_async,

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -492,6 +492,9 @@ def build_graph_passes(
             partial(specialize_kernel, trace, launchable.constraints, options),
             partial(gather_to_shared, trace, launchable.constraints, options),
             partial(gather_to_shared_swizzling, trace, launchable.constraints, options),
+        ]
+    if options.optimization_level and options.enable_mark_hardware_transpose_candidates:
+        graph_passes += [
             partial(
                 mark_hardware_transpose_candidates,
                 trace,

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -95,6 +95,7 @@ class WaveCompileOptions:
     scalarize_packed_math: bool = False
     coalescing_strategy_hint: CoalescingType = CoalescingType.LINEAR
     enable_swizzle: bool = True
+    enable_mark_hardware_transpose_candidates: bool = True
 
     # === Compiler options ===
     minimize_shared_allocs: bool = True


### PR DESCRIPTION
This pass breaks IR invariants yet seemingly generates numerically
correct code in the small subset of cases where it is exercised. Add an
option to disable it pending investigation in #982.

Signed-off-by: Alex Zinenko <git@ozinenko.com>