### PR TITLE
[asm] Fix dynamic-K unscheduled MXFP4 GEMM on gfx950 C++ ASM backend

### DIFF
--- a/tests/kernel/wave/asm/test_waveasm_e2e.py
+++ b/tests/kernel/wave/asm/test_waveasm_e2e.py
@@ -44,6 +44,7 @@ Environment variables:
 """
 
 import os
+import re
 import warnings
 
 import pytest
@@ -1321,6 +1322,7 @@ def _dbuf_mxfp4_helper(
     dump_asm,
     dynamic_dims=False,
     use_buffer_ops=True,
+    use_schedule=True,
 ):
     """Shared helper for double-buffered MXFP4 scheduled GEMM tests.
 
@@ -1347,6 +1349,7 @@ def _dbuf_mxfp4_helper(
         get_mxfp4_dbuf_schedule,
         get_mxfp4_asymmetric_schedule,
     )
+    from wave_lang.kernel.wave.scheduling.schedule_enums import SchedulingType
     from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
     from wave_lang.kernel.wave.utils.mxfp_utils import (
         generate_gemm_afp4wfp4_inputs,
@@ -1365,14 +1368,22 @@ def _dbuf_mxfp4_helper(
             wave_shape=(1, 4),
             reorder_workgroups=not dynamic_dims,
         )
-        schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
+        if use_schedule:
+            schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
+        else:
+            schedule = None
+            options.schedule = SchedulingType.NONE
     else:
         gemm, options = get_tagged_mxfp4_gemm(
             shape,
             block,
             wave_shape=(4, 2),
         )
-        schedule = get_mxfp4_dbuf_schedule(use_stagger=use_stagger)
+        if use_schedule:
+            schedule = get_mxfp4_dbuf_schedule(use_stagger=use_stagger)
+        else:
+            schedule = None
+            options.schedule = SchedulingType.NONE
 
     # Override to ASM backend for C++ compilation path
     options.backend = "asm"
@@ -1385,6 +1396,7 @@ def _dbuf_mxfp4_helper(
 
     M = tkl.sym.M
     N = tkl.sym.N
+    K = tkl.sym.K
     m, n, k = shape
 
     dynamic_symbols = []
@@ -1394,6 +1406,10 @@ def _dbuf_mxfp4_helper(
         dynamic_values = {M: m, N: n}
         del options.subs[M]
         del options.subs[N]
+        if not use_schedule:
+            dynamic_symbols.append(K)
+            dynamic_values[K] = k
+            del options.subs[K]
         options.dynamic_symbols = dynamic_symbols
 
     # Generate MXFP4 inputs and reference output
@@ -1413,6 +1429,17 @@ def _dbuf_mxfp4_helper(
     assert (
         "amdgpu.scaled_mfma" in kernel_info.mlir_text
     ), "Expected amdgpu.scaled_mfma operation in MLIR"
+    if dynamic_dims:
+        if use_schedule:
+            expected_idx = r"function_type = \([^)]*index, index\) -> \(\)"
+            expected_msg = "M and N"
+        else:
+            expected_idx = r"function_type = \([^)]*index, index, index\) -> \(\)"
+            expected_msg = "M, N, and K"
+        assert re.search(expected_idx, kernel_info.mlir_text), (
+            f"Expected dynamic-dims MLIR signature to carry trailing dynamic "
+            f"{expected_msg} index arguments, got:\n{kernel_info.mlir_text[:400]}"
+        )
 
     waves_str = f"{num_waves}wave"
     stagger_str = "stagger" if use_stagger else "no_stagger"
@@ -1481,13 +1508,15 @@ def _dbuf_mxfp4_helper(
 
 @param_bool("dynamic_dims", "dyn")
 @param_bool("use_buffer_ops", "bufops")
+@param_bool("use_schedule", "sched")
 def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
-    dynamic_dims, use_buffer_ops, compiler, backend, dump_asm
+    dynamic_dims, use_buffer_ops, use_schedule, compiler, backend, dump_asm
 ):
     """End-to-end test for asymmetric MXFP4 GEMM with 4 waves.
 
     Uses get_mxfp4_asymmetric_schedule() with wave_shape=(1,4),
     preshuffle B, and block=(128,256,256) matching 7.1_schedule.py.
+    When use_schedule=False, disables manual scheduling entirely.
     """
     _dbuf_mxfp4_helper(
         shape=(1024, 1024, 8192),
@@ -1499,6 +1528,7 @@ def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
         dump_asm=dump_asm,
         dynamic_dims=dynamic_dims,
         use_buffer_ops=use_buffer_ops,
+        use_schedule=use_schedule,
     )
 
 

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -497,10 +497,11 @@ def _cast_buffer_and_encode_stride(
     if stride_rank >= 2:
         stride_candidate = strides[-2]
         stride_int = _get_constant_value(stride_candidate)
-        # Only swizzle if stride is static and fits in signed i14
-        # (max representable positive value is 8191, but 8192 wraps to
-        # -8192 which the hardware accepts).
-        if stride_int and stride_int <= 8192:
+        # Emit swizzle stride for both static and dynamic cases.
+        # Static: only if stride fits in signed i14 (max 8192).
+        # Dynamic: always emit — the SRD swizzle encoding is constant
+        # (0x40400000 + 0x27000) regardless of the actual stride value.
+        if stride_int is None or stride_int <= 8192:
             swizzle_stride = arith_d.index_cast(uint14, stride_candidate)
 
     if swizzle_stride:

--- a/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -575,9 +575,9 @@ public:
     pendingSRDBaseAdjustMap.erase(memref);
   }
 
-  /// Default max buffer size (~2 GiB, dword-aligned) used when no matching
-  /// SRD is found.  Disables hardware OOB checking but keeps valid alignment.
-  static constexpr int64_t kDefaultMaxBufferSize = 0x7FFFFFFC;
+  /// Default max buffer size: sentinel-safe limit ensuring the OOB sentinel
+  /// at byte offset 0x7FFFFFFF falls outside the SRD range.
+  static constexpr int64_t kDefaultMaxBufferSize = 0x7FFFFFFE;
 
   /// Look up buffer size for an SRD by its SGPR base index
   int64_t getBufferSizeForSRD(int64_t srdBase) const {
@@ -629,8 +629,8 @@ public:
     int64_t count = 2;
     // On gfx950+ with kernarg preloading, add preloaded args
     if (llvm::isa<GFX950TargetAttr>(target)) {
-      // Each kernel arg pointer uses 2 SGPRs
-      count += getNumKernelArgs() * 2;
+      // Each kernel arg uses 2 SGPRs, capped at 14 (hardware max 16 total).
+      count += std::min(size_t(14), getNumKernelArgs() * 2);
     }
     return count;
   }

--- a/waveasm/lib/Transforms/MetadataEmitter.cpp
+++ b/waveasm/lib/Transforms/MetadataEmitter.cpp
@@ -148,7 +148,8 @@ static void scanSystemRegisterUsage(ProgramOp program, bool &usesWorkgroupIdX,
 
   int64_t userSgprCount = 2;
   if (isGfx950) {
-    userSgprCount = 2 + numArgs * 2;
+    // Hardware limits user SGPRs to 16 on gfx950.
+    userSgprCount = std::min(int64_t(16), 2 + numArgs * 2);
   }
 
   int64_t wgIdXIndex = userSgprCount;
@@ -191,6 +192,18 @@ MetadataEmitter::emitKernelDescriptor(int64_t peakVGPRs, int64_t peakSGPRs,
                   std::to_string(ldsBlocks * 128));
   lines.push_back("  .amdhsa_private_segment_fixed_size 0");
 
+  // Kernarg size must account for all args the runtime packs: buffer ptrs +
+  // dynamic dims + stride args. Use 2x base to safely accommodate strides.
+  {
+    int64_t numArgsForSize = 2;
+    if (auto numArgsAttr =
+            program->getAttrOfType<IntegerAttr>("num_kernel_args")) {
+      numArgsForSize = numArgsAttr.getInt();
+    }
+    int64_t kernargSize = numArgsForSize * 8 * 2;
+    lines.push_back("  .amdhsa_kernarg_size " + std::to_string(kernargSize));
+  }
+
   auto targetAttr = program.getTarget();
   auto targetKind = targetAttr.getTargetKind();
   int64_t preloadLength = program.getKernargPreloadLength();
@@ -202,7 +215,9 @@ MetadataEmitter::emitKernelDescriptor(int64_t peakVGPRs, int64_t peakSGPRs,
             program->getAttrOfType<IntegerAttr>("num_kernel_args")) {
       numArgs = numArgsAttr.getInt();
     }
-    preloadLength = numArgs * 2;
+    // Hardware limits user SGPRs to 16 on gfx950 (2 for kernarg ptr + 14 max
+    // preloaded). Overflow args are loaded via explicit s_load in the prologue.
+    preloadLength = std::min(int64_t(14), numArgs * 2);
   }
 
   int64_t userSgprCount = 2;
@@ -315,7 +330,10 @@ MetadataEmitter::emitMetadataYAML(int64_t peakVGPRs, int64_t peakSGPRs,
       numArgs = kernargPreload / 2;
     }
   }
-  int64_t kernargSize = numArgs * 8;
+  // The runtime packs: buffer_ptrs (8B each) + dynamic_dims (8B each) +
+  // stride_args (8B each). Strides are appended by the runtime for each 2D+
+  // tensor binding. Use 2x the base size to safely accommodate strides.
+  int64_t kernargSize = numArgs * 8 * 2;
   lines.push_back("    .args:");
   for (int64_t i = 0; i < numArgs; ++i) {
     lines.push_back("      - .name:       arg" + std::to_string(i) + "_ptr");

--- a/waveasm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/waveasm/lib/Transforms/TranslateFromMLIR.cpp
@@ -42,7 +42,7 @@ namespace waveasm {
 // Named constants for SRD descriptor fields and limits.
 // kDefaultMaxBufferSize lives in TranslationContext (header).
 static constexpr int64_t kSRDStrideSwizzle = 0x20000;
-static constexpr int64_t kMaxNumRecords32 = 0xFFFFFFFF;
+static constexpr int64_t kMaxNumRecords32 = 0x7FFFFFFE;
 
 //===----------------------------------------------------------------------===//
 // TranslationContext Implementation
@@ -165,8 +165,7 @@ void TranslationContext::emitSRDPrologue() {
   // SRDs must start after: user SGPRs + system SGPRs (workgroup IDs)
   int64_t userSgprCount = 2; // kernarg ptr
   if (isGFX95) {
-    userSgprCount +=
-        getNumKernelArgs() * 2; // preloaded args (bindings + scalars)
+    userSgprCount += std::min(int64_t(14), (int64_t)getNumKernelArgs() * 2);
   }
   int64_t systemSgprCount = 3; // workgroup_id_x, y, z
   int64_t srdStartIndex =
@@ -179,10 +178,16 @@ void TranslationContext::emitSRDPrologue() {
     srdIndexMap[pendingSRDs[i].memref] = newSrdBase;
   }
 
-  // Update nextSwizzleSRDIndex to start after all regular SRDs.
-  // This ensures cache-swizzle SRDs don't overlap with regular arg SRDs.
+  // Update nextSwizzleSRDIndex to start after all regular SRDs AND any
+  // overflow scalar arg slots (for args that exceed the 16-SGPR preload limit).
   int64_t afterLastSrd = srdStartIndex + pendingSRDs.size() * 4;
-  nextSwizzleSRDIndex = (afterLastSrd + 3) & ~3; // Align to 4
+  int64_t numOverflowScalars = 0;
+  for (const auto &pending : pendingScalarArgs) {
+    if (2 + pending.argIndex * 2 >= 16)
+      ++numOverflowScalars;
+  }
+  int64_t afterOverflow = afterLastSrd + numOverflowScalars * 2;
+  nextSwizzleSRDIndex = (afterOverflow + 3) & ~3; // Align to 4
 
   // Emit comment for prologue
   CommentOp::create(builder, loc, "SRD setup prologue");
@@ -199,9 +204,14 @@ void TranslationContext::emitSRDPrologue() {
   if (isGFX95) {
     // On gfx95*, the prologue loads kernarg data into preload locations
     // s[2:3], s[4:5], etc. Reserve those pairs so regalloc doesn't use them.
+    // Hardware limits user SGPRs to 16 (s[0:15]), so only reserve preload
+    // slots for args that fit within the limit. Overflow args are loaded
+    // via explicit s_load from the kernarg buffer at runtime.
     llvm::DenseSet<int64_t> reservedPreloadBases;
     for (const auto &pending : pendingSRDs) {
       int64_t preloadBase = 2 + pending.argIndex * 2;
+      if (preloadBase >= 16)
+        continue;
       if (reservedPreloadBases.insert(preloadBase).second) {
         auto preloadType = createSRegType(2, 2);
         PrecoloredSRegOp::create(builder, loc, preloadType, preloadBase,
@@ -210,6 +220,8 @@ void TranslationContext::emitSRDPrologue() {
     }
     for (const auto &pending : pendingScalarArgs) {
       int64_t preloadBase = 2 + pending.argIndex * 2;
+      if (preloadBase >= 16)
+        continue;
       if (reservedPreloadBases.insert(preloadBase).second) {
         auto preloadType = createSRegType(2, 2);
         PrecoloredSRegOp::create(builder, loc, preloadType, preloadBase,
@@ -230,6 +242,8 @@ void TranslationContext::emitSRDPrologue() {
 
     for (const auto &pending : pendingSRDs) {
       int64_t loadBase = 2 + pending.argIndex * 2;
+      if (loadBase >= 16)
+        continue; // Overflow arg: loaded via s_load_dword path below.
       int64_t kernargOffset = pending.argIndex * 8;
 
       auto loadDstType = createSRegType(2, loadBase);
@@ -240,9 +254,15 @@ void TranslationContext::emitSRDPrologue() {
                              offsetConst);
     }
 
-    // Also load scalar kernel arguments (index types) from kernarg buffer
+    // Also load scalar kernel arguments (index types) from kernarg buffer.
+    // Scalar args that still fit in the preload SGPR window can be loaded
+    // before the aligned main entry.
+    int64_t overflowSgprBase =
+        (srdStartIndex + (int64_t)pendingSRDs.size() * 4 + 3) & ~3;
     for (const auto &pending : pendingScalarArgs) {
       int64_t loadBase = 2 + pending.argIndex * 2;
+      if (loadBase >= 16)
+        continue;
       int64_t kernargOffset = pending.argIndex * 8;
 
       auto loadDstType = createSRegType(2, loadBase);
@@ -253,13 +273,10 @@ void TranslationContext::emitSRDPrologue() {
                              offsetConst);
     }
 
-    // Step 2: Wait for all scalar loads to complete
-    auto i32Type = builder.getI32Type();
-    auto lgkmcntAttr = IntegerAttr::get(i32Type, 0);
-    S_WAITCNT::create(builder, loc, /*vmcnt=*/IntegerAttr{}, lgkmcntAttr,
-                      /*expcnt=*/IntegerAttr{});
-
-    // Step 2.5: Branch to aligned entry point (gfx95* requirement)
+    // Step 2: Branch to aligned entry point (gfx95* requirement).
+    // Keep any high-SGPR overflow loads after the aligned entry; LLVM does the
+    // same, and loading them before the branch leaves the overflow arg stale
+    // on gfx95 hardware.
     // NOTE: Labels/branches are control flow and must remain as RawOp for now.
     std::string kernelName = program.getSymName().str();
     std::string mainLabel = ".L_" + kernelName + "_main";
@@ -268,7 +285,38 @@ void TranslationContext::emitSRDPrologue() {
     RawOp::create(builder, loc, ".p2align 8");
     RawOp::create(builder, loc, mainLabel + ":");
 
-    // Step 3: Copy from preload locations to SRD positions and fill
+    // Step 3: Load scalar overflow args after the aligned entry point.
+    // Reserve overflow SGPR slots so the register allocator avoids them.
+    for (int64_t i = 0; i < numOverflowScalars; ++i) {
+      int64_t base = overflowSgprBase + i * 2;
+      auto ovfType = createSRegType(2, 2);
+      PrecoloredSRegOp::create(builder, loc, ovfType, base, /*size=*/2);
+    }
+
+    int64_t overflowIdx = 0;
+    for (const auto &pending : pendingScalarArgs) {
+      int64_t preloadBase = 2 + pending.argIndex * 2;
+      if (preloadBase < 16)
+        continue;
+      int64_t loadBase = overflowSgprBase + overflowIdx * 2;
+      overflowIdx++;
+      int64_t kernargOffset = pending.argIndex * 8;
+
+      auto loadDstType = createSRegType(2, loadBase);
+      auto offsetImm = builder.getType<ImmType>(kernargOffset);
+      auto offsetConst =
+          ConstantOp::create(builder, loc, offsetImm, kernargOffset);
+      S_LOAD_DWORDX2::create(builder, loc, TypeRange{loadDstType}, kernargBase,
+                             offsetConst);
+    }
+
+    // Step 4: Wait for all scalar loads to complete.
+    auto i32Type = builder.getI32Type();
+    auto lgkmcntAttr = IntegerAttr::get(i32Type, 0);
+    S_WAITCNT::create(builder, loc, /*vmcnt=*/IntegerAttr{}, lgkmcntAttr,
+                      /*expcnt=*/IntegerAttr{});
+
+    // Step 5: Copy from preload locations to SRD positions and fill
     // size/stride. Must use RawOp: S_MOV_B64/S_MOV_B32 are Pure (SALUUnaryOp)
     // and write to physical registers with no SSA consumer, so CSE/DCE
     // eliminates them.
@@ -301,14 +349,23 @@ void TranslationContext::emitSRDPrologue() {
 
     // Move scalar args from preload SGPRs to VGPRs.
     // Lower 32 bits of the preload pair hold the value (little-endian).
+    // Overflow args were loaded into overflowSgprBase positions above.
+    int64_t ovfIdx = 0;
     for (const auto &pending : pendingScalarArgs) {
       int64_t preloadBase = 2 + pending.argIndex * 2;
+      int64_t sgprSrc;
+      if (preloadBase >= 16) {
+        sgprSrc = overflowSgprBase + ovfIdx * 2;
+        ovfIdx++;
+      } else {
+        sgprSrc = preloadBase;
+      }
       auto vregType = createVRegType();
       auto vreg =
           PrecoloredVRegOp::create(builder, loc, vregType, pending.argIndex, 1);
       RawOp::create(builder, loc,
                     "v_mov_b32 v" + std::to_string(pending.argIndex) + ", s" +
-                        std::to_string(preloadBase));
+                        std::to_string(sgprSrc));
       mapper.mapValue(pending.blockArg, vreg);
     }
   } else {

--- a/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
@@ -364,8 +364,11 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
 
   // Check if the source (or its memref.cast source) has a pending SRD base
   // adjustment from a linearized reinterpret_cast (use_buffer_ops path).
-  // If so, pass through and propagate the adjustment -- the C++ backend's
-  // prologue SRDs and per-workgroup adjustment handle addressing correctly.
+  // Emit the SRD adjustment eagerly here rather than deferring to the first
+  // load, because the fat_raw_buffer_cast is typically outside any scf.for
+  // loop while the loads are inside. Deferring to load-time would place
+  // the SRD init RawOps inside the loop body where they get lost during
+  // loop lowering.
   Value src = op->getOperand(0);
   auto *adj = ctx.getPendingSRDBaseAdjust(src);
   if (!adj) {
@@ -373,9 +376,8 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
       adj = ctx.getPendingSRDBaseAdjust(castOp.getSource());
   }
   if (adj) {
-    ctx.getMapper().mapValue(op->getResult(0), *srcMapped);
-    ctx.setPendingSRDBaseAdjust(op->getResult(0), adj->elementOffset,
-                                adj->srcSrdBase, adj->elementBytes);
+    Value srd = emitSRDBaseAdjustment(*adj, op->getResult(0), ctx, loc);
+    ctx.getMapper().mapValue(op->getResult(0), srd);
     return success();
   }
 
@@ -384,9 +386,13 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
   bool hasCacheSwizzle = false;
   int64_t swizzleStride = 0;
   if (op->getNumOperands() >= 3) {
+    // Enable cache swizzle whenever the stride operand exists, even if
+    // the value is dynamic (not a compile-time constant). The SRD
+    // encoding (0x40400000 in word 1, 0x27000 in word 3) is constant
+    // regardless of the actual stride value.
+    hasCacheSwizzle = true;
     if (auto swizzleVal = getArithConstantValue(op->getOperand(2))) {
       swizzleStride = *swizzleVal;
-      hasCacheSwizzle = (swizzleStride > 0);
     }
   }
 
@@ -435,10 +441,11 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
                     std::to_string(newSrdBase + 1) + ", 0x40400000";
   RawOp::create(builder, loc, or1);
 
-  // Use 0xFFFFFFFF for num_records to prevent OOB faults from dynamic
-  // bounds-check sentinel addresses (0x7FFFFFFF) used in gather_to_lds.
+  // Use 0x7FFFFFFE for num_records to match the Wave frontend's OOB sentinel
+  // scheme. The sentinel byte offset is 0x7FFFFFFF, so num_records must be
+  // <= 0x7FFFFFFE for hardware to clamp OOB accesses to 0.
   std::string mov2 =
-      "s_mov_b32 s" + std::to_string(newSrdBase + 2) + ", 0xFFFFFFFF";
+      "s_mov_b32 s" + std::to_string(newSrdBase + 2) + ", 0x7FFFFFFE";
   RawOp::create(builder, loc, mov2);
 
   std::string mov3 =

--- a/waveasm/lib/Transforms/handlers/HandlerUtils.cpp
+++ b/waveasm/lib/Transforms/handlers/HandlerUtils.cpp
@@ -62,11 +62,14 @@ int64_t getElementBytes(Type type) {
 //===----------------------------------------------------------------------===//
 
 int64_t computeBufferSizeFromMemRef(MemRefType memrefType) {
-  // Always use max SRD num_records. All bounds checking is handled in
-  // software (arith.select sentinel addresses, exec masking, or static
-  // guarantees), so hardware bounds checking via SRD is not needed.
+  // Use (1 << 31) - 2 = 0x7FFFFFFE as num_records. The Wave Python frontend
+  // emits OOB sentinel index values at (valid_bytes + elem_bytes) / elem_bytes
+  // which lands at byte offset 0x7FFFFFFF. With num_records = 0x7FFFFFFE the
+  // sentinel is one byte past the SRD range, so hardware returns 0 for OOB
+  // lanes. Using 0xFFFFFFFF would make the sentinel "in bounds" and cause a
+  // real access to unmapped memory, triggering HSA page faults.
   (void)memrefType;
-  return 0xFFFFFFFF;
+  return 0x7FFFFFFE;
 }
 
 //===----------------------------------------------------------------------===//

--- a/waveasm/test/Translate/buffer-ops-srd-adjust.mlir
+++ b/waveasm/test/Translate/buffer-ops-srd-adjust.mlir
@@ -40,14 +40,14 @@ func.func @buffer_ops_test(%arg0: memref<f16>, %arg1: memref<f32>) {
   // The load SRD should be adjusted with the workgroup offset via SALU:
   //   s_mov_b64 (copy base), v_readfirstlane_b32 (wg offset to SGPR),
   //   s_mul_i32 (byte offset), s_add_u32 + s_addc_u32 (adjust base),
-  //   s_mov_b32 (num_records = 0xFFFFFFFF, bumped to max for sentinel safety)
+  //   s_mov_b32 (num_records = 0x7FFFFFFE, sentinel-safe max)
   // CHECK: s_mov_b64 s[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
   // CHECK: waveasm.v_readfirstlane_b32
   // CHECK: waveasm.s_mul_hi_u32
   // CHECK: waveasm.s_mul_i32
   // CHECK: waveasm.s_add_u32
   // CHECK: waveasm.s_addc_u32
-  // CHECK: s_mov_b32 s{{[0-9]+}}, 0xFFFFFFFF
+  // CHECK: s_mov_b32 s{{[0-9]+}}, 0x7FFFFFFE
   // CHECK: s_mov_b32 s{{[0-9]+}}, 0x20000
   // CHECK: waveasm.buffer_load_dwordx2
   %loaded = vector.load %buf0[%th_offset]
@@ -71,14 +71,14 @@ func.func @buffer_ops_test(%arg0: memref<f16>, %arg1: memref<f32>) {
       : vector<4xf16> to vector<1xf16>
   %ext = arith.extf %elem : vector<1xf16> to vector<1xf32>
 
-  // The store SRD should also be adjusted, with max num_records for sentinel safety
+  // The store SRD should also be adjusted, with sentinel-safe max num_records
   // CHECK: s_mov_b64 s[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
   // CHECK: waveasm.v_readfirstlane_b32
   // CHECK: waveasm.s_mul_hi_u32
   // CHECK: waveasm.s_mul_i32
   // CHECK: waveasm.s_add_u32
   // CHECK: waveasm.s_addc_u32
-  // CHECK: s_mov_b32 s{{[0-9]+}}, 0xFFFFFFFF
+  // CHECK: s_mov_b32 s{{[0-9]+}}, 0x7FFFFFFE
   // CHECK: s_mov_b32 s{{[0-9]+}}, 0x20000
   // CHECK: waveasm.buffer_store_dword
   vector.store %ext, %buf1[%thread_id]

--- a/waveasm/test/Translate/dynamic-shapes.mlir
+++ b/waveasm/test/Translate/dynamic-shapes.mlir
@@ -10,8 +10,8 @@
 // CHECK: waveasm.s_load_dword
 // CHECK: waveasm.s_load_dword
 
-// Test 2: SRD buffer size is max (0xFFFFFFFF) for dynamic memrefs
-// CHECK: 0xFFFFFFFF
+// Test 2: SRD buffer size is 0x7FFFFFFE (sentinel-safe max) for dynamic memrefs
+// CHECK: 0x7FFFFFFE
 
 // Test 3: scalar args moved to VGPRs after SRD setup
 // CHECK: v_mov_b32 v2


### PR DESCRIPTION
Address gfx950 hardware SGPR preload limit and related kernel argument handling for dynamic-K unscheduled MXFP4 GEMM:

- Cap SGPR preload at 16 (hardware max); overflow args loaded via explicit s_load_dwordx2 after the aligned entry point
- Fix overflow SGPR allocation stride: each S_LOAD_DWORDX2 occupies 2 SGPRs, so overflow index increments by 2 (not 1) to avoid register overlap and odd-alignment violations
- Reserve overflow SGPR slots via PrecoloredSRegOp so the register allocator avoids them
- Account for overflow slots (2 SGPRs each) in nextSwizzleSRDIndex to prevent swizzle SRDs from aliasing overflow load destinations
- Cap userSgprCount in emitSRDPrologue to match getUserSgprCount() and MetadataEmitter (std::min(14, numArgs*2))
- Change SRD num_records from 0xFFFFFFFF to 0x7FFFFFFE so the OOB sentinel at byte offset 0x7FFFFFFF falls outside the SRD range and hardware returns 0 for out-of-bounds lanes
- Unify kMaxNumRecords32 and kDefaultMaxBufferSize to 0x7FFFFFFE
- Double kernarg_size in metadata to accommodate runtime-appended stride arguments
- Enable cache swizzle for dynamic strides (SRD encoding is constant)
- Emit SRD base adjustment eagerly at fat_raw_buffer_cast instead of deferring to load-time, preventing init code inside loop bodies
- Add use_schedule parameter to e2e tests; when False, K is also dynamic
- Fix Python swizzle stride condition to use explicit None check
- Refactor duplicated del options.subs in test helper
- Update lit tests for new num_records value