### PR TITLE
[water] Support IndexMapping roundtrip in MLIR <-> FX conversion

### DIFF
--- a/lit_tests/kernel/wave/mlir_to_fx.py
+++ b/lit_tests/kernel/wave/mlir_to_fx.py
@@ -368,7 +368,7 @@ def mlir_to_fx_mapping_roundtrip():
         b: Memory[N, K, M, GLOBAL_ADDRESS_SPACE, tkl.f16],
     ):
         mapping = wave.IndexMapping(
-            3, inputs={M: k, N: i, K: j}, outputs={N: i, K: j, M: k}
+            num_iterators=3, inputs={M: k, N: i, K: j}, outputs={N: i, K: j, M: k}
         )
         wave.write(wave.read(a, mapping=mapping), b)
 
@@ -381,7 +381,7 @@ def mlir_to_fx_mapping_roundtrip():
         b: Memory[N, M, K, GLOBAL_ADDRESS_SPACE, tkl.f16],
     ):
         mapping = wave.IndexMapping(
-            3, inputs={M: j, N: i, K: k}, outputs={N: i, M: j, K: k}
+            num_iterators=3, inputs={M: j, N: i, K: k}, outputs={N: i, M: j, K: k}
         )
         wave.write(wave.read(a, mapping=mapping), b)
 

--- a/wave_lang/kernel/lang/wave_types.py
+++ b/wave_lang/kernel/lang/wave_types.py
@@ -304,7 +304,7 @@ class IndexMapping:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, IndexMapping):
-            return NotImplemented
+            return False
         return (
             self.input_mapping == other.input_mapping
             and self.output_mapping == other.output_mapping

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -226,10 +226,10 @@ def _convert_mapping_attr(
     value_type: WaveTensorType,
     *,
     is_read: bool,
-) -> IndexMapping:
+) -> IndexMapping | None:
     """Reconstruct an IndexMapping from a Water MLIR permutation map attribute.
 
-    The water emitter stores the mapping as an inverse permutation affine map
+    The water emitter stores the mapping as a permutation affine map
     (memory dims -> value dims). This inverts the process: extracts the
     permutation, then rebuilds input/output mappings using dimension symbols
     from the memory and value types.
@@ -242,6 +242,8 @@ def _convert_mapping_attr(
     is not currently supported.
     """
     affine_map = mapping_attr.map
+    if affine_map is None:
+        return None
     n = affine_map.n_dims
 
     inverse_perm = []
@@ -724,8 +726,9 @@ def _handle_write_op(op: WriteOp, parse_ctx: _OpParseContext) -> None:
         type=get_custom(mem_node).type,
     )
     if mapping is not None:
-        # type was set from memory (e.g. [N,K,M]). infer_type corrects it to
-        # match indexing_dims which uses the mapping's input shape (e.g. [M,N,K]).
+        # type was set from memory shape (e.g. [N,K,M]). infer_type corrects
+        # it to the mapping's input shape (the value-to-store/register shape,
+        # e.g. [M,N,K]).
         write_op.infer_type()
     _apply_mlir_attrs_to_fx_node(write_op.fx_node, converted_attrs)
     # No mapping added because write produces no SSA results.


### PR DESCRIPTION
## Summary

- Reconstruct `IndexMapping` from the `WaveExprListAttr` permutation map on `wave.read`/`wave.write` during MLIR-to-FX import, enabling mapping roundtrip for permutation-only mappings.
- Add `IndexMapping.__eq__` to check for structural equality rather than object identity
- Add some tests for roundtripping mappings and generalize testing infrastructure a bit