### PR TITLE
silence iree-hip warnings

### DIFF
--- a/wave_lang/kernel/wave/utils/compile_utils.py
+++ b/wave_lang/kernel/wave/utils/compile_utils.py
@@ -45,10 +45,10 @@ def compile_to_vmfb(
     ]
 
     # TODO: More targets/backends support.
-    if options.device == "hip":
-        flags.append(f"--iree-hip-target={options.target}")
+    if options.device == "hip" or options.device == "rocm":
+        flags.append(f"--iree-rocm-target={options.target}")
         if not options.drop_debug_info_before_mlir:
-            flags.append("--iree-hip-emit-debug-info")
+            flags.append("--iree-rocm-emit-debug-info")
 
     if options.mlir_print_ir_after_all:
         flags.append("--mlir-print-ir-after-all")
@@ -57,7 +57,7 @@ def compile_to_vmfb(
         # scalarize_packed_math decomposes packed math into scalar math
         # so we need to disable SLP vectorization to prevent recombinining it
         # back on LLVM level.
-        flags.append("--iree-hip-llvm-slp-vec=false")
+        flags.append("--iree-rocm-llvm-slp-vec=false")
 
     if options.iree_preprocessing_pass_pipeline:
         flags.append(

--- a/wave_lang/runtime/device.py
+++ b/wave_lang/runtime/device.py
@@ -720,7 +720,7 @@ def _create_hip_device(torch_device: torch.device, props) -> Optional[Device]:
     if device:
         gcn_arch_name = gcn_arch_name
         device.compile_target_flags = device.compile_target_flags + (
-            f"--iree-hip-target={gcn_arch_name}",
+            f"--iree-rocm-target={gcn_arch_name}",
         )
         device._recompute_target_keys()
     return device


### PR DESCRIPTION
The `--iree-hip-*` options for iree-compile have all been deprecated and replaced by `--iree-rocm-*` flags.  This replaces our uses of the old flags with the new ones, silencing warnings.