### PR TITLE
[asm] Add dynamic shapes support to C++ ASM backend

### DIFF
--- a/tests/kernel/wave/asm/test_waveasm_e2e.py
+++ b/tests/kernel/wave/asm/test_waveasm_e2e.py
@@ -48,7 +48,7 @@ import warnings
 
 import pytest
 
-from tests.kernel.common.utils import require_cdna4
+from tests.kernel.common.utils import param_bool, require_cdna4
 from wave_lang.kernel.wave.asm.waveasm_e2e import (
     WaveASMCompiler,
     capture_wave_kernel_info,
@@ -1319,6 +1319,8 @@ def _dbuf_mxfp4_helper(
     compiler,
     backend,
     dump_asm,
+    dynamic_dims=False,
+    use_buffer_ops=True,
 ):
     """Shared helper for double-buffered MXFP4 scheduled GEMM tests.
 
@@ -1349,6 +1351,8 @@ def _dbuf_mxfp4_helper(
     from wave_lang.kernel.wave.utils.mxfp_utils import (
         generate_gemm_afp4wfp4_inputs,
         torchScaledGemmMXFP4,
+        b_preshuffle,
+        e8m0_shuffle,
     )
 
     # Get tagged kernel + options (same as 7.1_schedule.py)
@@ -1359,8 +1363,9 @@ def _dbuf_mxfp4_helper(
             shape,
             block,
             wave_shape=(1, 4),
+            reorder_workgroups=not dynamic_dims,
         )
-        schedule = get_mxfp4_asymmetric_schedule()
+        schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
     else:
         gemm, options = get_tagged_mxfp4_gemm(
             shape,
@@ -1373,7 +1378,23 @@ def _dbuf_mxfp4_helper(
     options.backend = "asm"
     options.wave_runtime = True
     options.compile_to_mlir = False
+    options.use_buffer_ops = use_buffer_ops
     options = set_default_run_config(options)
+
+    import wave_lang.kernel.lang as tkl
+
+    M = tkl.sym.M
+    N = tkl.sym.N
+    m, n, k = shape
+
+    dynamic_symbols = []
+    dynamic_values = {}
+    if dynamic_dims:
+        dynamic_symbols = [M, N]
+        dynamic_values = {M: m, N: n}
+        del options.subs[M]
+        del options.subs[N]
+        options.dynamic_symbols = dynamic_symbols
 
     # Generate MXFP4 inputs and reference output
     x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
@@ -1384,7 +1405,9 @@ def _dbuf_mxfp4_helper(
     c = torch.zeros(shape[0], shape[1], dtype=torch.float32).cuda()
 
     # Capture MLIR with schedule applied
-    kernel_info = capture_wave_kernel_info(options, gemm, schedule=schedule)
+    kernel_info = capture_wave_kernel_info(
+        options, gemm, schedule=schedule, dynamic_values=dynamic_values
+    )
 
     # Verify MLIR contains scaled_mfma operation
     assert (
@@ -1424,8 +1447,10 @@ def _dbuf_mxfp4_helper(
 
     # Execute on GPU
     # Kernel signature: (a, a_scale, b, b_scale, c)
-    # For preshuffle B: transform B data and B scales to preshuffled layout
+    # For preshuffle B: transform all inputs to match kernel expectations.
+    # a_scale_preshuffle=True (default) means a_scales must also be shuffled.
     if num_waves <= 4:
+        x_scales = e8m0_shuffle(x_scales).contiguous()
         w_input = b_preshuffle(w.T.contiguous()).contiguous()
         w_scales_input = e8m0_shuffle(w_scales).contiguous()
     else:
@@ -1439,6 +1464,7 @@ def _dbuf_mxfp4_helper(
         block=block_size,
         shared_memory_bytes=lds_size,
         func_name=kernel_name,
+        dynamic_dims=[dynamic_values[s] for s in dynamic_symbols],
     )
 
     # Numerical correctness validation (same tolerance as existing MXFP4 test)
@@ -1453,25 +1479,26 @@ def _dbuf_mxfp4_helper(
     )
 
 
-@pytest.mark.xfail(
-    reason="Asymmetric schedule with wave_shape=(1,4) requires ~323 VGPRs, "
-    "exceeding the 256 hardware encoding limit. Needs LDS scale layout "
-    "fix or spilling to resolve.",
-)
-def test_dbuf_4wave_mxfp4_gemm_cpp_backend(compiler, backend, dump_asm):
+@param_bool("dynamic_dims", "dyn")
+@param_bool("use_buffer_ops", "bufops")
+def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
+    dynamic_dims, use_buffer_ops, compiler, backend, dump_asm
+):
     """End-to-end test for asymmetric MXFP4 GEMM with 4 waves.
 
-    Uses get_mxfp4_asymmetric_schedule() with wave_shape=(1,4) and
-    B direct from global (no LDS).
+    Uses get_mxfp4_asymmetric_schedule() with wave_shape=(1,4),
+    preshuffle B, and block=(128,256,256) matching 7.1_schedule.py.
     """
     _dbuf_mxfp4_helper(
         shape=(1024, 1024, 8192),
-        block=(256, 256, 256),
+        block=(128, 256, 256),
         num_waves=4,
         use_stagger=False,
         compiler=compiler,
         backend=backend,
         dump_asm=dump_asm,
+        dynamic_dims=dynamic_dims,
+        use_buffer_ops=use_buffer_ops,
     )
 
 

--- a/wave_lang/kernel/wave/asm/waveasm_e2e.py
+++ b/wave_lang/kernel/wave/asm/waveasm_e2e.py
@@ -33,7 +33,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List, Tuple
+from typing import Dict, Optional, List, Tuple
 
 import torch
 
@@ -436,7 +436,12 @@ def capture_wave_mlir(options, kernel_func) -> str:
     return mlir_text
 
 
-def capture_wave_kernel_info(options, kernel_func, schedule=None) -> CapturedKernelInfo:
+def capture_wave_kernel_info(
+    options,
+    kernel_func,
+    schedule=None,
+    dynamic_values: Optional[Dict] = None,
+) -> CapturedKernelInfo:
     """
     Capture MLIR and kernel launch info from Wave compilation.
 
@@ -447,6 +452,9 @@ def capture_wave_kernel_info(options, kernel_func, schedule=None) -> CapturedKer
         options: WaveCompileOptions
         kernel_func: Decorated wave kernel function
         schedule: Optional WaveSchedule to apply during compilation
+        dynamic_values: Optional dict mapping dynamic symbols to their concrete
+            values. Used for grid computation when symbols are not in
+            options.subs (i.e. truly dynamic shapes).
 
     Returns:
         CapturedKernelInfo with all launch information
@@ -517,13 +525,19 @@ def capture_wave_kernel_info(options, kernel_func, schedule=None) -> CapturedKer
         dynamic_syms = list(getattr(options, "dynamic_symbols", None) or [])
         grid_symbols = list(kernel_func.bound_scalar_symbols.keys()) + dynamic_syms
         grid_values = []
+        dv = dynamic_values or {}
         for sym in grid_symbols:
-            if sym not in options.subs:
+            if sym in options.subs:
+                grid_values.append(options.subs[sym])
+            elif sym in dv:
+                grid_values.append(dv[sym])
+            else:
                 raise ValueError(
-                    f"Grid symbol {sym} not found in options.subs. "
-                    f"Available: {list(options.subs.keys())}"
+                    f"Grid symbol {sym} not found in options.subs or "
+                    f"dynamic_values. "
+                    f"Available subs: {list(options.subs.keys())}, "
+                    f"dynamic_values: {list(dv.keys())}"
                 )
-            grid_values.append(options.subs[sym])
         grid = launch_info.grid(grid_values)
         grid = tuple(int(x) for x in grid)
 
@@ -617,6 +631,7 @@ def run_with_wave_runtime(
     block: Tuple[int, int, int],
     shared_memory_bytes: int = 0,
     func_name: str = "isolated_benchmark",
+    dynamic_dims: Optional[List[int]] = None,
 ):
     """
     Execute a compiled GPU binary using wave_runtime.
@@ -629,6 +644,8 @@ def run_with_wave_runtime(
         block: Block dimensions (x, y, z)
         shared_memory_bytes: Shared memory size
         func_name: Function name in the binary (default: "isolated_benchmark")
+        dynamic_dims: Optional list of concrete values for dynamic dimension
+            symbols, passed as additional kernel arguments.
     """
     import wave_runtime
 
@@ -660,11 +677,13 @@ def run_with_wave_runtime(
     kern_args = [tensor.data_ptr() for tensor in all_tensors]
     kernel_args = wave_runtime.Int64Vector(kern_args)
 
+    dyn_dims = wave_runtime.Int64Vector(dynamic_dims or [])
+
     # Prepare dynamic stride arguments
     stride_args = get_dynamic_stride_args(all_tensors)
 
     # Launch
-    wave_runtime.launch(kernel_launch_info, kernel_args, [], [], stride_args)
+    wave_runtime.launch(kernel_launch_info, kernel_args, dyn_dims, [], stride_args)
 
     # Sync
     torch.cuda.synchronize()

--- a/waveasm/include/waveasm/Dialect/WaveASMOps.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMOps.td
@@ -591,7 +591,14 @@ def WaveASM_V_LSHL_OR_B32 : VALUTernaryOp<"v_lshl_or_b32">;
 def WaveASM_V_LSHL_ADD_U32 : VALUTernaryOp<"v_lshl_add_u32">;
 
 // Conditional mask and lane operations
-def WaveASM_V_CNDMASK_B32 : VALUTernaryOp<"v_cndmask_b32">;
+// V_CNDMASK_B32 implicitly reads VCC, so it must NOT have Pure or
+// ArithmeticOp traits (which would make CSE treat two instances with
+// identical explicit operands as equivalent even when VCC differs).
+def WaveASM_V_CNDMASK_B32 : WAVEASMOp<"v_cndmask_b32", []> {
+  let arguments = (ins WaveASM_VALUSrc:$src0, WaveASM_VALUSrc:$src1, WaveASM_VALUSrc:$src2);
+  let results = (outs WaveASM_AnyVGPR:$dst);
+  let assemblyFormat = "$src0 `,` $src1 `,` $src2 attr-dict `:` type($src0) `,` type($src1) `,` type($src2) `->` type($dst)";
+}
 
 // Lane read operations (VGPR -> SGPR)
 def WaveASM_V_READLANE_B32 : WAVEASMOp<"v_readlane_b32", [Pure]> {
@@ -905,6 +912,28 @@ def WaveASM_S_MOV_B32_M0 : WAVEASMOp<"s_mov_b32_m0", [WaveASM_SpecialRegOp]> {
     - LDS/GDS indirect addressing
   }];
   let arguments = (ins WaveASM_SRegOrImm:$src);
+  let assemblyFormat = "$src attr-dict `:` type($src)";
+}
+
+def WaveASM_S_AND_SAVEEXEC_B64 : WAVEASMOp<"s_and_saveexec_b64", [WaveASM_SpecialRegOp]> {
+  let summary = "Save exec to dst, then AND exec with VCC (implicit)";
+  let description = [{
+    dst = exec; exec &= vcc.
+    VCC is read implicitly (set by a preceding V_CMP).
+    Used for conditional execution: lanes where VCC is 0 become inactive.
+    The saved exec is restored later via s_mov_b64_exec.
+  }];
+  let results = (outs WaveASM_AnySGPR:$dst);
+  let assemblyFormat = "attr-dict `->` type($dst)";
+}
+
+def WaveASM_S_MOV_B64_EXEC : WAVEASMOp<"s_mov_b64_exec", [WaveASM_SpecialRegOp]> {
+  let summary = "Restore exec from saved SGPR pair";
+  let description = [{
+    exec = src.
+    Used to restore exec after a conditional execution region.
+  }];
+  let arguments = (ins WaveASM_AnySGPR:$src);
   let assemblyFormat = "$src attr-dict `:` type($src)";
 }
 

--- a/waveasm/include/waveasm/Transforms/Passes.td
+++ b/waveasm/include/waveasm/Transforms/Passes.td
@@ -224,6 +224,29 @@ def WAVEASMScalePackElimination : Pass<"waveasm-scale-pack-elimination"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Extract Scalarization Pass
+//===----------------------------------------------------------------------===//
+
+def WAVEASMExtractScalarization
+    : Pass<"waveasm-extract-scalarization"> {
+  let summary = "Scalarize vector.extract from broadcast+dense-const patterns";
+  let description = [{
+    Pre-translation pass that rewrites
+      vector.extract[k]( index_cast?( select?( addi(broadcast(x), dense<[...]>) )))
+    into scalar operations: arith.addi %x, dense[k], with an optional scalar
+    arith.select if the original chain included one.
+
+    This eliminates non-splat dense vector constants before the WaveASM
+    translator runs, so translation handlers only see ordinary scalar IR.
+  }];
+
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::vector::VectorDialect"
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // Memory Offset Optimization Pass
 //===----------------------------------------------------------------------===//
 

--- a/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -341,8 +341,17 @@ public:
     int64_t srdBaseIndex; // SGPR index for SRD (e.g., 8 for s[8:11])
   };
 
+  /// Information about a pending scalar kernel argument load (index, i32, etc.)
+  struct PendingScalarArg {
+    mlir::Value blockArg; // The MLIR block argument
+    int64_t argIndex;     // Position in function signature
+  };
+
   /// Queue an SRD setup for a binding
   void queueSRDSetup(mlir::Value memref, int64_t argIndex, int64_t bufferSize);
+
+  /// Queue a scalar argument load from the kernarg buffer
+  void queueScalarArgLoad(mlir::Value blockArg, int64_t argIndex);
 
   /// Emit all pending SRD setup instructions (called at start of kernel body)
   void emitSRDPrologue();
@@ -398,8 +407,10 @@ public:
   /// Update buffer size for a pending SRD (called when we see reinterpret_cast)
   void updateSRDBufferSize(mlir::Value memref, int64_t bufferSize);
 
-  /// Get the number of kernel arguments (based on pending SRD count)
-  size_t getNumKernelArgs() const { return pendingSRDs.size(); }
+  /// Get the number of kernel arguments (bindings + scalar args)
+  size_t getNumKernelArgs() const {
+    return pendingSRDs.size() + pendingScalarArgs.size();
+  }
 
   //===--------------------------------------------------------------------===//
   // Split Vector Result Tracking
@@ -512,6 +523,30 @@ public:
   /// Check if a memref has a tracked LDS base offset
   bool hasLDSBaseOffset(mlir::Value memref) const {
     return ldsBaseOffsetMap.contains(memref);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Dynamic Stride Tracking (for memref.reinterpret_cast with runtime strides)
+  //===--------------------------------------------------------------------===//
+
+  /// Store a dynamic (runtime) stride value for a memref dimension.
+  /// \p strideValue is the mapped WaveASM SSA value holding the element stride.
+  void setDynamicStride(mlir::Value memref, unsigned dim,
+                        mlir::Value strideValue) {
+    dynamicStrideMap[memref][dim] = strideValue;
+  }
+
+  /// Get the dynamic stride value for a memref dimension.
+  /// Returns nullopt if the stride is static.
+  std::optional<mlir::Value> getDynamicStride(mlir::Value memref,
+                                              unsigned dim) const {
+    auto it = dynamicStrideMap.find(memref);
+    if (it == dynamicStrideMap.end())
+      return std::nullopt;
+    auto dimIt = it->second.find(dim);
+    if (dimIt == it->second.end())
+      return std::nullopt;
+    return dimIt->second;
   }
 
   /// Track a pending per-workgroup SRD base adjustment for a linearized memref
@@ -690,6 +725,9 @@ private:
 
   llvm::DenseMap<mlir::Value, PendingSRDBaseAdjust> pendingSRDBaseAdjustMap;
   llvm::SmallVector<PendingSRD, 4> pendingSRDs;
+  llvm::SmallVector<PendingScalarArg, 2> pendingScalarArgs;
+  llvm::DenseMap<mlir::Value, llvm::DenseMap<unsigned, mlir::Value>>
+      dynamicStrideMap;
   llvm::StringMap<mlir::Value> exprCache;
   int64_t nextSRDIndex =
       -1; // Will be computed lazily, starts after user+system SGPRs
@@ -739,7 +777,8 @@ struct VOffsetResult {
 VOffsetResult computeVOffsetFromIndices(mlir::MemRefType memrefType,
                                         mlir::ValueRange indices,
                                         TranslationContext &ctx,
-                                        mlir::Location loc);
+                                        mlir::Location loc,
+                                        mlir::Value base = nullptr);
 
 /// Emit inline SRD base adjustment for per-workgroup buffer addressing.
 /// Allocates a new SRD (5 SGPRs: base pair, hi/lo temporaries, offset temp),

--- a/waveasm/lib/Transforms/AssemblyEmitter.cpp
+++ b/waveasm/lib/Transforms/AssemblyEmitter.cpp
@@ -471,6 +471,18 @@ std::optional<std::string> KernelGenerator::generateOp(Operation *op) {
         return result;
       })
 
+      .Case<S_AND_SAVEEXEC_B64>(
+          [&](S_AND_SAVEEXEC_B64 saveOp) -> std::optional<std::string> {
+            std::string dst = resolveValue(saveOp.getDst());
+            return "  s_and_saveexec_b64 " + dst + ", vcc";
+          })
+
+      .Case<S_MOV_B64_EXEC>(
+          [&](S_MOV_B64_EXEC restoreOp) -> std::optional<std::string> {
+            std::string src = resolveValue(restoreOp.getSrc());
+            return "  s_mov_b64 exec, " + src;
+          })
+
       .Case<S_BRANCH>([&](S_BRANCH branchOp) {
         return std::string("  s_branch ") +
                branchOp.getTarget().getRootReference().str();

--- a/waveasm/lib/Transforms/CMakeLists.txt
+++ b/waveasm/lib/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_dialect_library(MLIRWaveASMTransforms
   TranslateFromMLIR.cpp
   RegionBuilder.cpp
   ScopedCSE.cpp
+  ExtractScalarization.cpp
   Peephole.cpp
   M0RedundancyElimination.cpp
   MemoryOffsetOptimization.cpp

--- a/waveasm/lib/Transforms/ExtractScalarization.cpp
+++ b/waveasm/lib/Transforms/ExtractScalarization.cpp
@@ -1,0 +1,287 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// Extract Scalarization Pass
+//
+// Pre-translation pass that rewrites vector.extract[k] from
+//   arith.addi(vector.broadcast(%x), dense<[...]>)
+// (optionally wrapped in arith.index_cast / arith.select) into scalar
+// operations so that downstream translation handlers only see ordinary
+// scalar IR.
+//
+// This eliminates the need for special-case lane-index reasoning in
+// the translator's arith.addi handler.
+//===----------------------------------------------------------------------===//
+
+#include "waveasm/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/DebugLog.h"
+
+#define DEBUG_TYPE "waveasm-extract-scalarization"
+
+namespace waveasm {
+#define GEN_PASS_DEF_WAVEASMEXTRACTSCALARIZATION
+#include "waveasm/Transforms/Passes.h.inc"
+} // namespace waveasm
+
+using namespace mlir;
+
+namespace {
+
+/// Read element `index` from a DenseElementsAttr with integer elements,
+/// returning its value as int64_t.
+static std::optional<int64_t> getIntElement(DenseElementsAttr dense,
+                                            int64_t index) {
+  auto vecType = dyn_cast<VectorType>(dense.getType());
+  if (!vecType || index < 0 || index >= vecType.getNumElements())
+    return std::nullopt;
+  auto values = dense.getValues<APInt>();
+  return (*(values.begin() + index)).getSExtValue();
+}
+
+/// Peel through an optional arith.index_cast, returning the cast input
+/// and recording whether we peeled.
+static Value peelIndexCast(Value v, bool &peeled) {
+  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>()) {
+    peeled = true;
+    return castOp.getIn();
+  }
+  peeled = false;
+  return v;
+}
+
+/// Peel through an optional arith.select, returning both branches and
+/// the condition.  Returns failure if `v` is not a select.
+static LogicalResult peelSelect(Value v, Value &cond, Value &trueVal,
+                                Value &falseVal) {
+  if (auto selOp = v.getDefiningOp<arith::SelectOp>()) {
+    cond = selOp.getCondition();
+    trueVal = selOp.getTrueValue();
+    falseVal = selOp.getFalseValue();
+    return success();
+  }
+  return failure();
+}
+
+/// Try to match and scalarize:
+///   vector.extract[k] (
+///     index_cast? (
+///       select?(
+///         arith.addi(vector.broadcast(%x), dense<[...]>)
+///       )
+///     )
+///   )
+/// Returns the scalar replacement value, or nullptr on failure.
+static Value tryScalarize(vector::ExtractOp extractOp, OpBuilder &rewriter) {
+  auto staticPos = extractOp.getStaticPosition();
+  if (staticPos.size() != 1 || staticPos[0] == ShapedType::kDynamic)
+    return nullptr;
+  int64_t k = staticPos[0];
+
+  Value src = extractOp.getSource();
+  Location loc = extractOp.getLoc();
+
+  // Peel optional index_cast wrapping the extract source.
+  bool hadOuterIndexCast = false;
+  Value preIndexCast = peelIndexCast(src, hadOuterIndexCast);
+
+  // Try select path: extract[k]( index_cast?( select(cond, T, F) ) )
+  Value cond, selTrue, selFalse;
+  if (succeeded(peelSelect(preIndexCast, cond, selTrue, selFalse))) {
+    // Peel optional index_cast inside select branches.
+    bool trueHadCast = false, falseHadCast = false;
+    Value trueInner = peelIndexCast(selTrue, trueHadCast);
+    Value falseInner = peelIndexCast(selFalse, falseHadCast);
+
+    // Try to scalarize the true branch (addi(broadcast, dense)).
+    auto scalarizeBranch = [&](Value inner) -> Value {
+      auto addOp = inner.getDefiningOp<arith::AddIOp>();
+      if (!addOp)
+        return nullptr;
+
+      Value broadcastSide = nullptr;
+      DenseElementsAttr dense;
+
+      for (int swap = 0; swap < 2; ++swap) {
+        Value lhs = swap ? addOp.getRhs() : addOp.getLhs();
+        Value rhs = swap ? addOp.getLhs() : addOp.getRhs();
+
+        auto bcast = lhs.getDefiningOp<vector::BroadcastOp>();
+        auto constOp = rhs.getDefiningOp<arith::ConstantOp>();
+        if (bcast && constOp) {
+          auto d = dyn_cast<DenseElementsAttr>(constOp.getValue());
+          if (d && !d.isSplat()) {
+            broadcastSide = bcast.getSource();
+            dense = d;
+            break;
+          }
+        }
+      }
+      if (!broadcastSide)
+        return nullptr;
+
+      auto elemVal = getIntElement(dense, k);
+      if (!elemVal)
+        return nullptr;
+
+      Type scalarType = broadcastSide.getType();
+      Value elemConst = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(scalarType, *elemVal));
+      return arith::AddIOp::create(rewriter, loc, scalarType, broadcastSide,
+                                   elemConst);
+    };
+
+    Value scalarTrue = scalarizeBranch(trueInner);
+    if (!scalarTrue)
+      return nullptr;
+
+    // The false branch can be either another addi(broadcast, dense) or
+    // a splat dense constant.
+    Value scalarFalse = scalarizeBranch(falseInner);
+    if (!scalarFalse) {
+      // Try to extract element k from a splat dense constant.
+      auto constOp = falseInner.getDefiningOp<arith::ConstantOp>();
+      if (!constOp)
+        return nullptr;
+      auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue());
+      if (!denseAttr)
+        return nullptr;
+      auto elemVal = getIntElement(denseAttr, k);
+      if (!elemVal)
+        return nullptr;
+      Type scalarType = scalarTrue.getType();
+      scalarFalse = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(scalarType, *elemVal));
+    }
+
+    // The original select condition may be vector<Nxi1> (e.g. from a
+    // broadcast of a scalar i1).  Scalarize it for the new scalar select.
+    Value scalarCond = cond;
+    if (isa<VectorType>(cond.getType())) {
+      if (auto bcast = cond.getDefiningOp<vector::BroadcastOp>()) {
+        scalarCond = bcast.getSource();
+      } else {
+        scalarCond = vector::ExtractOp::create(rewriter, loc, cond, k);
+      }
+    }
+
+    return arith::SelectOp::create(rewriter, loc, scalarCond, scalarTrue,
+                                   scalarFalse);
+  }
+
+  // Non-select path: extract[k]( index_cast?( addi(broadcast, dense) ) )
+  auto addOp = preIndexCast.getDefiningOp<arith::AddIOp>();
+  if (!addOp)
+    return nullptr;
+
+  Value broadcastSide = nullptr;
+  DenseElementsAttr dense;
+
+  for (int swap = 0; swap < 2; ++swap) {
+    Value lhs = swap ? addOp.getRhs() : addOp.getLhs();
+    Value rhs = swap ? addOp.getLhs() : addOp.getRhs();
+
+    auto bcast = lhs.getDefiningOp<vector::BroadcastOp>();
+    auto constOp = rhs.getDefiningOp<arith::ConstantOp>();
+    if (bcast && constOp) {
+      auto d = dyn_cast<DenseElementsAttr>(constOp.getValue());
+      if (d && !d.isSplat()) {
+        broadcastSide = bcast.getSource();
+        dense = d;
+        break;
+      }
+    }
+  }
+  if (!broadcastSide)
+    return nullptr;
+
+  auto elemVal = getIntElement(dense, k);
+  if (!elemVal)
+    return nullptr;
+
+  Type scalarType = broadcastSide.getType();
+  Value elemConst = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getIntegerAttr(scalarType, *elemVal));
+  return arith::AddIOp::create(rewriter, loc, scalarType, broadcastSide,
+                               elemConst);
+}
+
+struct ExtractScalarizationPass
+    : public waveasm::impl::WAVEASMExtractScalarizationBase<
+          ExtractScalarizationPass> {
+  using WAVEASMExtractScalarizationBase::WAVEASMExtractScalarizationBase;
+
+  void runOnOperation() override {
+    IRRewriter rewriter(&getContext());
+    SmallVector<vector::ExtractOp> candidates;
+
+    getOperation()->walk(
+        [&](vector::ExtractOp op) { candidates.push_back(op); });
+
+    for (auto op : candidates) {
+      rewriter.setInsertionPoint(op);
+      Value scalar = tryScalarize(op, rewriter);
+      if (!scalar)
+        continue;
+
+      Type resultType = op.getResult().getType();
+      if (scalar.getType() != resultType) {
+        scalar = arith::IndexCastOp::create(rewriter, op.getLoc(), resultType,
+                                            scalar);
+      }
+
+      rewriter.replaceOp(op, scalar);
+    }
+
+    // Erase vector ops that became dead after the rewrites above.
+    // Only target vector-typed ops and dense vector constants -- never
+    // erase scalar arith.constant or other scalar ops that may be
+    // used elsewhere.
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      SmallVector<Operation *> deadOps;
+      getOperation()->walk([&](Operation *op) {
+        if (!op->use_empty())
+          return;
+        if (isDeadVectorOp(op))
+          deadOps.push_back(op);
+      });
+      for (auto *op : llvm::reverse(deadOps)) {
+        if (op->use_empty()) {
+          rewriter.eraseOp(op);
+          changed = true;
+        }
+      }
+    }
+  }
+
+private:
+  static bool isDeadVectorOp(Operation *op) {
+    if (isa<vector::BroadcastOp, vector::ExtractOp>(op))
+      return true;
+    // Vector-typed arith ops (addi, index_cast, select on vectors).
+    if (op->getNumResults() == 1 &&
+        isa<VectorType>(op->getResult(0).getType()) &&
+        isa<arith::AddIOp, arith::IndexCastOp, arith::SelectOp>(op))
+      return true;
+    // Dense vector constants.
+    if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
+      if (isa<VectorType>(constOp.getResult().getType()))
+        return true;
+    }
+    return false;
+  }
+};
+
+} // namespace

--- a/waveasm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/waveasm/lib/Transforms/TranslateFromMLIR.cpp
@@ -143,8 +143,15 @@ void TranslationContext::queueSRDSetup(Value memref, int64_t argIndex,
   setSRDIndex(memref, srdBase);
 }
 
+void TranslationContext::queueScalarArgLoad(Value blockArg, int64_t argIndex) {
+  PendingScalarArg pending;
+  pending.blockArg = blockArg;
+  pending.argIndex = argIndex;
+  pendingScalarArgs.push_back(pending);
+}
+
 void TranslationContext::emitSRDPrologue() {
-  if (srdPrologueEmitted || pendingSRDs.empty())
+  if (srdPrologueEmitted || (pendingSRDs.empty() && pendingScalarArgs.empty()))
     return;
 
   srdPrologueEmitted = true;
@@ -158,7 +165,8 @@ void TranslationContext::emitSRDPrologue() {
   // SRDs must start after: user SGPRs + system SGPRs (workgroup IDs)
   int64_t userSgprCount = 2; // kernarg ptr
   if (isGFX95) {
-    userSgprCount += pendingSRDs.size() * 2; // preloaded args
+    userSgprCount +=
+        getNumKernelArgs() * 2; // preloaded args (bindings + scalars)
   }
   int64_t systemSgprCount = 3; // workgroup_id_x, y, z
   int64_t srdStartIndex =
@@ -200,6 +208,14 @@ void TranslationContext::emitSRDPrologue() {
                                  /*size=*/2);
       }
     }
+    for (const auto &pending : pendingScalarArgs) {
+      int64_t preloadBase = 2 + pending.argIndex * 2;
+      if (reservedPreloadBases.insert(preloadBase).second) {
+        auto preloadType = createSRegType(2, 2);
+        PrecoloredSRegOp::create(builder, loc, preloadType, preloadBase,
+                                 /*size=*/2);
+      }
+    }
   }
 
   if (isGFX95) {
@@ -213,6 +229,19 @@ void TranslationContext::emitSRDPrologue() {
         PrecoloredSRegOp::create(builder, loc, kernargSRegType, 0, 2);
 
     for (const auto &pending : pendingSRDs) {
+      int64_t loadBase = 2 + pending.argIndex * 2;
+      int64_t kernargOffset = pending.argIndex * 8;
+
+      auto loadDstType = createSRegType(2, loadBase);
+      auto offsetImm = builder.getType<ImmType>(kernargOffset);
+      auto offsetConst =
+          ConstantOp::create(builder, loc, offsetImm, kernargOffset);
+      S_LOAD_DWORDX2::create(builder, loc, TypeRange{loadDstType}, kernargBase,
+                             offsetConst);
+    }
+
+    // Also load scalar kernel arguments (index types) from kernarg buffer
+    for (const auto &pending : pendingScalarArgs) {
       int64_t loadBase = 2 + pending.argIndex * 2;
       int64_t kernargOffset = pending.argIndex * 8;
 
@@ -269,6 +298,19 @@ void TranslationContext::emitSRDPrologue() {
 
       mapper.mapValue(pending.memref, srdReg);
     }
+
+    // Move scalar args from preload SGPRs to VGPRs.
+    // Lower 32 bits of the preload pair hold the value (little-endian).
+    for (const auto &pending : pendingScalarArgs) {
+      int64_t preloadBase = 2 + pending.argIndex * 2;
+      auto vregType = createVRegType();
+      auto vreg =
+          PrecoloredVRegOp::create(builder, loc, vregType, pending.argIndex, 1);
+      RawOp::create(builder, loc,
+                    "v_mov_b32 v" + std::to_string(pending.argIndex) + ", s" +
+                        std::to_string(preloadBase));
+      mapper.mapValue(pending.blockArg, vreg);
+    }
   } else {
     // Non-GFX95* path (e.g., gfx942): Load directly into SRD positions
     // This eliminates the s_mov_b64 copies by loading args directly into the
@@ -292,6 +334,27 @@ void TranslationContext::emitSRDPrologue() {
           ConstantOp::create(builder, loc, offsetImm, kernargOffset);
       S_LOAD_DWORDX2::create(builder, loc, TypeRange{loadDstType}, kernargBase,
                              offsetConst);
+    }
+
+    // Load scalar kernel arguments (index types) into pinned SGPRs after
+    // all SRDs.  Must use RawOp + PrecoloredSRegOp so the register
+    // allocator does not move the load destinations away from the SGPRs
+    // that the subsequent RawOp v_mov_b32 references.
+    int64_t scalarSgprBase =
+        (srdStartIndex + (int64_t)pendingSRDs.size() * 4 + 3) &
+        ~3; // Align to 4, after all SRDs
+    for (size_t i = 0; i < pendingScalarArgs.size(); ++i) {
+      const auto &pending = pendingScalarArgs[i];
+      int64_t sgprIdx = scalarSgprBase + (int64_t)i;
+      int64_t kernargOffset = pending.argIndex * 8;
+
+      // Pin the destination SGPR so regalloc doesn't reuse it.
+      PrecoloredSRegOp::create(builder, loc, createSRegType(1, 1), sgprIdx, 1);
+
+      // Use RawOp to load directly into the pinned SGPR.
+      RawOp::create(builder, loc,
+                    "s_load_dword s" + std::to_string(sgprIdx) + ", s[0:1], " +
+                        std::to_string(kernargOffset));
     }
 
     // Step 2: Wait for all scalar loads to complete
@@ -319,6 +382,20 @@ void TranslationContext::emitSRDPrologue() {
       RawOp::create(builder, loc, movStrideStr);
 
       mapper.mapValue(pending.memref, srdReg);
+    }
+
+    // Move scalar args from SGPRs to VGPRs
+    for (size_t i = 0; i < pendingScalarArgs.size(); ++i) {
+      const auto &pending = pendingScalarArgs[i];
+      int64_t sgprIdx = scalarSgprBase + (int64_t)i;
+
+      auto vregType = createVRegType();
+      auto vreg =
+          PrecoloredVRegOp::create(builder, loc, vregType, pending.argIndex, 1);
+      RawOp::create(builder, loc,
+                    "v_mov_b32 v" + std::to_string(pending.argIndex) + ", s" +
+                        std::to_string(sgprIdx));
+      mapper.mapValue(pending.blockArg, vreg);
     }
   }
 
@@ -362,7 +439,8 @@ void TranslationContext::updateSRDBufferSize(Value memref, int64_t bufferSize) {
 
 VOffsetResult computeVOffsetFromIndices(MemRefType memrefType,
                                         ValueRange indices,
-                                        TranslationContext &ctx, Location loc) {
+                                        TranslationContext &ctx, Location loc,
+                                        Value base) {
   auto &builder = ctx.getBuilder();
   Type elementType = memrefType.getElementType();
   int64_t elementBytes = (elementType.getIntOrFloatBitWidth() + 7) / 8;
@@ -378,6 +456,36 @@ VOffsetResult computeVOffsetFromIndices(MemRefType memrefType,
       if (!idxMapped)
         continue;
       Value idx = *idxMapped;
+
+      // Handle dynamic strides: look up the runtime stride value from
+      // the reinterpret_cast that created this memref.
+      if (strides[i] == ShapedType::kDynamic && base) {
+        auto dynStride = ctx.getDynamicStride(base, i);
+        if (dynStride) {
+          // dimOffset = idx * (runtimeStride * elementBytes)
+          // First: compute runtimeStride * elementBytes if elementBytes > 1
+          Value bytesPerElement;
+          if (elementBytes > 1) {
+            auto elemBytesImm = ConstantOp::create(
+                builder, loc, ctx.createImmType(elementBytes), elementBytes);
+            bytesPerElement = V_MUL_LO_U32::create(
+                builder, loc, ctx.createVRegType(), *dynStride, elemBytesImm);
+          } else {
+            bytesPerElement = *dynStride;
+          }
+          // dimOffset = idx * bytesPerElement
+          Value dimOffset = V_MUL_LO_U32::create(
+              builder, loc, ctx.createVRegType(), idx, bytesPerElement);
+          if (!voffset) {
+            voffset = dimOffset;
+          } else {
+            voffset = V_ADD_U32::create(builder, loc, ctx.createVRegType(),
+                                        voffset, dimOffset);
+          }
+          continue;
+        }
+      }
+
       int64_t strideBytes = strides[i] * elementBytes;
       if (strideBytes == 0)
         continue;
@@ -1014,14 +1122,11 @@ LogicalResult handleVectorLoad(Operation *op, TranslationContext &ctx) {
     ctx.getMapper().mapValue(loadOp.getResult(), readOp->getResult(0));
   } else {
     // Global load - buffer_load_dwordx* with splitting for large vectors
-    auto [voffset, instOffset] =
-        computeVOffsetFromIndices(memrefType, loadOp.getIndices(), ctx, loc);
+    auto [voffset, instOffset] = computeVOffsetFromIndices(
+        memrefType, loadOp.getIndices(), ctx, loc, loadOp.getBase());
 
     Value srd;
 
-    // Check for pending per-workgroup SRD base adjustment (from linearized
-    // reinterpret_cast when use_buffer_ops=True). Create an adjusted SRD
-    // with the workgroup offset baked into the base address.
     if (auto *adj = ctx.getPendingSRDBaseAdjust(loadOp.getBase())) {
       srd = emitSRDBaseAdjustment(*adj, loadOp.getBase(), ctx, loc);
     } else {
@@ -1042,40 +1147,71 @@ LogicalResult handleVectorLoad(Operation *op, TranslationContext &ctx) {
   return success();
 }
 
-/// Handle vector.maskedload - emit buffer_load unconditionally.
-///
-/// NOTE: The mask and passthrough operands are intentionally ignored.
-/// In the split-K GEMM context, masked loads are generated with all-true
-/// masks (the SRD is configured with correct buffer bounds, so out-of-bounds
-/// lanes return zero via hardware). If this assumption is violated, the
-/// loaded values for masked-off lanes will be incorrect.
+/// Emit exec masking: save exec, AND with VCC derived from mask VGPR.
+/// Returns the saved-exec SSA value for later restoration.
+static Value emitExecMask(Value maskVgpr, TranslationContext &ctx,
+                          OpBuilder &builder, Location loc) {
+  auto immZero = ctx.createImmType(0);
+  auto zeroConst = ConstantOp::create(builder, loc, immZero, 0);
+  V_CMP_NE_U32::create(builder, loc, maskVgpr, zeroConst);
+  auto sregType64 = ctx.createSRegType(2, 2);
+  return S_AND_SAVEEXEC_B64::create(builder, loc, sregType64);
+}
+
+/// Restore exec from saved value.
+static void emitExecRestore(Value savedExec, TranslationContext &ctx,
+                            OpBuilder &builder, Location loc) {
+  S_MOV_B64_EXEC::create(builder, loc, savedExec);
+}
+
+/// Handle vector.maskedload with exec masking.
+/// Pre-fills the result register with the passthrough value, then exec-masks
+/// the buffer_load so only active lanes overwrite their result.
 LogicalResult handleVectorMaskedLoad(Operation *op, TranslationContext &ctx) {
   auto maskedLoadOp = cast<vector::MaskedLoadOp>(op);
+  auto &builder = ctx.getBuilder();
   auto loc = op->getLoc();
 
   auto memrefType = cast<MemRefType>(maskedLoadOp.getBase().getType());
   auto vectorType = maskedLoadOp.getVectorType();
   int64_t numBytes = getVectorBytes(vectorType);
 
-  if (numBytes <= 0) {
-    return op->emitError(
-        "vector.maskedload with zero-size vector type is invalid");
+  if (numBytes <= 0)
+    return op->emitError("vector.maskedload with zero-size vector is invalid");
+
+  // Pre-fill result with passthrough value so inactive lanes get the right data
+  auto passthrough = ctx.getMapper().getMapped(maskedLoadOp.getPassThru());
+  Value resultReg;
+  if (passthrough) {
+    resultReg = *passthrough;
+  } else {
+    auto immZero = ctx.createImmType(0);
+    resultReg = ConstantOp::create(builder, loc, immZero, 0);
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "vector.maskedload: mask and passthrough "
-                             "operands are ignored (assuming all-true mask)\n");
+  // Get mask VGPR (the mask is broadcast from a scalar i1 comparison)
+  auto mask = ctx.getMapper().getMapped(maskedLoadOp.getMask());
+  if (!mask)
+    return op->emitError("mask operand not mapped");
 
+  // Save exec and apply mask
+  Value savedExec = emitExecMask(*mask, ctx, builder, loc);
+
+  // Emit buffer_load (only active lanes execute)
   auto [voffset, instOffset] = computeVOffsetFromIndices(
-      memrefType, maskedLoadOp.getIndices(), ctx, loc);
+      memrefType, maskedLoadOp.getIndices(), ctx, loc, maskedLoadOp.getBase());
   Value srd = lookupSRD(maskedLoadOp.getBase(), ctx, loc);
   auto loadResults =
       emitBufferLoads(srd, voffset, instOffset, numBytes, ctx, loc);
 
+  // Restore exec
+  emitExecRestore(savedExec, ctx, builder, loc);
+
+  // Map result
   if (!loadResults.empty()) {
     ctx.getMapper().mapValue(maskedLoadOp.getResult(), loadResults[0]);
-    if (loadResults.size() > 1) {
+    if (loadResults.size() > 1)
       ctx.registerSplitResults(maskedLoadOp.getResult(), loadResults);
-    }
   }
 
   return success();
@@ -1312,6 +1448,32 @@ LogicalResult handleVectorStore(Operation *op, TranslationContext &ctx) {
           continue;
 
         Value idx = *idxMapped;
+
+        // Handle dynamic strides from reinterpret_cast
+        if (strides[i] == ShapedType::kDynamic) {
+          auto dynStride = ctx.getDynamicStride(storeOp.getBase(), i);
+          if (dynStride) {
+            Value bytesPerElement;
+            if (elementBytes > 1) {
+              auto elemBytesImm = ConstantOp::create(
+                  builder, loc, ctx.createImmType(elementBytes), elementBytes);
+              bytesPerElement = V_MUL_LO_U32::create(
+                  builder, loc, ctx.createVRegType(), *dynStride, elemBytesImm);
+            } else {
+              bytesPerElement = *dynStride;
+            }
+            Value dimOffset = V_MUL_LO_U32::create(
+                builder, loc, ctx.createVRegType(), idx, bytesPerElement);
+            if (!voffset) {
+              voffset = dimOffset;
+            } else {
+              voffset = V_ADD_U32::create(builder, loc, ctx.createVRegType(),
+                                          voffset, dimOffset);
+            }
+            continue;
+          }
+        }
+
         int64_t strideBytes = strides[i] * elementBytes;
 
         if (strideBytes == 0)
@@ -1469,6 +1631,109 @@ LogicalResult handleVectorStore(Operation *op, TranslationContext &ctx) {
       splitIndex++;
     }
   }
+
+  return success();
+}
+
+/// Handle vector.maskedstore with exec masking.
+/// Sets exec to mask lanes before the buffer_store so inactive lanes
+/// do not write to memory, then restores exec.
+LogicalResult handleVectorMaskedStore(Operation *op, TranslationContext &ctx) {
+  auto maskedStoreOp = cast<vector::MaskedStoreOp>(op);
+  auto &builder = ctx.getBuilder();
+  auto loc = op->getLoc();
+
+  auto memrefType = cast<MemRefType>(maskedStoreOp.getBase().getType());
+  Type elementType = memrefType.getElementType();
+
+  auto data = ctx.getMapper().getMapped(maskedStoreOp.getValueToStore());
+  if (!data)
+    return op->emitError("maskedstore data value not mapped");
+
+  auto vectorType = maskedStoreOp.getValueToStore().getType();
+  auto vecType = dyn_cast<VectorType>(vectorType);
+  int64_t numBytes = vecType ? getVectorBytes(vecType)
+                             : (vectorType.getIntOrFloatBitWidth() + 7) / 8;
+
+  if (isLDSMemRef(memrefType))
+    return op->emitError("maskedstore to LDS not yet supported");
+
+  // Get mask VGPR
+  auto mask = ctx.getMapper().getMapped(maskedStoreOp.getMask());
+  if (!mask)
+    return op->emitError("mask operand not mapped");
+
+  // Save exec and apply mask
+  Value savedExec = emitExecMask(*mask, ctx, builder, loc);
+
+  // Compute address (same as handleVectorStore global path)
+  auto [voffset, instOffset] =
+      computeVOffsetFromIndices(memrefType, maskedStoreOp.getIndices(), ctx,
+                                loc, maskedStoreOp.getBase());
+
+  Value srd;
+  if (auto *adj = ctx.getPendingSRDBaseAdjust(maskedStoreOp.getBase())) {
+    srd = emitSRDBaseAdjustment(*adj, maskedStoreOp.getBase(), ctx, loc);
+  } else {
+    srd = lookupSRD(maskedStoreOp.getBase(), ctx, loc);
+  }
+
+  auto splitResults = ctx.getSplitResults(maskedStoreOp.getValueToStore());
+
+  if (vecType && elementType.isBF16() && data.has_value()) {
+    int64_t numElems = vecType.getNumElements();
+    auto [converted, newNumBytes] =
+        convertF32ToBF16ForStore(*data, numElems, ctx, builder, loc);
+    data = converted;
+    numBytes = newNumBytes;
+  }
+
+  // Emit buffer_store (only active lanes execute)
+  int64_t bytesRemaining = numBytes;
+  int64_t currentOffset = instOffset;
+  size_t splitIndex = 0;
+
+  while (bytesRemaining > 0) {
+    int64_t storeBytes = (bytesRemaining >= 16)  ? 16
+                         : (bytesRemaining >= 8) ? 8
+                         : (bytesRemaining >= 4) ? 4
+                         : (bytesRemaining >= 2) ? 2
+                                                 : 1;
+
+    Value storeData = *data;
+    if (!splitResults.empty() && splitIndex < splitResults.size())
+      storeData = splitResults[splitIndex];
+
+    if (isAGPRType(storeData.getType())) {
+      int64_t storeDwords = (storeBytes + 3) / 4;
+      auto vregType =
+          ctx.createVRegType(storeDwords, storeDwords > 1 ? storeDwords : 1);
+      storeData = V_ACCVGPR_READ_B32::create(builder, loc, vregType, storeData);
+    }
+
+    if (storeBytes >= 16)
+      BUFFER_STORE_DWORDX4::create(builder, loc, storeData, srd, voffset,
+                                   currentOffset);
+    else if (storeBytes >= 8)
+      BUFFER_STORE_DWORDX2::create(builder, loc, storeData, srd, voffset,
+                                   currentOffset);
+    else if (storeBytes >= 4)
+      BUFFER_STORE_DWORD::create(builder, loc, storeData, srd, voffset,
+                                 currentOffset);
+    else if (storeBytes == 2)
+      BUFFER_STORE_SHORT::create(builder, loc, storeData, srd, voffset,
+                                 currentOffset);
+    else
+      BUFFER_STORE_BYTE::create(builder, loc, storeData, srd, voffset,
+                                currentOffset);
+
+    bytesRemaining -= storeBytes;
+    currentOffset += storeBytes;
+    splitIndex++;
+  }
+
+  // Restore exec
+  emitExecRestore(savedExec, ctx, builder, loc);
 
   return success();
 }
@@ -1657,6 +1922,7 @@ void OpHandlerRegistry::registerDefaultHandlers(mlir::MLIRContext *ctx) {
   REGISTER_HANDLER(vector::LoadOp, handleVectorLoad);
   REGISTER_HANDLER(vector::MaskedLoadOp, handleVectorMaskedLoad);
   REGISTER_HANDLER(vector::StoreOp, handleVectorStore);
+  REGISTER_HANDLER(vector::MaskedStoreOp, handleVectorMaskedStore);
   REGISTER_HANDLER(vector::ExtractStridedSliceOp,
                    handleVectorExtractStridedSlice);
   REGISTER_HANDLER(vector::BroadcastOp, handleVectorBroadcast);
@@ -1765,8 +2031,11 @@ LogicalResult translateModule(ModuleOp module, StringRef targetId) {
         // Queue SRD setup for this binding
         int64_t bufferSize = computeBufferSizeFromMemRef(memrefType);
         ctx.queueSRDSetup(arg, argIdx, bufferSize);
+      } else if (arg.getType().isIndex() || arg.getType().isInteger()) {
+        // Scalar kernel arg (index, i32, i64) - load from kernarg buffer
+        ctx.queueScalarArgLoad(arg, argIdx);
       } else {
-        // Non-memref args (i32, index, etc.) - map to VGPR
+        // Other args (stream.binding, etc.) - placeholder VGPR
         auto vregType = ctx.createVRegType();
         auto vreg = PrecoloredVRegOp::create(builder, gpuFunc.getLoc(),
                                              vregType, argIdx, 1);
@@ -1863,8 +2132,11 @@ LogicalResult translateModule(ModuleOp module, StringRef targetId) {
         // Queue SRD setup for this binding
         int64_t bufferSize = computeBufferSizeFromMemRef(memrefType);
         ctx.queueSRDSetup(arg, argIdx, bufferSize);
+      } else if (arg.getType().isIndex() || arg.getType().isInteger()) {
+        // Scalar kernel arg (index, i32, i64) - load from kernarg buffer
+        ctx.queueScalarArgLoad(arg, argIdx);
       } else {
-        // Non-memref args (i32, index, etc.) - map to VGPR
+        // Other args (stream.binding, etc.) - placeholder VGPR
         auto vregType = ctx.createVRegType();
         auto vreg = PrecoloredVRegOp::create(builder, funcOp.getLoc(), vregType,
                                              argIdx, 1);
@@ -2047,6 +2319,8 @@ LogicalResult translateModule(ModuleOp module,
       if (auto memrefType = dyn_cast<MemRefType>(arg.getType())) {
         int64_t bufferSize = computeBufferSizeFromMemRef(memrefType);
         transCtx.queueSRDSetup(arg, argIdx, bufferSize);
+      } else if (arg.getType().isIndex() || arg.getType().isInteger()) {
+        transCtx.queueScalarArgLoad(arg, argIdx);
       } else {
         auto vregType = transCtx.createVRegType();
         auto vreg = PrecoloredVRegOp::create(builder, funcOp.getLoc(), vregType,

--- a/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
@@ -435,8 +435,10 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
                     std::to_string(newSrdBase + 1) + ", 0x40400000";
   RawOp::create(builder, loc, or1);
 
+  // Use 0xFFFFFFFF for num_records to prevent OOB faults from dynamic
+  // bounds-check sentinel addresses (0x7FFFFFFF) used in gather_to_lds.
   std::string mov2 =
-      "s_mov_b32 s" + std::to_string(newSrdBase + 2) + ", 0x7ffffffd";
+      "s_mov_b32 s" + std::to_string(newSrdBase + 2) + ", 0xFFFFFFFF";
   RawOp::create(builder, loc, mov2);
 
   std::string mov3 =
@@ -1065,8 +1067,8 @@ LogicalResult handleMemRefAtomicRMW(Operation *op, TranslationContext &ctx) {
         "unsupported atomic_rmw kind; only addf/addi supported");
   }
 
-  auto [voffset, instOffset] =
-      computeVOffsetFromIndices(memrefType, atomicOp.getIndices(), ctx, loc);
+  auto [voffset, instOffset] = computeVOffsetFromIndices(
+      memrefType, atomicOp.getIndices(), ctx, loc, atomicOp.getMemref());
   Value srd = lookupSRD(atomicOp.getMemref(), ctx, loc);
 
   if (elementType.isBF16()) {

--- a/waveasm/lib/Transforms/handlers/AffineHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/AffineHandlers.cpp
@@ -26,12 +26,39 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
+#include "llvm/Support/Debug.h"
 
 #include <functional>
+
+#define DEBUG_TYPE "waveasm-affine-handlers"
 
 using namespace mlir;
 
 namespace waveasm {
+
+// Returns floordiv(x, d) = floor(cvt_f32(x) * rcp(cvt_f32(d))) with
+// off-by-one correction. Valid for x, d < 2^23 (float precision limit).
+static Value emitUnsignedFloordiv(Value x, Value d, OpBuilder &builder,
+                                  Location loc, TranslationContext &ctx) {
+  auto vregType = ctx.createVRegType();
+  Value xf = V_CVT_F32_U32::create(builder, loc, vregType, x);
+  Value df = V_CVT_F32_U32::create(builder, loc, vregType, d);
+  Value rcpD = V_RCP_F32::create(builder, loc, vregType, df);
+  Value qf = V_MUL_F32::create(builder, loc, vregType, xf, rcpD);
+  Value qfFloor = V_FLOOR_F32::create(builder, loc, vregType, qf);
+  Value q = V_CVT_U32_F32::create(builder, loc, vregType, qfFloor);
+  Value qd = V_MUL_LO_U32::create(builder, loc, vregType, q, d);
+  Value rem = V_SUB_U32::create(builder, loc, vregType, x, qd);
+  V_CMP_GE_U32::create(builder, loc, rem, d);
+  auto oneImm = ctx.createImmType(1);
+  auto oneConst = ConstantOp::create(builder, loc, oneImm, 1);
+  Value oneVgpr = V_MOV_B32::create(builder, loc, vregType, oneConst);
+  auto zeroImm = ctx.createImmType(0);
+  auto zeroConst = ConstantOp::create(builder, loc, zeroImm, 0);
+  Value inc = V_CNDMASK_B32::create(builder, loc, vregType, zeroConst, oneVgpr,
+                                    zeroConst);
+  return V_ADD_U32::create(builder, loc, vregType, q, inc);
+}
 
 /// Handle affine.apply - compile affine expression to arithmetic instructions
 LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
@@ -146,11 +173,13 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
       if (dimExpr.getPosition() < applyOp.getOperands().size()) {
         Value operand = applyOp.getOperands()[dimExpr.getPosition()];
         if (auto mapped = ctx.getMapper().getMapped(operand)) {
-          // Use tracked bit range if available
           BitRange range = ctx.getBitRange(*mapped);
           return ExprResult(*mapped, range);
         }
       }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "WARNING: affine dim d" << dimExpr.getPosition()
+                 << " not mapped, falling back to baseValue\n");
       return ExprResult(baseValue, ctx.getBitRange(baseValue));
     }
 
@@ -164,6 +193,9 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
           return ExprResult(*mapped, range);
         }
       }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "WARNING: affine symbol s" << symExpr.getPosition()
+                 << " (idx=" << symIdx << ") not mapped, falling back\n");
       return ExprResult(baseValue, ctx.getBitRange(baseValue));
     }
 
@@ -379,26 +411,23 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
                 ConstantOp::create(builder, loc, shiftAmt, shiftAmount);
             Value shiftResult =
                 V_LSHRREV_B32::create(builder, loc, vregType, shiftConst, lhs);
-            // Shift the bit range right by shiftAmount
             BitRange resultRange = lhsRange.shiftRight(shiftAmount);
             ctx.setBitRange(shiftResult, resultRange);
             return ExprResult(shiftResult, resultRange);
           }
         }
-        // General floordiv - needs more complex handling
-        return ExprResult(lhs, BitRange()); // Conservative
+        // Symbolic divisor fallback: floordiv(x, d) via float reciprocal
+        // with off-by-one correction.
+        {
+          Value qFixed = emitUnsignedFloordiv(lhs, rhs, builder, loc, ctx);
+          return ExprResult(qFixed, BitRange());
+        }
       }
 
       case AffineExprKind::CeilDiv: {
         if (auto constRhs = dyn_cast<AffineConstantExpr>(binExpr.getRHS())) {
           int64_t divisor = constRhs.getValue();
 
-          // Optimization: ceildiv(x, 2^k) = (x + 2^k - 1) >> k.
-          // Only valid for non-negative x because V_LSHRREV_B32 is a logical
-          // (unsigned) right shift. Negative values would produce a large
-          // positive result instead of the correct negative ceiling.
-          // Affine expressions in this context originate from index
-          // computations which are non-negative by construction.
           if (isPowerOf2(divisor)) {
             int64_t shiftAmount = log2(divisor);
             int64_t bias = divisor - 1;
@@ -418,7 +447,17 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
             return ExprResult(shiftResult, resultRange);
           }
         }
-        return ExprResult(lhs, BitRange());
+        // Symbolic divisor fallback: ceildiv(x, d) = floordiv(x + d - 1, d)
+        {
+          auto oneImm = ctx.createImmType(1);
+          auto oneConst = ConstantOp::create(builder, loc, oneImm, 1);
+          Value dMinus1 =
+              V_SUB_U32::create(builder, loc, vregType, rhs, oneConst);
+          Value biased =
+              V_ADD_U32::create(builder, loc, vregType, lhs, dMinus1);
+          Value qFixed = emitUnsignedFloordiv(biased, rhs, builder, loc, ctx);
+          return ExprResult(qFixed, BitRange());
+        }
       }
 
       case AffineExprKind::Mod: {
@@ -430,14 +469,18 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
             auto maskConst = ConstantOp::create(builder, loc, maskVal, val - 1);
             Value andResult =
                 V_AND_B32::create(builder, loc, vregType, lhs, maskConst);
-            // Result uses bits 0..(log2(val)-1)
             BitRange resultRange = BitRange(0, log2(val) - 1);
             ctx.setBitRange(andResult, resultRange);
             return ExprResult(andResult, resultRange);
           }
         }
-        // General mod - needs more complex handling
-        return ExprResult(lhs, BitRange()); // Conservative
+        // Symbolic divisor fallback: x mod d = x - floordiv(x, d) * d
+        {
+          Value q = emitUnsignedFloordiv(lhs, rhs, builder, loc, ctx);
+          Value qd = V_MUL_LO_U32::create(builder, loc, vregType, q, rhs);
+          Value rem = V_SUB_U32::create(builder, loc, vregType, lhs, qd);
+          return ExprResult(rem, BitRange());
+        }
       }
 
       default:
@@ -446,7 +489,10 @@ LogicalResult handleAffineApply(Operation *op, TranslationContext &ctx) {
       }
     }
 
-    return ExprResult(baseValue, BitRange()); // Fallback
+    LLVM_DEBUG(llvm::dbgs() << "WARNING: unhandled affine expression kind "
+                            << static_cast<int>(e.getKind())
+                            << ", falling back to baseValue\n");
+    return ExprResult(baseValue, BitRange());
   };
 
   ExprResult result = compileExpr(exprToCompile);

--- a/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
@@ -16,6 +16,7 @@
 #include "Handlers.h"
 
 #include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Dialect/WaveASMTypes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -26,6 +27,22 @@
 using namespace mlir;
 
 namespace waveasm {
+
+// Materializes VCC (set by a preceding V_CMP) into a VGPR holding 0 or 1.
+// V_CNDMASK_B32 implicitly reads VCC; the op definition lacks Pure/ArithmeticOp
+// traits so CSE will never merge distinct instances.
+static Value materializeVCCToBoolVGPR(OpBuilder &builder, Location loc,
+                                      TranslationContext &ctx) {
+  auto vregType = ctx.createVRegType();
+  auto immZero = ctx.createImmType(0);
+  auto zeroConst = ConstantOp::create(builder, loc, immZero, 0);
+  auto immOne = ctx.createImmType(1);
+  auto oneConst = ConstantOp::create(builder, loc, immOne, 1);
+  Value oneVgpr = V_MOV_B32::create(builder, loc, vregType, oneConst);
+  Value boolVgpr = V_CNDMASK_B32::create(builder, loc, vregType, zeroConst,
+                                         oneVgpr, zeroConst);
+  return boolVgpr;
+}
 
 //===----------------------------------------------------------------------===//
 // Constant Handler
@@ -60,17 +77,26 @@ LogicalResult handleArithConstant(Operation *op, TranslationContext &ctx) {
     return success();
   }
 
-  // Handle dense vector constants (e.g., dense<0.0> for accumulator init)
+  // Handle dense vector constants.
+  // The C++ backend is SIMT: each thread processes one vector element.
+  // For splat constants, map to the scalar value.
+  // Non-splat dense vectors are left unmapped and must be handled by a
+  // consumer that can prove a sound scalarization.
   if (auto denseAttr = dyn_cast<DenseElementsAttr>(value)) {
     if (denseAttr.isSplat()) {
       auto splatVal = denseAttr.getSplatValue<Attribute>();
       if (auto floatAttr = dyn_cast<FloatAttr>(splatVal)) {
         double floatVal = floatAttr.getValueAsDouble();
-        if (floatVal == 0.0) {
-          auto immType = ctx.createImmType(0);
-          auto immOp = ConstantOp::create(builder, loc, immType, 0);
-          ctx.getMapper().mapValue(constOp.getResult(), immOp);
-        }
+        float f = static_cast<float>(floatVal);
+        int32_t bits = (floatVal == 0.0) ? 0 : bitCast<int32_t>(f);
+        auto immType = ctx.createImmType(bits);
+        auto immOp = ConstantOp::create(builder, loc, immType, bits);
+        ctx.getMapper().mapValue(constOp.getResult(), immOp);
+      } else if (auto intAttr = dyn_cast<IntegerAttr>(splatVal)) {
+        int64_t intVal = intAttr.getInt();
+        auto immType = ctx.createImmType(intVal);
+        auto immOp = ConstantOp::create(builder, loc, immType, intVal);
+        ctx.getMapper().mapValue(constOp.getResult(), immOp);
       }
     }
     return success();
@@ -302,8 +328,60 @@ LogicalResult handleArithCmpI(Operation *op, TranslationContext &ctx) {
     return failure();
   }
 
-  // Emit comparison based on predicate
-  // These operations set VCC implicitly (no SSA result)
+  // When both operands are scalar (SGPR or immediate), use S_CMP which
+  // produces an SGPR result directly.  This is required for scf.if/scf.for
+  // conditions that feed waveasm.if/waveasm.condition (which require SGPRs).
+  bool lhsScalar = isSGPRType(lhs->getType()) || isImmType(lhs->getType());
+  bool rhsScalar = isSGPRType(rhs->getType()) || isImmType(rhs->getType());
+
+  if (lhsScalar && rhsScalar) {
+    auto sregType = ctx.createSRegType();
+    // S_CMP requires SGPR operands; move immediates to SGPRs first.
+    Value lhsOp = *lhs;
+    Value rhsOp = *rhs;
+    if (isImmType(lhsOp.getType()))
+      lhsOp = S_MOV_B32::create(builder, loc, sregType, lhsOp);
+    if (isImmType(rhsOp.getType()))
+      rhsOp = S_MOV_B32::create(builder, loc, sregType, rhsOp);
+    Value result;
+    switch (cmpOp.getPredicate()) {
+    case arith::CmpIPredicate::eq:
+      result = S_CMP_EQ_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::ne:
+      result = S_CMP_NE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::slt:
+      result = S_CMP_LT_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::sle:
+      result = S_CMP_LE_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::sgt:
+      result = S_CMP_GT_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::sge:
+      result = S_CMP_GE_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::ult:
+      result = S_CMP_LT_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::ule:
+      result = S_CMP_LE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::ugt:
+      result = S_CMP_GT_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    case arith::CmpIPredicate::uge:
+      result = S_CMP_GE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      break;
+    }
+    ctx.getMapper().mapValue(cmpOp.getResult(), result);
+    return success();
+  }
+
+  // Vector path: at least one operand is a VGPR, so use V_CMP which writes
+  // to VCC implicitly.
   switch (cmpOp.getPredicate()) {
   case arith::CmpIPredicate::eq:
     V_CMP_EQ_U32::create(builder, loc, *lhs, *rhs);
@@ -337,10 +415,8 @@ LogicalResult handleArithCmpI(Operation *op, TranslationContext &ctx) {
     break;
   }
 
-  // Map result to a placeholder (the select handler will use VCC implicitly)
-  auto immOne = ctx.createImmType(1);
-  auto one = ConstantOp::create(builder, loc, immOne, 1);
-  ctx.getMapper().mapValue(cmpOp.getResult(), one);
+  Value boolVgpr = materializeVCCToBoolVGPR(builder, loc, ctx);
+  ctx.getMapper().mapValue(cmpOp.getResult(), boolVgpr);
   return success();
 }
 
@@ -357,6 +433,11 @@ LogicalResult handleArithSelect(Operation *op, TranslationContext &ctx) {
   if (!cond || !trueVal || !falseVal) {
     return op->emitError("operands not mapped");
   }
+
+  // Restore the materialized boolean VGPR (0/1) back into VCC
+  auto immZero = ctx.createImmType(0);
+  auto zeroConst = ConstantOp::create(builder, loc, immZero, 0);
+  V_CMP_NE_U32::create(builder, loc, *cond, zeroConst);
 
   auto result =
       V_CNDMASK_B32::create(builder, loc, vregType, *falseVal, *trueVal, *cond);
@@ -425,10 +506,8 @@ LogicalResult handleArithCmpF(Operation *op, TranslationContext &ctx) {
     break;
   }
 
-  // Map result to a placeholder (the select handler will use VCC implicitly)
-  auto immOne = ctx.createImmType(1);
-  auto one = ConstantOp::create(builder, loc, immOne, 1);
-  ctx.getMapper().mapValue(cmpOp.getResult(), one);
+  Value boolVgpr = materializeVCCToBoolVGPR(builder, loc, ctx);
+  ctx.getMapper().mapValue(cmpOp.getResult(), boolVgpr);
   return success();
 }
 

--- a/waveasm/lib/Transforms/handlers/HandlerUtils.cpp
+++ b/waveasm/lib/Transforms/handlers/HandlerUtils.cpp
@@ -62,16 +62,11 @@ int64_t getElementBytes(Type type) {
 //===----------------------------------------------------------------------===//
 
 int64_t computeBufferSizeFromMemRef(MemRefType memrefType) {
-  int64_t numElements = 1;
-  for (int64_t dim : memrefType.getShape()) {
-    if (dim == ShapedType::kDynamic)
-      dim = 1; // Conservative estimate for dynamic dims
-    numElements *= dim;
-  }
-  int64_t elementBytes = memrefType.getElementTypeBitWidth() / 8;
-  if (elementBytes == 0)
-    elementBytes = 1; // Minimum 1 byte
-  return numElements * elementBytes;
+  // Always use max SRD num_records. All bounds checking is handled in
+  // software (arith.select sentinel addresses, exec masking, or static
+  // guarantees), so hardware bounds checking via SRD is not needed.
+  (void)memrefType;
+  return 0xFFFFFFFF;
 }
 
 //===----------------------------------------------------------------------===//

--- a/waveasm/lib/Transforms/handlers/MemRefHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/MemRefHandlers.cpp
@@ -173,6 +173,27 @@ LogicalResult handleMemRefReinterpretCast(Operation *op,
     ctx.updateSRDBufferSize(castOp.getSource(), bufferSize);
   }
 
+  // Track dynamic strides so load/store handlers can compute correct offsets.
+  // Dynamic stride operands fill positions where static_strides == kDynamic.
+  if (auto memrefType = dyn_cast<MemRefType>(castOp.getResult().getType())) {
+    SmallVector<int64_t, 4> staticStrides;
+    int64_t memrefOff;
+    if (succeeded(memrefType.getStridesAndOffset(staticStrides, memrefOff))) {
+      auto dynamicStrides = castOp.getStrides();
+      unsigned dynIdx = 0;
+      for (unsigned dim = 0; dim < staticStrides.size(); ++dim) {
+        if (staticStrides[dim] == ShapedType::kDynamic &&
+            dynIdx < dynamicStrides.size()) {
+          auto mapped = ctx.getMapper().getMapped(dynamicStrides[dynIdx]);
+          if (mapped) {
+            ctx.setDynamicStride(castOp.getResult(), dim, *mapped);
+          }
+          ++dynIdx;
+        }
+      }
+    }
+  }
+
   return success();
 }
 
@@ -286,19 +307,34 @@ LogicalResult handleMemRefStore(Operation *op, TranslationContext &ctx) {
   return success();
 }
 
-/// Handle memref.cast - pass through source and propagate pending SRD
-/// adjustment so that cast chains (reinterpret_cast -> cast -> cast ->
-/// fat_raw_buffer_cast) do not silently lose the per-workgroup offset.
+/// Handle memref.cast - pass through source and propagate metadata.
+/// memref.cast only changes the static type (e.g. erasing dynamic info);
+/// it does not change the underlying buffer, so all runtime metadata
+/// (dynamic strides, SRD adjustments, LDS offsets) must be forwarded.
 LogicalResult handleMemRefCast(Operation *op, TranslationContext &ctx) {
   auto castOp = cast<memref::CastOp>(op);
 
   if (auto src = ctx.getMapper().getMapped(castOp.getSource())) {
     ctx.getMapper().mapValue(castOp.getResult(), *src);
   }
+
+  // Propagate dynamic strides through cast chains.
+  auto sourceType = cast<MemRefType>(castOp.getSource().getType());
+  for (unsigned dim = 0; dim < (unsigned)sourceType.getRank(); ++dim) {
+    if (auto dynStride = ctx.getDynamicStride(castOp.getSource(), dim)) {
+      ctx.setDynamicStride(castOp.getResult(), dim, *dynStride);
+    }
+  }
+
   if (auto *adj = ctx.getPendingSRDBaseAdjust(castOp.getSource())) {
     ctx.setPendingSRDBaseAdjust(castOp.getResult(), adj->elementOffset,
                                 adj->srcSrdBase, adj->elementBytes);
   }
+
+  if (auto ldsOffset = ctx.getLDSBaseOffset(castOp.getSource())) {
+    ctx.setLDSBaseOffset(castOp.getResult(), *ldsOffset);
+  }
+
   return success();
 }
 

--- a/waveasm/test/Transforms/extract-scalarization.mlir
+++ b/waveasm/test/Transforms/extract-scalarization.mlir
@@ -1,0 +1,92 @@
+// RUN: waveasm-translate --waveasm-extract-scalarization %s | FileCheck %s
+//
+// Test: extract scalarization pre-translation pass.
+// Note: without a follow-up canonicalization, dead vector ops and
+// trivial addi(x, 0) remain but are harmless.
+
+module {
+  gpu.module @test_extract_scalarization {
+
+    // ---------------------------------------------------------------
+    // Positive: extract[0] from addi(broadcast(x), iota)
+    // iota[0] == 0, so the scalar result is addi(x, 0).
+    // ---------------------------------------------------------------
+    // CHECK-LABEL: func @extract_zero
+    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK: %[[ADD:.*]] = arith.addi %arg0, %[[C0]] : i32
+    // CHECK: return %[[ADD]]
+    func.func @extract_zero(%x: i32) -> i32 {
+      %bcast = vector.broadcast %x : i32 to vector<4xi32>
+      %iota = arith.constant dense<[0, 1, 2, 3]> : vector<4xi32>
+      %sum = arith.addi %bcast, %iota : vector<4xi32>
+      %r = vector.extract %sum[0] : i32 from vector<4xi32>
+      return %r : i32
+    }
+
+    // ---------------------------------------------------------------
+    // Positive: extract[2] from addi(broadcast(x), dense<[10,11,12,13]>)
+    // ---------------------------------------------------------------
+    // CHECK-LABEL: func @extract_two
+    // CHECK: %[[C12:.*]] = arith.constant 12 : i32
+    // CHECK: %[[ADD:.*]] = arith.addi %arg0, %[[C12]] : i32
+    // CHECK: return %[[ADD]]
+    func.func @extract_two(%x: i32) -> i32 {
+      %bcast = vector.broadcast %x : i32 to vector<4xi32>
+      %offsets = arith.constant dense<[10, 11, 12, 13]> : vector<4xi32>
+      %sum = arith.addi %bcast, %offsets : vector<4xi32>
+      %r = vector.extract %sum[2] : i32 from vector<4xi32>
+      return %r : i32
+    }
+
+    // ---------------------------------------------------------------
+    // Positive: extract[0] through index_cast and select (buffer_ops pattern)
+    // ---------------------------------------------------------------
+    // CHECK-LABEL: func @extract_with_select
+    // CHECK: arith.addi %arg0,
+    // CHECK: %[[SENT:.*]] = arith.constant 2147483647 : i32
+    // CHECK: arith.select %arg1,
+    func.func @extract_with_select(%x: i32, %mask: i1) -> i32 {
+      %bcast = vector.broadcast %x : i32 to vector<4xi32>
+      %iota = arith.constant dense<[0, 1, 2, 3]> : vector<4xi32>
+      %sum = arith.addi %bcast, %iota : vector<4xi32>
+      %sum_idx = arith.index_cast %sum : vector<4xi32> to vector<4xindex>
+      %sentinel = arith.constant dense<2147483647> : vector<4xindex>
+      %sel = arith.select %mask, %sum_idx, %sentinel : vector<4xindex>
+      %lane = vector.extract %sel[0] : index from vector<4xindex>
+      %r = arith.index_cast %lane : index to i32
+      return %r : i32
+    }
+
+    // ---------------------------------------------------------------
+    // Positive: multiple extracts at different indices from same vector
+    // ---------------------------------------------------------------
+    // CHECK-LABEL: func @extract_multiple
+    // CHECK: %[[C5:.*]] = arith.constant 5 : i32
+    // CHECK: arith.addi %arg0, %[[C5]] : i32
+    // CHECK: %[[C7:.*]] = arith.constant 7 : i32
+    // CHECK: arith.addi %arg0, %[[C7]] : i32
+    func.func @extract_multiple(%x: i32) -> i32 {
+      %bcast = vector.broadcast %x : i32 to vector<4xi32>
+      %offsets = arith.constant dense<[5, 5, 7, 7]> : vector<4xi32>
+      %sum = arith.addi %bcast, %offsets : vector<4xi32>
+      %a = vector.extract %sum[0] : i32 from vector<4xi32>
+      %b = vector.extract %sum[2] : i32 from vector<4xi32>
+      %r = arith.addi %a, %b : i32
+      return %r : i32
+    }
+
+    // ---------------------------------------------------------------
+    // Negative: splat dense constant should not be rewritten
+    // ---------------------------------------------------------------
+    // CHECK-LABEL: func @no_rewrite_splat
+    // CHECK: arith.constant dense<42> : vector<4xi32>
+    // CHECK: vector.extract
+    func.func @no_rewrite_splat(%x: i32) -> i32 {
+      %bcast = vector.broadcast %x : i32 to vector<4xi32>
+      %splat = arith.constant dense<42> : vector<4xi32>
+      %sum = arith.addi %bcast, %splat : vector<4xi32>
+      %r = vector.extract %sum[0] : i32 from vector<4xi32>
+      return %r : i32
+    }
+  }
+}

--- a/waveasm/test/Translate/affine-symbolic-div.mlir
+++ b/waveasm/test/Translate/affine-symbolic-div.mlir
@@ -1,0 +1,53 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: affine.apply with symbolic (runtime) divisors for floordiv, ceildiv,
+// and mod. These use float-reciprocal-based division with off-by-one
+// correction, unlike the constant-divisor path that uses shifts.
+
+module {
+func.func @symbolic_div(
+    %binding: !stream.binding,
+    %D: index) {
+
+  %c0 = arith.constant 0 : index
+  %flat = "stream.binding.subspan"(%binding, %c0) : (!stream.binding, index) -> memref<f32>
+  %tid = gpu.thread_id x
+
+  // CHECK-LABEL: waveasm.program @symbolic_div
+
+  // --- Test 1: floordiv with symbolic divisor ---
+  // Expect: cvt_f32_u32, rcp_f32, mul_f32, floor_f32, cvt_u32_f32,
+  //         then correction: mul_lo, sub, cmp_ge, cndmask, add
+  // CHECK: waveasm.v_cvt_f32_u32
+  // CHECK: waveasm.v_rcp_f32
+  // CHECK: waveasm.v_mul_f32
+  // CHECK: waveasm.v_floor_f32
+  // CHECK: waveasm.v_cvt_u32_f32
+  // CHECK: waveasm.v_mul_lo_u32
+  // CHECK: waveasm.v_sub_u32
+  // CHECK: waveasm.v_cmp_ge_u32
+  // CHECK: waveasm.v_cndmask_b32
+  // CHECK: waveasm.v_add_u32
+  %fdiv = affine.apply affine_map<()[s0, s1] -> (s0 floordiv s1)>()[%tid, %D]
+
+  // --- Test 2: ceildiv with symbolic divisor ---
+  // Expect: bias = D - 1, then floordiv(tid + bias, D)
+  // CHECK: waveasm.v_sub_u32
+  // CHECK: waveasm.v_add_u32
+  // CHECK: waveasm.v_cvt_f32_u32
+  // CHECK: waveasm.v_rcp_f32
+  // CHECK: waveasm.v_cndmask_b32
+  %cdiv = affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%tid, %D]
+
+  // --- Test 3: mod with symbolic divisor ---
+  // Expect: floordiv(tid, D), then tid - q*D
+  // CHECK: waveasm.v_cvt_f32_u32
+  // CHECK: waveasm.v_rcp_f32
+  // CHECK: waveasm.v_cndmask_b32
+  // CHECK: waveasm.v_mul_lo_u32
+  // CHECK: waveasm.v_sub_u32
+  %mod = affine.apply affine_map<()[s0, s1] -> (s0 mod s1)>()[%tid, %D]
+
+  return
+}
+}

--- a/waveasm/test/Translate/arith-cmpi-select.mlir
+++ b/waveasm/test/Translate/arith-cmpi-select.mlir
@@ -1,0 +1,54 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: arith.cmpi with VGPR operands materializes VCC into a VGPR via
+// V_CNDMASK_B32, arith.select restores VCC before conditional move,
+// and arith.cmpf also materializes VCC into a VGPR.
+
+module {
+func.func @cmpi_select_cmpf(
+    %binding_a: !stream.binding,
+    %binding_c: !stream.binding,
+    %M: index) {
+
+  %c0 = arith.constant 0 : index
+
+  %flat_a = "stream.binding.subspan"(%binding_a, %c0) : (!stream.binding, index) -> memref<f32>
+  %flat_c = "stream.binding.subspan"(%binding_c, %c0) : (!stream.binding, index) -> memref<f32>
+
+  %a = memref.reinterpret_cast %flat_a to
+      offset: [0], sizes: [%M], strides: [1]
+      : memref<f32> to memref<?xf32, strided<[1]>>
+
+  %c_buf = memref.reinterpret_cast %flat_c to
+      offset: [0], sizes: [%M], strides: [1]
+      : memref<f32> to memref<?xf32, strided<[1]>>
+
+  %tid = gpu.thread_id x
+
+  // Load a value from memory so we have a VGPR operand for cmpf
+  %v = vector.load %a[%tid] : memref<?xf32, strided<[1]>>, vector<1xf32>
+  %vs = vector.extract %v[0] : f32 from vector<1xf32>
+
+  // --- Test 1: arith.cmpi slt with VGPR index operands ---
+  // tid and M are both VGPRs -> V_CMP + VCC materialization
+  // CHECK-LABEL: waveasm.program @cmpi_select_cmpf
+  // CHECK: waveasm.v_cmp_lt_i32
+  // CHECK: waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<1> -> !waveasm.vreg
+  // CHECK: waveasm.v_cndmask_b32
+  %cmp = arith.cmpi slt, %tid, %M : index
+
+  // --- Test 2: arith.select restores VCC from materialized bool ---
+  // CHECK: waveasm.v_cmp_ne_u32
+  // CHECK: waveasm.v_cndmask_b32
+  %cf0 = arith.constant 0.0 : f32
+  %sel = arith.select %cmp, %vs, %cf0 : f32
+
+  // --- Test 3: arith.cmpf with VGPR operands ---
+  // CHECK: waveasm.v_cmp_lt_f32
+  // CHECK: waveasm.v_mov_b32 %{{.*}} : !waveasm.imm<1> -> !waveasm.vreg
+  // CHECK: waveasm.v_cndmask_b32
+  %cmpf = arith.cmpf olt, %vs, %cf0 : f32
+
+  return
+}
+}

--- a/waveasm/test/Translate/buffer-ops-srd-adjust.mlir
+++ b/waveasm/test/Translate/buffer-ops-srd-adjust.mlir
@@ -40,14 +40,14 @@ func.func @buffer_ops_test(%arg0: memref<f16>, %arg1: memref<f32>) {
   // The load SRD should be adjusted with the workgroup offset via SALU:
   //   s_mov_b64 (copy base), v_readfirstlane_b32 (wg offset to SGPR),
   //   s_mul_i32 (byte offset), s_add_u32 + s_addc_u32 (adjust base),
-  //   s_mov_b32 (num_records = 0x7FFFFFFC, not a tiny value)
+  //   s_mov_b32 (num_records = 0xFFFFFFFF, bumped to max for sentinel safety)
   // CHECK: s_mov_b64 s[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
   // CHECK: waveasm.v_readfirstlane_b32
   // CHECK: waveasm.s_mul_hi_u32
   // CHECK: waveasm.s_mul_i32
   // CHECK: waveasm.s_add_u32
   // CHECK: waveasm.s_addc_u32
-  // CHECK: s_mov_b32 s{{[0-9]+}}, 0x7FFFFFFC
+  // CHECK: s_mov_b32 s{{[0-9]+}}, 0xFFFFFFFF
   // CHECK: s_mov_b32 s{{[0-9]+}}, 0x20000
   // CHECK: waveasm.buffer_load_dwordx2
   %loaded = vector.load %buf0[%th_offset]
@@ -71,14 +71,14 @@ func.func @buffer_ops_test(%arg0: memref<f16>, %arg1: memref<f32>) {
       : vector<4xf16> to vector<1xf16>
   %ext = arith.extf %elem : vector<1xf16> to vector<1xf32>
 
-  // The store SRD should also be adjusted, with correct num_records (0x7FFFFFF8)
+  // The store SRD should also be adjusted, with max num_records for sentinel safety
   // CHECK: s_mov_b64 s[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
   // CHECK: waveasm.v_readfirstlane_b32
   // CHECK: waveasm.s_mul_hi_u32
   // CHECK: waveasm.s_mul_i32
   // CHECK: waveasm.s_add_u32
   // CHECK: waveasm.s_addc_u32
-  // CHECK: s_mov_b32 s{{[0-9]+}}, 0x7FFFFFF8
+  // CHECK: s_mov_b32 s{{[0-9]+}}, 0xFFFFFFFF
   // CHECK: s_mov_b32 s{{[0-9]+}}, 0x20000
   // CHECK: waveasm.buffer_store_dword
   vector.store %ext, %buf1[%thread_id]

--- a/waveasm/test/Translate/dynamic-shapes.mlir
+++ b/waveasm/test/Translate/dynamic-shapes.mlir
@@ -1,0 +1,62 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: dynamic shapes support -- index-typed kernel arguments loaded from
+// kernarg buffer, dynamic SRD buffer sizes, vector.store translation with
+// dynamic stride address computation from memref.reinterpret_cast.
+
+// CHECK-LABEL: waveasm.program @dynamic_shapes_kernel
+
+// Test 1: index args loaded from kernarg buffer via s_load_dword
+// CHECK: waveasm.s_load_dword
+// CHECK: waveasm.s_load_dword
+
+// Test 2: SRD buffer size is max (0xFFFFFFFF) for dynamic memrefs
+// CHECK: 0xFFFFFFFF
+
+// Test 3: scalar args moved to VGPRs after SRD setup
+// CHECK: v_mov_b32 v2
+// CHECK: v_mov_b32 v3
+
+// Test 4: dynamic stride address computation (runtime v_mul_lo_u32)
+// CHECK: waveasm.v_mul_lo_u32
+// CHECK: waveasm.v_mul_lo_u32
+
+// Test 5: vector.store emits buffer_store
+// CHECK: waveasm.buffer_store
+
+module {
+func.func @dynamic_shapes_kernel(
+    %binding_a: !stream.binding,
+    %binding_c: !stream.binding,
+    %M: index,
+    %N: index) {
+
+  %c0 = arith.constant 0 : index
+
+  %flat_a = "stream.binding.subspan"(%binding_a, %c0) : (!stream.binding, index) -> memref<f16>
+  %flat_c = "stream.binding.subspan"(%binding_c, %c0) : (!stream.binding, index) -> memref<f32>
+
+  // Reinterpret with dynamic sizes and static strides (input)
+  %a = memref.reinterpret_cast %flat_a to
+      offset: [0], sizes: [%M, 128], strides: [128, 1]
+      : memref<f16> to memref<?x128xf16, strided<[128, 1]>>
+
+  // Reinterpret with dynamic sizes AND dynamic stride (output)
+  %c = memref.reinterpret_cast %flat_c to
+      offset: [0], sizes: [%M, %N], strides: [%N, 1]
+      : memref<f32> to memref<?x?xf32, strided<[?, 1]>>
+
+  %thread_id = gpu.thread_id x
+
+  // Load from input
+  %loaded = vector.load %a[%thread_id, %c0]
+      : memref<?x128xf16, strided<[128, 1]>>, vector<1xf16>
+  %ext = arith.extf %loaded : vector<1xf16> to vector<1xf32>
+
+  // Store with dynamic stride to output
+  vector.store %ext, %c[%thread_id, %c0]
+      : memref<?x?xf32, strided<[?, 1]>>, vector<1xf32>
+
+  return
+}
+}

--- a/waveasm/test/Translate/masked-load-store.mlir
+++ b/waveasm/test/Translate/masked-load-store.mlir
@@ -1,0 +1,54 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: vector.maskedload and vector.maskedstore with proper exec masking.
+// The mask disables lanes via s_and_saveexec_b64 before the memory access,
+// then exec is restored via s_mov_b64 exec.
+
+module {
+func.func @masked_load_store(
+    %binding_in: !stream.binding,
+    %binding_out: !stream.binding,
+    %M: index,
+    %N: index) {
+
+  %c0 = arith.constant 0 : index
+  %passthru = arith.constant dense<0.0> : vector<1xf32>
+
+  %flat_in = "stream.binding.subspan"(%binding_in, %c0) : (!stream.binding, index) -> memref<f32>
+  %flat_out = "stream.binding.subspan"(%binding_out, %c0) : (!stream.binding, index) -> memref<f32>
+
+  %in = memref.reinterpret_cast %flat_in to
+      offset: [0], sizes: [%M, %N], strides: [%N, 1]
+      : memref<f32> to memref<?x?xf32, strided<[?, 1]>>
+
+  %out = memref.reinterpret_cast %flat_out to
+      offset: [0], sizes: [%M, %N], strides: [%N, 1]
+      : memref<f32> to memref<?x?xf32, strided<[?, 1]>>
+
+  %tid = gpu.thread_id x
+
+  // Bounds check: tid < M
+  %cmp = arith.cmpi slt, %tid, %M : index
+  %mask = vector.broadcast %cmp : i1 to vector<1xi1>
+
+  // CHECK-LABEL: waveasm.program @masked_load_store
+
+  // --- maskedload: exec mask around buffer_load ---
+  // CHECK: waveasm.v_cmp_ne_u32
+  // CHECK: waveasm.s_and_saveexec_b64
+  // CHECK: waveasm.buffer_load
+  // CHECK: waveasm.s_mov_b64_exec
+  %loaded = vector.maskedload %in[%tid, %c0], %mask, %passthru
+      : memref<?x?xf32, strided<[?, 1]>>, vector<1xi1>, vector<1xf32> into vector<1xf32>
+
+  // --- maskedstore: exec mask around buffer_store ---
+  // CHECK: waveasm.v_cmp_ne_u32
+  // CHECK: waveasm.s_and_saveexec_b64
+  // CHECK: waveasm.buffer_store
+  // CHECK: waveasm.s_mov_b64_exec
+  vector.maskedstore %out[%tid, %c0], %mask, %loaded
+      : memref<?x?xf32, strided<[?, 1]>>, vector<1xi1>, vector<1xf32>
+
+  return
+}
+}

--- a/waveasm/test/Translate/memref-cast-dynamic-stride.mlir
+++ b/waveasm/test/Translate/memref-cast-dynamic-stride.mlir
@@ -1,0 +1,52 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: memref.cast propagates dynamic strides from memref.reinterpret_cast
+// through the cast chain so that vector.store correctly uses runtime
+// v_mul_lo_u32 for address computation instead of static stride constants.
+
+module {
+func.func @cast_stride_propagation(
+    %binding_in: !stream.binding,
+    %binding_out: !stream.binding,
+    %M: index,
+    %N: index) {
+
+  %c0 = arith.constant 0 : index
+
+  %flat_in = "stream.binding.subspan"(%binding_in, %c0) : (!stream.binding, index) -> memref<f32>
+  %flat_out = "stream.binding.subspan"(%binding_out, %c0) : (!stream.binding, index) -> memref<f32>
+
+  // Reinterpret input with static stride (for loading a VGPR value)
+  %in = memref.reinterpret_cast %flat_in to
+      offset: [0], sizes: [%M], strides: [1]
+      : memref<f32> to memref<?xf32, strided<[1]>>
+
+  // Reinterpret output with dynamic stride
+  %rc = memref.reinterpret_cast %flat_out to
+      offset: [0], sizes: [%M, %N], strides: [%N, 1]
+      : memref<f32> to memref<?x?xf32, strided<[?, 1]>>
+
+  // Cast erases static info but must preserve dynamic stride metadata
+  %cast = memref.cast %rc
+      : memref<?x?xf32, strided<[?, 1]>>
+        to memref<?x?xf32, strided<[?, 1]>>
+
+  %tid = gpu.thread_id x
+
+  // Load a value to get a VGPR for the store
+  %v = vector.load %in[%tid] : memref<?xf32, strided<[1]>>, vector<1xf32>
+
+  // CHECK-LABEL: waveasm.program @cast_stride_propagation
+
+  // The store through the cast chain must use dynamic stride (v_mul_lo_u32),
+  // not a static stride constant. This confirms memref.cast propagated
+  // the dynamic stride from reinterpret_cast.
+  // CHECK: waveasm.v_mul_lo_u32
+  // CHECK: waveasm.buffer_store
+
+  vector.store %v, %cast[%tid, %c0]
+      : memref<?x?xf32, strided<[?, 1]>>, vector<1xf32>
+
+  return
+}
+}

--- a/waveasm/test/Translate/vector-constants.mlir
+++ b/waveasm/test/Translate/vector-constants.mlir
@@ -1,0 +1,25 @@
+// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+//
+// Test: end-to-end translation after extract scalarization rewrites the
+// broadcast+dense-const chain to scalar ops.
+
+module {
+  gpu.module @test_vec_constants {
+
+    // The scalarization pass rewrites extract[2](addi(broadcast(base),
+    // dense<[10,11,12,13]>)) into scalar arith.addi(base, 12).
+    // The translator emits a single v_add_u32 with the constant 12.
+    //
+    // CHECK-LABEL: waveasm.program @scalarized_kernel
+    // CHECK: waveasm.constant 12
+    // CHECK: waveasm.v_add_u32
+    // CHECK: waveasm.s_endpgm
+    gpu.func @scalarized_kernel(%base: i32) kernel {
+      %bcast = vector.broadcast %base : i32 to vector<4xi32>
+      %offsets = arith.constant dense<[10, 11, 12, 13]> : vector<4xi32>
+      %sum = arith.addi %bcast, %offsets : vector<4xi32>
+      %lane = vector.extract %sum[2] : i32 from vector<4xi32>
+      gpu.return
+    }
+  }
+}

--- a/waveasm/tools/waveasm-translate/waveasm-translate.cpp
+++ b/waveasm/tools/waveasm-translate/waveasm-translate.cpp
@@ -157,13 +157,16 @@ int main(int argc, char **argv) {
 
   // If not already WAVEASM IR, translate from MLIR
   if (!hasWaveASMPrograms) {
-    // Run pre-translation MLIR passes (e.g., CSE to reduce redundant
-    // computations)
-    if (runPreTranslationCSE) {
+    // Run pre-translation MLIR passes.
+    {
       PassManager prePm(&context);
-      prePm.addPass(mlir::createCSEPass());
+      // Scalarize vector.extract from broadcast+dense-const patterns so the
+      // translator only sees ordinary scalar IR.
+      prePm.addPass(waveasm::createWAVEASMExtractScalarization());
+      if (runPreTranslationCSE)
+        prePm.addPass(mlir::createCSEPass());
       if (failed(prePm.run(*module))) {
-        llvm::errs() << "Pre-translation CSE failed\n";
+        llvm::errs() << "Pre-translation passes failed\n";
         return 1;
       }
     }


### PR DESCRIPTION
Enable dynamic M/N dimensions in test_dbuf_4wave_mxfp4_gemm_cpp_backend. Fix the test to use block=(128,256,256), is_bscale_shuffled=True, and a_scale shuffling to match 7.1_schedule.py. Both static and dynamic cases pass with numerical correctness.

C++ ASM backend changes for dynamic shapes support:

- Load index-typed kernel arguments from the kernarg buffer (both GFX95 and non-GFX95 paths) and map them to VGPRs via pinned SGPRs
- Track dynamic strides from memref.reinterpret_cast and use runtime stride values in address computations for loads and stores
- Handle vector constants (splat and non-splat) in handleArithConstant for dynamic bounds-check address selection patterns
- Add symbolic floordiv/ceildiv/mod support in the affine expression emitter via float reciprocal with off-by-one correction, enabling runtime division for dynamic workgroup reordering expressions
- Use maximum SRD buffer size (0xFFFFFFFF) for memrefs with dynamic dimensions and for swizzle SRDs to prevent OOB faults from sentinel addresses used in gather_to_lds bounds checking
- Add vector.maskedstore handler for dynamic-shaped output stores
- Extend capture_wave_kernel_info and run_with_wave_runtime to support dynamic dimension values for grid computation and kernel launch
- Add lit test for dynamic shapes translation
