### PR TITLE
[water] drop unused error message

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -1613,14 +1613,13 @@ verifyIndexElementsPerThread(Operation *op, ArrayAttr indexAttr,
 
   // The 'index' attribute is optional. For non-MMA ops (read/write), we only
   // use a single index expression, which is stored as the first (and only)
-  // dictionary inside the array attribute.
+  // dictionary inside the array attribute. Length is validated earlier (index
+  // attribute length must match the number of index expression values).
   ArrayAttr arr = dyn_cast_or_null<ArrayAttr>(indexAttr);
   if (!arr)
     return success();
-  if (!llvm::hasSingleElement(arr.getValue()))
-    return op->emitError() << "'index' attribute must contain exactly one "
-                              "dictionary for this op, got "
-                           << arr.size();
+  assert(llvm::hasSingleElement(arr.getValue()) &&
+         "index length already validated for non-MMA read/write");
   DictionaryAttr indexDict = dyn_cast<DictionaryAttr>(arr[0]);
   if (!indexDict)
     return success();

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -513,6 +513,18 @@ normalform.module [#wave.normal_form<full_types>] {
 // -----
 
 normalform.module [#wave.normal_form<full_types>] {
+  func.func @read_index_multiple_dicts(%mem: !wave.tensor<[@M] of f16, <global>>)
+  attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>} {
+    // expected-error @below {{index attribute length (2) does not match the number of index expression values (1)}}
+    %0 = wave.read %mem index [{M : <[] -> (<NULL>, 4, <NULL>)>}, {M : <[] -> (<NULL>, 4, <NULL>)>}]
+      : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
+    return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_types>] {
   func.func @elements_per_thread_mismatch(%mem: !wave.tensor<[@M] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>}  {
     // expected-error @below {{expected result vector type to have the number of elements per thread matching the attribute (4), got 42}}


### PR DESCRIPTION
verifyIndexElementsPerThread was emitting an error message, never
exercised by tests, on mismatching length of the index attribute for
read/write ops. This has been superseded by a broader verifier for all
ops, remove the error message and add a test for read op.

Signed-off-by: Alex Zinenko <git@ozinenko.com>