### PR TITLE
optimize compile time re: piecewise, a ~5.5x speedup

### DIFF
--- a/wave_lang/kernel/_support/indexing.py
+++ b/wave_lang/kernel/_support/indexing.py
@@ -61,9 +61,14 @@ def safe_subs(
     """
     Substitute input using provided `subs` list if input is sympy object.
     Otherwise return input unchanged.
+
+    Uses Piecewise-aware substitution to avoid sympy's expensive recursive
+    boolean simplification on Piecewise nodes.
     """
-    if isinstance(input, (sympy.Basic, IndexSequence)):
-        return input.subs(subs, simultaneous=simultaneous)  # type: ignore
+    if isinstance(input, IndexSequence):
+        return input.subs(subs, simultaneous=simultaneous)
+    if isinstance(input, sympy.Basic):
+        return piecewise_aware_subs(input, subs, simultaneous=simultaneous)
 
     return input
 

--- a/wave_lang/kernel/compiler/wave_codegen/emitter.py
+++ b/wave_lang/kernel/compiler/wave_codegen/emitter.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from dataclasses import dataclass
 from os import environ
 from typing import Any, Callable, ClassVar, List, Optional, Type
+from wave_lang.support.indexing import piecewise_aware_subs
 
 import sympy
 import torch.fx as fx
@@ -605,56 +606,6 @@ _Rational = namedtuple("_Rational", ["numerator", "denominator"])
 _ApplyExpr = namedtuple("_ApplyExpr", ["expr", "args"])
 
 
-def _fast_subs(expr: sympy.Expr, subs_dict: dict) -> sympy.Expr:
-    """Substitute into expr efficiently, with caching and Piecewise-aware handling.
-
-    Avoids sympy's expensive recursive boolean simplification in
-    Piecewise._eval_subs by substituting into each (value, condition) pair
-    of a Piecewise independently.
-    """
-    if not isinstance(expr, sympy.Basic):
-        return expr
-
-    expr_syms = expr.free_symbols
-    subs_keys = set(subs_dict.keys())
-    matching = expr_syms & subs_keys
-    if not matching:
-        return expr
-
-    filtered_subs = {k: v for k, v in subs_dict.items() if k in matching}
-
-    if isinstance(expr, sympy.Piecewise):
-        result = sympy.Piecewise(
-            *[(e.subs(filtered_subs), c.subs(filtered_subs)) for e, c in expr.args]
-        )
-    elif expr.has(sympy.Piecewise):
-        result = _subs_piecewise_aware(expr, filtered_subs)
-    else:
-        result = expr.subs(filtered_subs)
-
-    return result
-
-
-def _subs_piecewise_aware(expr, subs_dict):
-    """Walk the expression tree substituting while handling Piecewise nodes
-    by substituting into each (value, condition) pair independently."""
-    if isinstance(expr, sympy.Piecewise):
-        return sympy.Piecewise(
-            *[(e.subs(subs_dict), c.subs(subs_dict)) for e, c in expr.args]
-        )
-
-    if not isinstance(expr, sympy.Basic) or expr.is_Atom:
-        if isinstance(expr, sympy.Symbol) and expr in subs_dict:
-            return subs_dict[expr]
-        return expr
-
-    if not expr.has(sympy.Piecewise):
-        return expr.subs(subs_dict)
-
-    new_args = [_subs_piecewise_aware(arg, subs_dict) for arg in expr.args]
-    return expr.func(*new_args)
-
-
 def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Value:
     use_affine_expr = _use_affine_expr
     stack: list[OpResult] = []
@@ -967,7 +918,7 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
     # Substitute in frozen vars to simplify expression.
     if not isinstance(expr, sympy.Expr):
         expr = sympy.sympify(expr)
-    expr = _fast_subs(expr, idxc.subs)
+    expr = piecewise_aware_subs(expr, idxc.subs)
 
     # Why affine, for now simply create indexing expressions.
     # This can easily be adapted to affine expressions later.

--- a/wave_lang/kernel/wave/utils/mapping_utils.py
+++ b/wave_lang/kernel/wave/utils/mapping_utils.py
@@ -12,6 +12,7 @@ from ..._support.indexing import IndexingContext
 from ...lang.wave_types import IndexMapping
 from .general_utils import infer_dim, get_fastest_index
 from .symbol_utils import IndexExpr, IndexSequence, IndexSymbol, simplify, subs_idxc
+from ....support.indexing import piecewise_aware_subs
 from ...compiler.utils import strides_from_symbolic_shape
 
 K = TypeVar("K")  # Key type
@@ -132,10 +133,10 @@ def check_is_mapping_contiguous(
     index_mapping = tuple(subs_idxc(i) for i in index_mapping)
     iters = mapping.iters
 
-    subs = [(sym, sym + int(i == len(iters) - 1)) for i, sym in enumerate(iters)]
+    subs = {sym: sym + int(i == len(iters) - 1) for i, sym in enumerate(iters)}
     diff = [
         approximate_difference(
-            index_mapping[i].subs(subs) - index_mapping[i],
+            piecewise_aware_subs(index_mapping[i], subs) - index_mapping[i],
             list(iters.keys())[-1:],
             elements_per_thread,
         )
@@ -266,13 +267,15 @@ def transform_index_on_mapping(
         index_mapping = mapping.map_output_indices(symbolic_shape)
 
     idxc = IndexingContext.current()
-    index_mapping = tuple(i.subs(idxc.subs) for i in index_mapping)
+    index_mapping = tuple(piecewise_aware_subs(i, idxc.subs) for i in index_mapping)
     iters = mapping.iters
-    subs = [
-        (sym, expr.start) for sym, expr in zip(iters.keys(), index.values())
-    ] + list(idxc.subs.items())
+    subs = dict(
+        list(zip(iters.keys(), (expr.start for expr in index.values())))
+        + list(idxc.subs.items())
+    )
     transformed_index = {
-        key: m.subs(subs) for key, m in zip(symbolic_shape, index_mapping)
+        key: piecewise_aware_subs(m, subs)
+        for key, m in zip(symbolic_shape, index_mapping)
     }
 
     return transformed_index

--- a/wave_lang/support/indexing.py
+++ b/wave_lang/support/indexing.py
@@ -16,6 +16,7 @@ __all__ = [
     "IndexSymbol",
     "index_symbol",
     "index_expr",
+    "piecewise_aware_subs",
     "MMA_ACC_SYMBOL_NAME",
     "THREAD_SYMBOL_NAMES",
     "WORKGROUP_SYMBOL_NAMES",
@@ -56,6 +57,66 @@ class _IndexSymbolExpando:
 sym = _IndexSymbolExpando()
 
 
+def _subs_piecewise_walk(expr, subs_dict):
+    if isinstance(expr, sympy.Piecewise):
+        return sympy.Piecewise(
+            *[(e.subs(subs_dict), c.subs(subs_dict)) for e, c in expr.args]
+        )
+
+    if not isinstance(expr, sympy.Basic) or expr.is_Atom:
+        if isinstance(expr, sympy.Symbol) and expr in subs_dict:
+            return subs_dict[expr]
+        return expr
+
+    if not expr.has(sympy.Piecewise):
+        return expr.subs(subs_dict)
+
+    new_args = [_subs_piecewise_walk(arg, subs_dict) for arg in expr.args]
+    return expr.func(*new_args)
+
+
+def piecewise_aware_subs(
+    expr: "IndexExpr",
+    subs_dict,
+    simultaneous: bool = False,
+) -> "IndexExpr":
+    """Substitute into expr, handling Piecewise nodes efficiently.
+
+    Avoids sympy's expensive recursive boolean simplification in
+    Piecewise._eval_subs by substituting into each (value, condition) pair of a
+    Piecewise independently.
+
+    For expressions without Piecewise, delegates to sympy's normal subs().
+
+    subs_dict can be a dict or a list of (old, new) pairs, matching sympy convention.
+    """
+    if not isinstance(expr, sympy.Basic):
+        return expr
+
+    if simultaneous:
+        return expr.subs(subs_dict, simultaneous=True)
+
+    if isinstance(subs_dict, (list, tuple)):
+        subs_dict = dict(subs_dict)
+
+    expr_syms = expr.free_symbols
+    subs_keys = set(subs_dict.keys())
+    matching = expr_syms & subs_keys
+    if not matching:
+        return expr
+
+    filtered = {k: v for k, v in subs_dict.items() if k in matching}
+
+    if isinstance(expr, sympy.Piecewise):
+        return sympy.Piecewise(
+            *[(e.subs(filtered), c.subs(filtered)) for e, c in expr.args]
+        )
+    elif expr.has(sympy.Piecewise):
+        return _subs_piecewise_walk(expr, filtered)
+    else:
+        return expr.subs(filtered)
+
+
 @dataclass
 class IndexSequence:
     start: IndexExpr | int
@@ -68,8 +129,10 @@ class IndexSequence:
         map: dict[IndexExpr, IndexExpr],
         simultaneous: bool = False,
     ) -> int | IndexExpr:
-        if isinstance(value, (sympy.Basic, IndexSequence)):
-            return value.subs(map, simultaneous=simultaneous)  # type: ignore
+        if isinstance(value, IndexSequence):
+            return value.subs(map, simultaneous=simultaneous)
+        if isinstance(value, sympy.Basic):
+            return piecewise_aware_subs(value, map, simultaneous=simultaneous)
         return value
 
     def has(self, symbol: IndexSymbol) -> bool:


### PR DESCRIPTION
This really just expands the previous commit about piecewise-aware substitution (https://github.com/iree-org/wave/pull/1039).  Previously we just used it in emitter.py, but this hoists it out and uses it more broadly, eg. in IndexSequence.subs, so now we are avoiding this big slowdown from sympy.Piecewise throughout the compiler.

Reduces time from ~149 to ~27 seconds, a ~5.5x speedup (for the dynamic shape mxfp4 kernel).