### PR TITLE
Add IfOp else-branch type coercion in waveasm translation

### DIFF
--- a/waveasm/lib/Transforms/RegionBuilder.cpp
+++ b/waveasm/lib/Transforms/RegionBuilder.cpp
@@ -13,6 +13,35 @@
 using namespace mlir;
 using namespace waveasm;
 
+/// Insert a move instruction to coerce `src` into a register of the target
+/// type's register class.  Returns the coerced value, or a null Value if the
+/// target type is not a recognized register type.
+static Value coerceToRegType(OpBuilder &builder, Location loc,
+                             TranslationContext &ctx, Type targetType,
+                             Value src) {
+  auto regClass = getRegClass(targetType);
+  if (!regClass)
+    return {};
+  int64_t size = getRegSize(targetType);
+  Type regType;
+  switch (*regClass) {
+  case RegClass::AGPR:
+    regType = ctx.createARegType(size);
+    break;
+  case RegClass::VGPR:
+    regType = ctx.createVRegType(size);
+    break;
+  case RegClass::SGPR:
+    regType = ctx.createSRegType(size);
+    break;
+  default:
+    llvm_unreachable("unhandled register class");
+  }
+  if (*regClass == RegClass::SGPR)
+    return S_MOV_B32::create(builder, loc, regType, src);
+  return V_MOV_B32::create(builder, loc, regType, src);
+}
+
 /// Check if a value is a memref in LDS (workgroup address space).
 /// Used to detect memref iter_args that carry LDS buffer offsets.
 static bool isLDSMemRefValue(Value val) {
@@ -324,8 +353,7 @@ IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
   auto waveIfOp =
       IfOp::create(builder, loc, resultTypes, conditionValue, hasElse);
 
-  // Translate then region.  thenYieldVals is needed later by else-branch
-  // type coercion, so it's declared outside the insertion guard scope.
+  // Translate then region body (yield created later, after type coercion).
   SmallVector<Value> thenYieldVals;
   {
     OpBuilder::InsertionGuard guard(builder);
@@ -338,10 +366,8 @@ IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
       }
     }
 
-    // Get yield values and create waveasm.yield
     auto scfYield =
         cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
-
     for (Value res : scfYield.getResults()) {
       if (auto mapped = ctx.getMapper().getMapped(res)) {
         thenYieldVals.push_back(*mapped);
@@ -350,19 +376,10 @@ IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
         return nullptr;
       }
     }
-
-    YieldOp::create(builder, loc, thenYieldVals);
-
-    // Update the if-op result types to match actual then-yield types, since
-    // the initial result types were guessed before translating the then body.
-    for (unsigned i = 0; i < waveIfOp->getNumResults(); ++i) {
-      if (i < thenYieldVals.size()) {
-        waveIfOp->getResult(i).setType(thenYieldVals[i].getType());
-      }
-    }
   }
 
-  // Translate else region if present
+  // Translate else region body (yield created later, after type coercion).
+  SmallVector<Value> elseYieldVals;
   if (hasElse) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(waveIfOp.getElseBlock());
@@ -376,8 +393,6 @@ IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
 
     auto scfYield =
         cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
-
-    SmallVector<Value> elseYieldVals;
     for (Value res : scfYield.getResults()) {
       if (auto mapped = ctx.getMapper().getMapped(res)) {
         elseYieldVals.push_back(*mapped);
@@ -386,33 +401,64 @@ IfOp RegionBuilder::buildIfFromSCFIf(scf::IfOp ifOp) {
         return nullptr;
       }
     }
+  }
 
-    // Coerce else-yield values to match then-yield types.  The then branch
-    // may produce AGPR/VGPR accumulators while the else branch yields bare
-    // immediates (e.g. zero constants).  The waveasm.if verifier requires
-    // both branches to yield type-compatible values.
-    for (unsigned i = 0; i < elseYieldVals.size(); ++i) {
-      if (i >= thenYieldVals.size())
-        break;
+  // Coerce yield values so both branches produce type-compatible results.
+  // One branch may produce register values (AGPR/VGPR/SGPR) while the
+  // other yields bare immediates (e.g. zero constants).  The waveasm.if
+  // verifier requires both branches to yield type-compatible values.
+  if (hasElse) {
+    for (unsigned i = 0, numYields = thenYieldVals.size(); i < numYields; ++i) {
       Type thenType = thenYieldVals[i].getType();
       Type elseType = elseYieldVals[i].getType();
-      if (!typesCompatible(thenType, elseType)) {
-        if (isAGPRType(thenType)) {
-          auto aregType = cast<ARegType>(thenType);
-          elseYieldVals[i] =
-              V_MOV_B32::create(builder, loc, aregType, elseYieldVals[i]);
-        } else if (isVGPRType(thenType)) {
-          auto vregType = cast<VRegType>(thenType);
-          elseYieldVals[i] =
-              V_MOV_B32::create(builder, loc, vregType, elseYieldVals[i]);
-        } else if (isSGPRType(thenType)) {
-          auto sregType = cast<SRegType>(thenType);
-          elseYieldVals[i] =
-              S_MOV_B32::create(builder, loc, sregType, elseYieldVals[i]);
+      if (typesCompatible(thenType, elseType))
+        continue;
+      // Coerce the immediate side to the register side.
+      if (getRegClass(thenType)) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToEnd(waveIfOp.getElseBlock());
+        Value coerced =
+            coerceToRegType(builder, loc, ctx, thenType, elseYieldVals[i]);
+        if (!coerced) {
+          ifOp.emitError("unsupported type coercion for yield result ")
+              << i << ": then type " << thenType << ", else type " << elseType;
+          return nullptr;
         }
+        elseYieldVals[i] = coerced;
+      } else if (getRegClass(elseType)) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointToEnd(&waveIfOp.getThenBlock());
+        Value coerced =
+            coerceToRegType(builder, loc, ctx, elseType, thenYieldVals[i]);
+        if (!coerced) {
+          ifOp.emitError("unsupported type coercion for yield result ")
+              << i << ": then type " << thenType << ", else type " << elseType;
+          return nullptr;
+        }
+        thenYieldVals[i] = coerced;
+      } else {
+        ifOp.emitError("unsupported type coercion for yield result ")
+            << i << ": then type " << thenType << ", else type " << elseType;
+        return nullptr;
       }
     }
+  }
 
+  // Create then yield and update if-op result types.
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(&waveIfOp.getThenBlock());
+    YieldOp::create(builder, loc, thenYieldVals);
+    for (unsigned i = 0, e = waveIfOp->getNumResults(); i < e; ++i) {
+      if (i < thenYieldVals.size())
+        waveIfOp->getResult(i).setType(thenYieldVals[i].getType());
+    }
+  }
+
+  // Create else yield.
+  if (hasElse) {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(waveIfOp.getElseBlock());
     YieldOp::create(builder, loc, elseYieldVals);
   }
 

--- a/waveasm/test/Translate/scf-if-agpr-else-coercion.mlir
+++ b/waveasm/test/Translate/scf-if-agpr-else-coercion.mlir
@@ -1,4 +1,4 @@
-// RUN: waveasm-translate %s 2>&1 | FileCheck %s
+// RUN: waveasm-translate %s | FileCheck %s
 //
 // Test: scf.if where the then branch yields a computed VGPR value and the
 // else branch yields a constant (which translates to an immediate).


### PR DESCRIPTION
When an scf.if has a then branch that produces register values and an else branch that yields constants (which become immediates), the waveasm.if verifier requires both branches to yield type-compatible values. This implements the coercion and tests it.