### PR TITLE
Support for BF16 output in tagged_mxfp4_gemm

### DIFF
--- a/tests/kernel/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave_gemm_mxfp_test.py
@@ -721,6 +721,7 @@ def testScaledGemmMXFP4AsymmetricSchedule(
 
     torch.testing.assert_close(torch_out, out, check_dtype=False)
 
+
 @require_e2e
 @require_cdna4
 @pytest.mark.parametrize(
@@ -767,6 +768,7 @@ def testScaledGemmMXFP4AsymmetricScheduleBF16(
     torch_out = torchScaledGemmMXFP4(x, w, x_scales, w_scales)
 
     torch.testing.assert_close(torch_out, out, check_dtype=False)
+
 
 @require_e2e
 @require_cdna4

--- a/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
+++ b/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
@@ -52,7 +52,10 @@ def get_tagged_mxfp4_gemm(
     Returns:
         (kernel_function, WaveCompileOptions)
     """
-    assert output_dtype in [tkl.f32, tkl.bf16], f"Unsupported output dtype: {output_dtype}"
+    assert output_dtype in [
+        tkl.f32,
+        tkl.bf16,
+    ], f"Unsupported output dtype: {output_dtype}"
 
     M = tkl.sym.M
     N = tkl.sym.N


### PR DESCRIPTION
- Add bf16 output support to tagged MXFP4 GEMM: allow output_dtype=bf16 in addition to f32; validated via assert
- Added testScaledGemmMXFP4AsymmetricScheduleBF16 in e2e tests with output_dtype parameter