### PR TITLE
Check that vector shapes don't clash during propagation

### DIFF
--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -848,15 +848,15 @@ def propagate_indices(
         if source in visited:
             continue
         if not isinstance(source, (NestedRegionOp, MMABase)):
+            assert (
+                not source.vector_shapes or source.vector_shapes == source_vector_shapes
+            ), f"Vector shapes mismatch for {source};\n{source.vector_shapes}\n{source_vector_shapes}"
             if not should_update_index(
                 source, source_index, source_vector_shapes, symbolic_constraints
             ):
                 continue
             # GetResults inherit their index from the Iterate node
             # and hence we don't need to update their index.
-            assert (
-                not source.vector_shapes or source.vector_shapes == source_vector_shapes
-            ), f"Vector shapes mismatch for {source};\n{source.vector_shapes}\n{source_vector_shapes}"
             source.vector_shapes = deepcopy(source_vector_shapes)
             if not isinstance(source, GetResult):
                 source_index = source.transform_index(source_index)


### PR DESCRIPTION
Add an assertion that vector shapes wouldn't clash during index sequence analysis. This is done prior to the code that stops propagation of index sequences as that code relies on vector shapes.