### PR TITLE
minor compile time optimizations

### DIFF
--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -107,6 +107,11 @@ def _split_index(src: IndexExpr | int) -> tuple[IndexExpr, IndexExpr]:
     # Compute thread-independent index as `orig_index - thread_dependent_index`
     # All thread symbols and dynamic should cancel-out in the result.
     diff = src - thread_dependent_index
+
+    # Fast path: if diff is zero, src has no WG symbols
+    if diff == 0:
+        return sympy.sympify(0), thread_dependent_index
+
     # Avoid sympy.simplify on Piecewise expressions — it recurses into boolean
     # condition simplification and can hang for complex dynamic-shape indices.
     # expand() handles basic polynomial cancellation and is O(fast).

--- a/wave_lang/support/indexing.py
+++ b/wave_lang/support/indexing.py
@@ -99,9 +99,12 @@ def piecewise_aware_subs(
     if isinstance(subs_dict, (list, tuple)):
         subs_dict = dict(subs_dict)
 
+    if expr.is_number:
+        return expr
+
     expr_syms = expr.free_symbols
-    subs_keys = set(subs_dict.keys())
-    matching = expr_syms & subs_keys
+    subs_keys = frozenset(subs_dict.keys())
+    matching = expr_syms.intersection(subs_keys)
     if not matching:
         return expr
 


### PR DESCRIPTION
piecewise_aware_subs:

Add is_number early return before computing free_symbols. Use frozenset and intersection() instead of set and & for the subs key matching.

_split_index:

Skip the expensive simplify/expand when the difference between the original expression and the WG-zeroed expression is already zero, meaning the expression has no workgroup symbols.