### PR TITLE
fix torch specs in requirements files

### DIFF
--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -29,7 +29,7 @@ from urllib.request import Request, urlopen
 PYTORCH_INDEX = "https://download.pytorch.org/whl/rocm{ver}"
 AMD_FIND_LINKS = "https://repo.radeon.com/rocm/manylinux/rocm-rel-{ver}/"
 
-TORCH_SPEC = "torch>=2.6"
+TORCH_SPEC = "torch>=2.6,<2.10"
 
 # ---------------------------------------------------------------------------
 # ROCm version detection

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<2.9
+torch>=2.6,<2.10

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/rocm6.4
-torch>=2.6,<2.9
+torch>=2.6,<2.10


### PR DESCRIPTION
The requirements files had "<2.9", but our pyproject.yaml has "<2.10". Also, as an oversight the gen-pytorch-rocm-requirements.py script omitted an upper bound, this adds one at <2.10.