### PR TITLE
[asm] Support bf16 output in MXFP4 GEMM on WaveASM backend

### DIFF
--- a/examples/python/7.1_schedule.py
+++ b/examples/python/7.1_schedule.py
@@ -55,7 +55,9 @@ def _run_mxfp_gemm(gemm, shape):
     )
 
 
-def _run_mxfp_gemm_preshuffle(gemm, shape, all=False, only_scale=False, only_b=False):
+def _run_mxfp_gemm_preshuffle(
+    gemm, shape, all=False, only_scale=False, only_b=False, output_dtype=torch.float32
+):
     """Run compiled GEMM kernel with preshuffled B and B_scale, verify against reference.
 
     Shuffling is applied based on the flags:
@@ -79,7 +81,7 @@ def _run_mxfp_gemm_preshuffle(gemm, shape, all=False, only_scale=False, only_b=F
 
     x, w_t_ps = x.cuda(), w_t_ps.cuda()
     x_scales_ps, w_scales_ps = x_scales_ps.cuda(), w_scales_ps.cuda()
-    out = torch.zeros(x.shape[0], w_t_ps.shape[0], dtype=torch.float32).cuda()
+    out = torch.zeros(x.shape[0], w_t_ps.shape[0], dtype=output_dtype).cuda()
 
     gemm(x, x_scales_ps, w_t_ps, w_scales_ps, out)
 
@@ -329,7 +331,9 @@ def test_dbuf_4wave_mxfp_preshuffle_b_gemm_cpp(
     is_debug=False, shape=(1024, 1024, 8192), block=(128, 256, 256)
 ):
     """Preshuffle-B MXFP4 GEMM using C++ WaveASM backend."""
-    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(shape, block, wave_shape=(1, 4))
+    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(
+        shape, block, wave_shape=(1, 4), output_dtype=tkl.bf16
+    )
     options.backend = "asm"
     options.use_buffer_ops = False
     options.wave_runtime = True
@@ -340,7 +344,7 @@ def test_dbuf_4wave_mxfp_preshuffle_b_gemm_cpp(
     options = set_default_run_config(options)
     gemm = wave_compile(options, gemm, schedule)
 
-    _run_mxfp_gemm_preshuffle(gemm, shape, all=True)
+    _run_mxfp_gemm_preshuffle(gemm, shape, all=True, output_dtype=torch.bfloat16)
     print("MXFP GEMM preshuffle-B 4-wave (WaveASM backend) test passed!")
 
 

--- a/tests/kernel/wave/asm/test_waveasm_e2e.py
+++ b/tests/kernel/wave/asm/test_waveasm_e2e.py
@@ -1323,6 +1323,7 @@ def _dbuf_mxfp4_helper(
     dynamic_dims=False,
     use_buffer_ops=True,
     use_schedule=True,
+    output_dtype="f32",
 ):
     """Shared helper for double-buffered MXFP4 scheduled GEMM tests.
 
@@ -1332,6 +1333,9 @@ def _dbuf_mxfp4_helper(
 
     This exercises the C++ ASM backend on MLIR produced by the full
     Wave scheduling pipeline (MANUAL schedule + wave_schedule clusters).
+
+    Args:
+        output_dtype: Output element type, one of "f32" or "bf16".
     """
     if not is_cdna4():
         pytest.skip("MXFP4 double-buffered GEMM only supported on gfx950+ (CDNA4)")
@@ -1340,6 +1344,7 @@ def _dbuf_mxfp4_helper(
     skip_if_no_wave_lang()
 
     import torch
+    import wave_lang.kernel.lang as tkl
 
     from wave_lang.kernel.wave.templates import (
         get_tagged_mxfp4_gemm,
@@ -1358,6 +1363,12 @@ def _dbuf_mxfp4_helper(
         e8m0_shuffle,
     )
 
+    dtype_map = {
+        "f32": (tkl.f32, torch.float32),
+        "bf16": (tkl.bf16, torch.bfloat16),
+    }
+    tkl_dtype, torch_dtype = dtype_map[output_dtype]
+
     # Get tagged kernel + options (same as 7.1_schedule.py)
     # Use preshuffle B + asymmetric schedule with wave_shape=(1,4) for 4-wave,
     # standard double-buffer with wave_shape=(4,2) for 8-wave.
@@ -1367,6 +1378,7 @@ def _dbuf_mxfp4_helper(
             block,
             wave_shape=(1, 4),
             reorder_workgroups=not dynamic_dims,
+            output_dtype=tkl_dtype,
         )
         if use_schedule:
             schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
@@ -1378,6 +1390,7 @@ def _dbuf_mxfp4_helper(
             shape,
             block,
             wave_shape=(4, 2),
+            output_dtype=tkl_dtype,
         )
         if use_schedule:
             schedule = get_mxfp4_dbuf_schedule(use_stagger=use_stagger)
@@ -1391,8 +1404,6 @@ def _dbuf_mxfp4_helper(
     options.compile_to_mlir = False
     options.use_buffer_ops = use_buffer_ops
     options = set_default_run_config(options)
-
-    import wave_lang.kernel.lang as tkl
 
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1418,7 +1429,7 @@ def _dbuf_mxfp4_helper(
 
     x, w = x.cuda(), w.cuda()
     x_scales, w_scales = x_scales.cuda(), w_scales.cuda()
-    c = torch.zeros(shape[0], shape[1], dtype=torch.float32).cuda()
+    c = torch.zeros(shape[0], shape[1], dtype=torch_dtype).cuda()
 
     # Capture MLIR with schedule applied
     kernel_info = capture_wave_kernel_info(
@@ -1509,8 +1520,15 @@ def _dbuf_mxfp4_helper(
 @param_bool("dynamic_dims", "dyn")
 @param_bool("use_buffer_ops", "bufops")
 @param_bool("use_schedule", "sched")
+@pytest.mark.parametrize("output_dtype", ["f32", "bf16"])
 def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
-    dynamic_dims, use_buffer_ops, use_schedule, compiler, backend, dump_asm
+    dynamic_dims,
+    use_buffer_ops,
+    use_schedule,
+    output_dtype,
+    compiler,
+    backend,
+    dump_asm,
 ):
     """End-to-end test for asymmetric MXFP4 GEMM with 4 waves.
 
@@ -1529,6 +1547,7 @@ def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
         dynamic_dims=dynamic_dims,
         use_buffer_ops=use_buffer_ops,
         use_schedule=use_schedule,
+        output_dtype=output_dtype,
     )
 
 

--- a/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
+++ b/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
@@ -374,6 +374,7 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
     a_scale_preshuffle: bool = True,
     reorder_workgroups=True,
     group_size_n=32,
+    output_dtype=tkl.f32,
 ):
     """Return a tagged MXFP4 scaled GEMM kernel with preshuffled B and B_scale.
 
@@ -506,7 +507,7 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
         a_scale: tkl.Memory[M, K / 32, A_ADDRESS_SPACE, tkl.i8],
         b: tkl.Memory[N, K / 2, GLOBAL_ADDRESS_SPACE, tkl.i8],
         b_scale: tkl.Memory[N, K / 32, GLOBAL_ADDRESS_SPACE, tkl.i8],
-        c: tkl.Memory[M, N, C_ADDRESS_SPACE, tkl.f32],
+        c: tkl.Memory[M, N, C_ADDRESS_SPACE, output_dtype],
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
@@ -527,6 +528,8 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
             )
             return acc
 
+        if output_dtype == tkl.bf16:
+            repeat = tkw.cast(repeat, tkl.bf16)
         tkw.write(repeat, c)
 
     hyperparams = {

--- a/waveasm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/waveasm/lib/Transforms/TranslateFromMLIR.cpp
@@ -1285,6 +1285,14 @@ convertF32ToBF16ForStore(Value srcData, int64_t numElems,
                          Location loc) {
   Type srcType = srcData.getType();
 
+  // VALU conversion instructions cannot read from AGPR. Move to VGPR first.
+  if (isAGPRType(srcType)) {
+    int64_t size = getRegSize(srcType);
+    auto vregType = ctx.createVRegType(size, size > 1 ? size : 1);
+    srcData = V_ACCVGPR_READ_B32::create(builder, loc, vregType, srcData);
+    srcType = srcData.getType();
+  }
+
   auto extractF32Elem = [&](int64_t i) -> Value {
     if (auto pvreg = dyn_cast<PVRegType>(srcType)) {
       int64_t baseIdx = pvreg.getIndex() + i;

--- a/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
@@ -531,14 +531,20 @@ LogicalResult handleArithTruncF(Operation *op, TranslationContext &ctx) {
   if (numElems > 1) {
     ctx.getMapper().mapValue(truncOp.getResult(), *src);
   } else {
+    Value srcVal = *src;
+    // VALU conversion instructions cannot read from AGPR.
+    if (isAGPRType(srcVal.getType())) {
+      auto vregTmp = ctx.createVRegType();
+      srcVal = V_ACCVGPR_READ_B32::create(builder, loc, vregTmp, srcVal);
+    }
     auto vregType = ctx.createVRegType();
     Value result;
     if (srcElemType.isF32() && dstElemType.isBF16()) {
-      result = V_CVT_BF16_F32::create(builder, loc, vregType, *src);
+      result = V_CVT_BF16_F32::create(builder, loc, vregType, srcVal);
     } else if (srcElemType.isF32() && dstElemType.isF16()) {
-      result = V_CVT_F16_F32::create(builder, loc, vregType, *src);
+      result = V_CVT_F16_F32::create(builder, loc, vregType, srcVal);
     } else {
-      result = V_MOV_B32::create(builder, loc, vregType, *src);
+      result = V_MOV_B32::create(builder, loc, vregType, srcVal);
     }
     ctx.getMapper().mapValue(truncOp.getResult(), result);
   }
@@ -558,15 +564,22 @@ LogicalResult handleArithExtF(Operation *op, TranslationContext &ctx) {
   Type srcElemType = getElementTypeOrSelf(extOp.getIn().getType());
   Type dstElemType = getElementTypeOrSelf(extOp.getResult().getType());
 
+  Value srcVal = *src;
+  // VALU conversion instructions cannot read from AGPR.
+  if (isAGPRType(srcVal.getType())) {
+    auto vregTmp = ctx.createVRegType();
+    srcVal = V_ACCVGPR_READ_B32::create(builder, loc, vregTmp, srcVal);
+  }
+
   auto vregType = ctx.createVRegType();
   Value result;
 
   if (srcElemType.isBF16() && dstElemType.isF32()) {
-    result = V_CVT_F32_BF16::create(builder, loc, vregType, *src);
+    result = V_CVT_F32_BF16::create(builder, loc, vregType, srcVal);
   } else if (srcElemType.isF16() && dstElemType.isF32()) {
-    result = V_CVT_F32_F16::create(builder, loc, vregType, *src);
+    result = V_CVT_F32_F16::create(builder, loc, vregType, srcVal);
   } else {
-    result = V_MOV_B32::create(builder, loc, vregType, *src);
+    result = V_MOV_B32::create(builder, loc, vregType, srcVal);
   }
 
   ctx.getMapper().mapValue(extOp.getResult(), result);

--- a/waveasm/test/Transforms/agpr-bf16-store.mlir
+++ b/waveasm/test/Transforms/agpr-bf16-store.mlir
@@ -1,0 +1,74 @@
+// RUN: waveasm-translate --target=gfx950 --waveasm-linear-scan --emit-assembly %s 2>&1 | FileCheck %s
+//
+// Test: bf16 store from AGPR accumulator inserts v_accvgpr_read_b32.
+//
+// On gfx950, MFMA accumulators live in AGPRs. When the loop result is
+// truncated to bf16 (arith.truncf) and stored to a bf16 memref, the
+// translation must move the data from AGPR to VGPR via v_accvgpr_read_b32
+// before the v_cvt_pk_bf16_f32 conversion, since VALU instructions cannot
+// read AGPRs directly.
+//
+// This test verifies the epilogue sequence:
+//   1. v_accvgpr_read_b32 (AGPR -> VGPR)
+//   2. v_cvt_pk_bf16_f32  (f32 pair -> packed bf16)
+//   3. buffer_store         (write packed bf16 to global memory)
+
+module {
+  gpu.module @test_agpr_bf16_store {
+
+    // CHECK-LABEL: agpr_bf16_store:
+    gpu.func @agpr_bf16_store(
+        %out: memref<1024xbf16> {llvm.noalias},
+        %tidx: index {llvm.mlir.workitem_id_x}
+    ) kernel {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c3 = arith.constant 3 : index
+
+      %data_buf = memref.alloc() : memref<16x128xi8, 3>
+      %scale_buf = memref.alloc() : memref<16x8xi8, 3>
+
+      %acc_init = arith.constant dense<0.0> : vector<4xf32>
+
+      // Loop with scaled MFMA — accumulator lives in AGPRs on gfx950.
+      // CHECK: v_mfma_scale_f32_16x16x128_f8f6f4 a[{{.*}}]
+      %result = scf.for %i = %c0 to %c3 step %c1
+          iter_args(%acc = %acc_init) -> (vector<4xf32>) {
+
+        %raw_a = vector.load %data_buf[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %a = "vector.bitcast"(%raw_a) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        %raw_b = vector.load %data_buf[%tidx, %c0] : memref<16x128xi8, 3>, vector<16xi8>
+        %b = "vector.bitcast"(%raw_b) : (vector<16xi8>) -> vector<32xf4E2M1FN>
+
+        %raw_sa = vector.load %scale_buf[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %svec_a = "vector.bitcast"(%raw_sa) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %sa = "vector.extract"(%svec_a) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        %raw_sb = vector.load %scale_buf[%tidx, %c0] : memref<16x8xi8, 3>, vector<1xi8>
+        %svec_b = "vector.bitcast"(%raw_sb) : (vector<1xi8>) -> vector<1xf8E8M0FNU>
+        %sb = "vector.extract"(%svec_b) <{static_position = array<i64: 0>}> : (vector<1xf8E8M0FNU>) -> f8E8M0FNU
+
+        %new_acc = "amdgpu.scaled_mfma"(%a, %b, %acc, %sa, %sb) <{
+          k = 128 : i32, m = 16 : i32, n = 16 : i32,
+          scalesIdxA = 0 : i32, scalesIdxB = 0 : i32
+        }> : (vector<32xf4E2M1FN>, vector<32xf4E2M1FN>, vector<4xf32>, f8E8M0FNU, f8E8M0FNU) -> vector<4xf32>
+
+        scf.yield %new_acc : vector<4xf32>
+      }
+
+      // Epilogue: truncate f32 accumulator to bf16 and store.
+      // The AGPR data must be moved to VGPR before the VALU bf16 conversion.
+      %bf16_result = arith.truncf %result : vector<4xf32> to vector<4xbf16>
+
+      // CHECK: v_accvgpr_read_b32 v[{{[0-9]+}}:{{[0-9]+}}], a[{{[0-9]+}}:{{[0-9]+}}]
+      // CHECK: v_cvt_pk_bf16_f32 v{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+      // CHECK: v_cvt_pk_bf16_f32 v{{[0-9]+}}, v{{[0-9]+}}, v{{[0-9]+}}
+      // CHECK: buffer_store_dwordx2
+      vector.store %bf16_result, %out[%tidx] : memref<1024xbf16>, vector<4xbf16>
+
+      // CHECK: s_endpgm
+      gpu.return
+    }
+  }
+}


### PR DESCRIPTION
VALU conversion instructions (v_cvt_pk_bf16_f32, v_cvt_f32_bf16, etc.) cannot read from AGPRs. When MFMA accumulators in AGPRs are truncated to bf16 for storage, the translation must first move data to VGPRs via v_accvgpr_read_b32.

- Fix get_tagged_mxfp4_gemm_preshuffle_b to use output_dtype for the output memory type (was hardcoded to f32), and add the bf16 cast when output_dtype is bf16.
- Fix convertF32ToBF16ForStore to insert v_accvgpr_read_b32 when the source data is in AGPRs before extracting elements for bf16 packing.
- Fix handleArithTruncF/ExtF to insert v_accvgpr_read_b32 before scalar VALU type-conversion instructions when the source is an AGPR.
- Add output_dtype parameter to _run_mxfp_gemm_preshuffle and the test_dbuf_4wave_mxfp_preshuffle_b_gemm_cpp test.
- Add output_dtype parametrize (f32/bf16) to the e2e test test_dbuf_4wave_mxfp4_gemm_cpp_backend.
- Add lit test agpr-bf16-store.mlir verifying the AGPR->VGPR->bf16->store sequence on gfx950.