### PR TITLE
[examples] Fix undefined function call in test_dbuf_4wave_mxfp_preshu…

### DIFF
--- a/examples/python/7.1_schedule.py
+++ b/examples/python/7.1_schedule.py
@@ -265,7 +265,7 @@ def test_dbuf_4wave_mxfp_preshuffle_b_gemm_cpp(
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm, schedule)
 
-    _run_mxfp_gemm_preshuffle_b(gemm, shape)
+    _run_mxfp_gemm_preshuffle(gemm, shape, all=True)
     print("MXFP GEMM preshuffle-B 4-wave (WaveASM backend) test passed!")
 
 


### PR DESCRIPTION
…ffle_b_gemm_cpp

`_run_mxfp_gemm_preshuffle_b` was never defined; replace with the existing `_run_mxfp_gemm_preshuffle(gemm, shape, all=True)`, consistent with the non-CPP preshuffle-B test.