### PR TITLE
[asm] Fix _gemm_mma_type_params returning None on non-CDNA4 architect…

### DIFF
--- a/tests/kernel/wave/asm/test_waveasm_e2e.py
+++ b/tests/kernel/wave/asm/test_waveasm_e2e.py
@@ -570,7 +570,7 @@ def _gemm_mma_type_params():
     ]
     if is_cdna4():
         params.append(pytest.param(tkw.MMAType.F32_16x16x32_F16, id="16x16x32"))
-        return params
+    return params
 
 
 def _global_to_shared_params():


### PR DESCRIPTION
…ures

The return statement was incorrectly indented inside the if is_cdna4() block, causing the function to return None on gfx942 and other non-CDNA4 GPUs. This broke test collection with TypeError: 'NoneType' object is not iterable.