### PR TITLE
Set IfOp result type from allocation mapping in LinearScan regalloc

### DIFF
--- a/waveasm/lib/Transforms/LinearScanPass.cpp
+++ b/waveasm/lib/Transforms/LinearScanPass.cpp
@@ -34,7 +34,8 @@ namespace waveasm {
 } // namespace waveasm
 
 /// Convert a virtual register type to a physical register type.
-/// Returns the original type unchanged if it's not a virtual register type
+/// Also handles re-indexing an already-physical type to a new physReg.
+/// Returns the original type unchanged if it's not a register type
 /// or if physReg < 0.
 static Type makePhysicalType(MLIRContext *ctx, Type virtualType,
                              int64_t physReg) {
@@ -46,6 +47,12 @@ static Type makePhysicalType(MLIRContext *ctx, Type virtualType,
     return PSRegType::get(ctx, physReg, sreg.getSize());
   if (auto areg = dyn_cast<ARegType>(virtualType))
     return PARegType::get(ctx, physReg, areg.getSize());
+  if (auto pvreg = dyn_cast<PVRegType>(virtualType))
+    return PVRegType::get(ctx, physReg, pvreg.getSize());
+  if (auto psreg = dyn_cast<PSRegType>(virtualType))
+    return PSRegType::get(ctx, physReg, psreg.getSize());
+  if (auto pareg = dyn_cast<PARegType>(virtualType))
+    return PARegType::get(ctx, physReg, pareg.getSize());
   return virtualType;
 }
 
@@ -428,14 +435,27 @@ private:
       }
     });
 
-    // Also update if op result types from yield operand types
+    // Also update if op result types.
+    // Prefer the allocation mapping (which respects loop ties) over the
+    // then-yield operand type.  When an if result feeds a loop init arg,
+    // the allocator ties it to the loop block arg and both receive the
+    // same physical register.  The then-yield operand may carry a
+    // *different* physical register (from the inner loop), so copying it
+    // blindly would break the LoopLikeOpInterface verifier which requires
+    // exact type equality between init args and region iter_args.
     program.walk([&](IfOp ifOp) {
       auto &thenBlock = ifOp.getThenBlock();
-      if (auto yieldOp = dyn_cast<YieldOp>(thenBlock.getTerminator())) {
-        for (unsigned i = 0; i < ifOp->getNumResults(); ++i) {
-          if (i < yieldOp.getResults().size()) {
-            ifOp->getResult(i).setType(yieldOp.getResults()[i].getType());
-          }
+      auto yieldOp = dyn_cast<YieldOp>(thenBlock.getTerminator());
+      if (!yieldOp)
+        return;
+      for (unsigned i = 0; i < ifOp->getNumResults(); ++i) {
+        Value res = ifOp->getResult(i);
+        int64_t physReg = mapping.getPhysReg(res);
+        if (physReg >= 0) {
+          res.setType(
+              makePhysicalType(ifOp->getContext(), res.getType(), physReg));
+        } else if (i < yieldOp.getResults().size()) {
+          res.setType(yieldOp.getResults()[i].getType());
         }
       }
     });

--- a/waveasm/test/Transforms/linear-scan-if-feeds-loop.mlir
+++ b/waveasm/test/Transforms/linear-scan-if-feeds-loop.mlir
@@ -1,0 +1,68 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// Test: waveasm.if results feeding waveasm.loop init args.
+//
+// When an if-op result is used as a loop init arg, the register allocator
+// ties the if result and the loop block arg to the same physical register.
+// The LinearScanPass must set the if-op result type from the allocation
+// mapping (not from the then-yield operand type), because the then-yield
+// operand may have been allocated to a different physical register (e.g.
+// from an inner loop).  Without the fix, the LoopLikeOpInterface verifier
+// rejects the mismatch between init arg and region iter_arg types.
+
+// CHECK-LABEL: waveasm.program @if_result_feeds_loop
+
+// The if-op result must get its physical register from the allocation
+// mapping, which ties it to the loop block arg.  Capture the if-result
+// physical register index as IF_REG.
+// CHECK:       waveasm.if {{.*}} -> !waveasm.pareg<[[IF_REG:[0-9]+]], 4>
+
+// The then-yield (from MFMA) carries a *different* physical register.
+// CHECK:         waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 {{.*}} -> !waveasm.pareg<[[MFMA_REG:[0-9]+]], 4>
+// CHECK-NEXT:    waveasm.yield {{.*}} : !waveasm.pareg<[[MFMA_REG]], 4>
+
+// The loop init arg type must exactly match the if-result type (IF_REG).
+// CHECK:       waveasm.loop ({{.*}}!waveasm.pareg<[[IF_REG]], 4>) -> ({{.*}}!waveasm.pareg<[[IF_REG]], 4>)
+
+// Inside the loop body, the block arg fed to MFMA must also be pareg<IF_REG, 4>.
+// CHECK:         waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 {{.*}}!waveasm.pareg<[[IF_REG]], 4>{{.*}} -> !waveasm.pareg<[[IF_REG]], 4>
+
+waveasm.program @if_result_feeds_loop
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c4 = waveasm.constant 4 : !waveasm.imm<4>
+  %v0 = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %v4 = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+  %vs = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
+
+  %s_zero = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+
+  %if_result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.areg<4, 4> {
+    %acc_init = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.areg<4, 4>
+    %mfma = waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 %v0, %v4, %acc_init, %vs, %vs
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.areg<4, 4>, !waveasm.pvreg<8>, !waveasm.pvreg<8> -> !waveasm.areg<4, 4>
+    waveasm.yield %mfma : !waveasm.areg<4, 4>
+  } else {
+    %zero_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.areg<4, 4>
+    waveasm.yield %zero_acc : !waveasm.areg<4, 4>
+  }
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  %i_out, %acc_out = waveasm.loop(%i = %init_i, %acc = %if_result)
+      : (!waveasm.sreg, !waveasm.areg<4, 4>) -> (!waveasm.sreg, !waveasm.areg<4, 4>) {
+
+    %new_mfma = waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 %v0, %v4, %acc, %vs, %vs
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.areg<4, 4>, !waveasm.pvreg<8>, !waveasm.pvreg<8> -> !waveasm.areg<4, 4>
+
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i#0, %new_mfma) : !waveasm.sreg, !waveasm.areg<4, 4>
+  }
+
+  waveasm.s_endpgm
+}


### PR DESCRIPTION
When a waveasm.if result is used as a loop init arg, the allocator ties the if result and the loop block arg to the same physical register. The LinearScanPass must set the if-op result type from the allocation mapping rather than copying the then-yield operand type, which may carry a different physical register from an inner computation. Without the fix the LoopLikeOpInterface verifier rejects the type mismatch between init arg and region iter_arg.