### PR TITLE
[water] Unwrap single-element variadic reduction inputs in FX importer

### DIFF
--- a/lit_tests/kernel/wave/mlir_to_fx.py
+++ b/lit_tests/kernel/wave/mlir_to_fx.py
@@ -33,6 +33,7 @@ from wave_lang.kernel.ops.wave_ops import (
 )
 from wave_lang.kernel.wave.compile import build_graph_passes
 from wave_lang.kernel.wave.decompose_reduce_ops import decompose_reduce_ops
+from wave_lang.kernel.wave.expansion.expansion import expand_graph
 from wave_lang.kernel._support.indexing import IndexingContext
 from wave_lang.kernel._support.tracing import CapturedTrace
 
@@ -475,54 +476,30 @@ def mlir_to_fx_mapping_roundtrip():
 def mlir_to_fx_reduction_roundtrip():
     """Test MLIR roundtrip for sum and max reductions.
 
-    Stops compilation before decompose_reduce_ops so the trace still
-    contains wave.sum / wave.max_element ops.
+    Tests both reduction input representations with the same kernel:
+    - Single-input (stop_before=expand_graph): reduction arg is a
+      single node; verifies the importer unwraps single-element
+      variadic inputs back to a scalar.
+    - Variadic-input (stop_before=decompose_reduce_ops): reduction arg
+      is a list of tiled slices; verifies multi-input reductions
+      roundtrip as lists.
+
+    A single wave covers N so that the halved vector shape produces
+    dim_scaling = tile / (waves * vshape) = 128 / (1 * 64) = 2,
+    giving two reduction tiles after expansion.
     """
     constraints = [
         wave.WorkgroupConstraint(M, BLOCK_M, 0),
         wave.WorkgroupConstraint(N, BLOCK_N, 1),
         wave.WaveConstraint(M, sympy.floor(BLOCK_M / 2)),
-        wave.WaveConstraint(N, sympy.floor(BLOCK_N / 2)),
+        wave.WaveConstraint(N, BLOCK_N),
         wave.HardwareConstraint(
-            threads_per_wave=64, vector_shapes={M: BLOCK_M, N: BLOCK_N}
+            threads_per_wave=64,
+            vector_shapes={M: BLOCK_M, N: sympy.floor(BLOCK_N / 2)},
         ),
     ]
 
-    subs = {
-        BLOCK_M: 64,
-        BLOCK_N: 64,
-        M: 128,
-        N: 128,
-    }
-
-    def _assert_reduction_roundtrip(kernel, label):
-        options = WaveCompileOptions(subs=subs, compile_to_mlir=True)
-        with IndexingContext() as idxc:
-            idxc.set_subs(options.subs)
-            kernel.initialize_wave_constraints()
-            kernel.initialize_symbolic_constraints()
-            kernel.initialize_workgroup_constraints()
-            trace = kernel._trace(
-                location_capture_config=options.location_capture_config
-            )
-            graph_passes = build_graph_passes(kernel, trace, options)
-            for p in graph_passes:
-                if p.__name__ == decompose_reduce_ops.__name__:
-                    break
-                p()
-
-            mlir_text, diagnostics, _ = emitter.emit_wave_dialect(
-                trace, kernel.constraints, options
-            )
-        errors = error_diagnostics(diagnostics)
-        assert errors == [], f"[{label}] unexpected emit errors: {errors}"
-
-        fx_trace, fx_constraints, fx_options, fx_diags = emitter.mlir_to_fx(mlir_text)
-        errors = error_diagnostics(fx_diags)
-        assert errors == [], f"[{label}] unexpected import errors: {errors}"
-
-        assert_traces_equivalent(trace, fx_trace, subs=options.subs)
-        print(f"  {label}: OK")
+    subs = {BLOCK_M: 64, BLOCK_N: 128, M: 128, N: 128}
 
     @wave.wave(constraints)
     def sum_kernel(
@@ -534,8 +511,6 @@ def mlir_to_fx_reduction_roundtrip():
         res = wave.sum(res, init, dim=N)
         wave.write(res, c)
 
-    _assert_reduction_roundtrip(sum_kernel, "sum roundtrip")
-
     @wave.wave(constraints)
     def max_kernel(
         a: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
@@ -546,10 +521,19 @@ def mlir_to_fx_reduction_roundtrip():
         res = wave.max(res, init, dim=N)
         wave.write(res, c)
 
-    _assert_reduction_roundtrip(max_kernel, "max roundtrip")
+    _assert_roundtrip(sum_kernel, subs, "sum single-input", stop_before=expand_graph)
+    _assert_roundtrip(max_kernel, subs, "max single-input", stop_before=expand_graph)
+    _assert_roundtrip(
+        sum_kernel, subs, "sum variadic-input", stop_before=decompose_reduce_ops
+    )
+    _assert_roundtrip(
+        max_kernel, subs, "max variadic-input", stop_before=decompose_reduce_ops
+    )
 
-    # CHECK: sum roundtrip: OK
-    # CHECK: max roundtrip: OK
+    # CHECK: sum single-input: OK
+    # CHECK: max single-input: OK
+    # CHECK: sum variadic-input: OK
+    # CHECK: max variadic-input: OK
 
 
 # CHECK-LABEL: mlir_to_fx_binary_op_roundtrip

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -869,9 +869,13 @@ def _handle_reduction_op(
 
     converted_attrs = _convert_supported_attrs(op, ignore_attrs={"scope", "axis"})
 
+    # The MLIR op always has a variadic input list, but pre-expansion
+    # the FX graph uses a single node. Unwrap to match.
+    arg = input_nodes[0] if len(input_nodes) == 1 else input_nodes
+
     reduce_op = reduce_cls.create(
         parse_ctx.graph,
-        arg=input_nodes,
+        arg=arg,
         init=init_node,
         dim=dim,
         block=is_block,
@@ -1083,7 +1087,10 @@ def _reconstruct_expr_lambda(
     `lt`).  This ensures the reconstructed lambda produces the same sympy
     expression as the original.
     """
-    sympy_results: list[sympy.Expr | int] = expr_list_attr_to_exprs(expr_attr)
+    sympy_results: list[sympy.Basic] = [
+        r if isinstance(r, sympy.Basic) else sympy.Integer(r)
+        for r in expr_list_attr_to_exprs(expr_attr)
+    ]
 
     combinator_fn = None
     if combinator_attr is not None:
@@ -1096,9 +1103,7 @@ def _reconstruct_expr_lambda(
 
     def expr_lambda(*args):
         subs_map = {operand_syms[i]: args[i] for i in range(len(args))}
-        results = [
-            r.subs(subs_map) if isinstance(r, sympy.Basic) else r for r in sympy_results
-        ]
+        results = [r.subs(subs_map) for r in sympy_results]
         if combinator_fn is not None:
             return combinator_fn(*results)
         assert len(results) == 1, (


### PR DESCRIPTION
The Water dialect models reduction inputs as a variadic, but the FX graph uses a scalar arg for single-operand reductions (pre-expansion) and a list only after expand_graph tiles the reduction dimension. The importer produced a list since #1053, causing a representation mismatch for single-operand reductions.
Unwrap single-element input lists in _handle_reduction_op so the roundtripped FX graph matches the original. Multi-element lists are kept as-is.
The reduction roundtrip test now covers both representations - single-input and variadic-input - with the same kernel, using constraints that produce two reduction tiles after expansion. It also migrates to the shared `_assert_roundtrip` helper.

Also fixes an issue with pickling the lambda of an ApplyExpr. There was a problem with the use of `isinstance(r, sympy.Basic)` in it.