### PR TITLE
Fix dill serialization failure when scipy is installed

### DIFF
--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -934,8 +934,10 @@ def _trace_launchable_and_get_kernel_signature(
     grid_symbols = list(launchable.bound_scalar_symbols.keys()) + list(
         options.dynamic_symbols
     )
+    # Explicit modules list prevents sympy from auto-importing scipy,
+    # which pollutes sys.modules and breaks dill serialization later.
     options.kernel_launch_info.grid = sympy.lambdify(
-        [grid_symbols], launchable.grid_type.dims
+        [grid_symbols], launchable.grid_type.dims, modules=["math"]
     )
     options.kernel_launch_info.grid_str = lambdastr(
         [grid_symbols], launchable.grid_type.dims


### PR DESCRIPTION
sympy.lambdify auto-imports scipy when no explicit modules list is given. This pollutes sys.modules with 140 scipy submodules, and when dill later serializes the trace object graph it encounters scipy ufuncs that it cannot pickle. Pass modules=["math"] to prevent the implicit scipy import.