### PR TITLE
[water] use vectorized dim in read/write mask generation

### DIFF
--- a/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LowerReadWriteOps.cpp
@@ -394,7 +394,7 @@ createMemoryIndicesAndMask(ConversionPatternRewriter &rewriter,
          "NYI: only permutation mappings are currently supported");
   FailureOr<Value> mask =
       buildMask(op->getLoc(), boundsMapping, memoryShape, rewriter, hyper,
-                startIndices, elementsPerThread);
+                startIndices, elementsPerThread, *vectorizedDim);
   if (failed(mask))
     return rewriter.notifyMatchFailure(op, "couldn't build the required mask");
 

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -1196,7 +1196,7 @@ normalform.module [#wave.normal_form<full_types,index_exprs,memory_only_types,re
   func.func @lower_read_write_bounds_non_trailing_vectorized_dim(
       %mem: memref<100x64xf16, #gpu.address_space<workgroup>>)
       attributes {wave.hyperparameters = #wave.hyperparameters<{M = 100, N = 64}>} {
-    // The bound for M is M itself, which is substitued with its constant value from hyperparams.
+    // The bound for M is M itself, which is substituted with its constant value from hyperparams.
     // CHECK: %[[BOUND:.*]] = affine.apply affine_map<() -> (100)>()
     // CHECK: %[[IOTA:.*]] = vector.step : vector<4xindex>
     // CHECK: %[[START_VEC:.*]] = vector.broadcast {{.*}} : index to vector<4xindex>


### PR DESCRIPTION
Existing implementation was assuming the trailing dimension is the vectorized one, which is not always the case. The vectorized dimension is the one for which index expression step is greater than 1. We already compute that, but were not passing it into the mask generator. Do so.

Remark: it is unclear why transfer_read/write accepts a 1D mask for an nD memref, should be investigated separately.