### PR TITLE
[water] Add BitcastOp and Scaled Dimensions

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveAttrs.td
+++ b/water/include/water/Dialect/Wave/IR/WaveAttrs.td
@@ -495,12 +495,25 @@ def WaveHyperparameterAttr : AttrDef<WaveDialect, "WaveHyperparameter"> {
   let mnemonic = "hyperparameters";
   let description = [{
     This attribute contains a dictionary mapping from symbol parameters (strings)
-    to their concrete integer values. It is used to resolve symbolic shapes
-    in wave.tensor types when converting to memref or vector types.
+    to either concrete integer values or affine expressions over other symbols.
+    It is used to resolve symbolic shapes in wave.tensor types when converting
+    to memref or vector types.
+
+    Values can be:
+    - `IntegerAttr`: a concrete integer value for a base symbol.
+    - `WaveExprListAttr`: an affine expression over other symbols defined in
+      the same mapping, for derived symbols.  The expression must be a
+      single-result affine map whose sole result is a `ceildiv` of a symbol
+      by an integer constant.  All symbols referenced by the expression must
+      be defined in the same mapping, and the dividend must be evenly
+      divisible by the divisor after resolving all symbols to their concrete
+      values.
 
     Example:
     ```
-    #wave.hyperparameters<{B = 64, H = 128, W = 256}>
+    #wave.hyperparameters<{M = 16 : i64, K = 128 : i64,
+      K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>,
+      K32 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 32)>}>
     ```
   }];
 
@@ -508,8 +521,15 @@ def WaveHyperparameterAttr : AttrDef<WaveDialect, "WaveHyperparameter"> {
   let assemblyFormat = "`<` $mapping `>`";
 
   let extraClassDeclaration = [{
-    /// Get the concrete value for a symbol name, returns std::nullopt if not found
+    /// Get the concrete value for a symbol name, returns std::nullopt if not
+    /// found. For derived symbols (WaveExprListAttr values), the expression is
+    /// evaluated by recursively resolving the referenced symbols.
     std::optional<int64_t> getSymbolValue(::llvm::StringRef symbolName) const;
+
+    /// Like getSymbolValue, but asserts that the symbol exists and can be
+    /// resolved.  Use when the caller has already verified the symbol is
+    /// present.
+    int64_t getKnownSymbolValue(::llvm::StringRef symbolName) const;
 
     /// Check if a symbol exists in the mapping
     bool hasSymbol(::llvm::StringRef symbolName) const;

--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -744,6 +744,48 @@ def CastOp : WaveOp<"cast", [
   let hasVerifier = 1;
 }
 
+def BitcastOp : WaveOp<"bitcast", [
+    DeclareOpInterfaceMethods<WaveElementsPerThreadOpInterface>,
+    DeclareOpInterfaceMethods<WaveInferIndexExprsOpInterface>]> {
+  let summary = "Reinterpret the bits of a register-resident tensor as a different type";
+  let description = [{
+    Reinterprets the raw bits of a register-resident tensor to a different
+    element type without changing the data. Exactly one dimension of the
+    result is scaled by the ratio of source-to-destination element bitwidths.
+
+    For example, bitcasting a tensor with i8 elements to f4E2M1FN doubles
+    the scaled dimension (8/4 = 2), while bitcasting to f8E8M0FNU preserves
+    it (8/8 = 1).
+
+    The scaled dimension is detected automatically: when hyperparameters are
+    available, it is the dimension whose symbol maps to a `WaveExprListAttr`
+    (a derived expression) rather than a plain integer.  Otherwise the
+    verifier looks for the dimension whose symbol differs between source and
+    result, falling back to the last dimension.
+
+    When both operand and result are fully-specified wave tensors, the
+    verifier enforces:
+
+    - The rank must be non-zero and must match between input and result.
+    - All dimensions except the scaled one must be identical.
+    - The larger element bitwidth must be evenly divisible by the smaller.
+    - When the element bitwidths differ, the scaled dimension must be
+      sized accordingly (it may not remain unchanged).
+  }];
+  let arguments = !con((ins
+    Arg<WaveTensorInRegister, "Value to bitcast">:$value_to_cast
+  ), commonArguments);
+  let results = (outs
+    Res<WaveTensorInRegister, "Bitcast value">:$result
+  );
+
+  let assemblyFormat =
+    "$value_to_cast " # commonArgumentsSyntax # " attr-dict `:`"
+    "qualified(type($value_to_cast)) `to` qualified(type($result))";
+
+  let hasVerifier = 1;
+}
+
 def BroadcastOp : WaveOp<"broadcast", [
     WaveInferTypeOpInterface, NoOpTypeInferenceOpTrait,
     NoOpElementsPerThreadOpTrait,

--- a/water/include/water/Dialect/Wave/IR/WaveUtils.h
+++ b/water/include/water/Dialect/Wave/IR/WaveUtils.h
@@ -69,6 +69,13 @@ void permuteShape(llvm::ArrayRef<wave::WaveSymbolAttr> shape,
                   mlir::AffineMap map, bool inverse,
                   llvm::SmallVectorImpl<wave::WaveSymbolAttr> &permutedShape);
 
+/// Verify that derived hyperparameter symbols (expr_list values) form a DAG.
+/// Returns success if there are no cycles, or emits a diagnostic naming the
+/// cycle participants.
+llvm::LogicalResult verifyHyperparameterAcyclicity(
+    wave::WaveHyperparameterAttr hyperparams, mlir::MLIRContext *ctx,
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError);
+
 } // namespace wave
 
 namespace llvm {

--- a/water/lib/CAPI/Dialects.cpp
+++ b/water/lib/CAPI/Dialects.cpp
@@ -258,9 +258,10 @@ MlirAttribute mlirWaveHyperparameterAttrGet(MlirAttribute mapping) {
 
   assert(llvm::all_of(dictAttr,
                       [](const NamedAttribute &namedAttr) {
-                        return llvm::isa<IntegerAttr>(namedAttr.getValue());
+                        return llvm::isa<IntegerAttr, wave::WaveExprListAttr>(
+                            namedAttr.getValue());
                       }) &&
-         "expected mapping to contain only integer values");
+         "expected mapping to contain only integer or WaveExprListAttr values");
 
   return wrap(wave::WaveHyperparameterAttr::get(ctx, dictAttr));
 }

--- a/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveAttrs.cpp
@@ -486,14 +486,77 @@ WaveIndexMappingAttr WaveIndexMappingAttr::removeInput(Attribute input) const {
 std::optional<int64_t>
 WaveHyperparameterAttr::getSymbolValue(StringRef symbolName) const {
   DictionaryAttr mapping = getMapping();
-  Attribute attr = mapping.get(symbolName);
-  if (!attr)
+  llvm::StringMap<int64_t> resolved;
+
+  // Iterative worklist: each entry is a symbol name still to resolve.
+  // When we pop a name whose dependencies are all resolved we can evaluate
+  // its expression; otherwise we push it back followed by its unresolved
+  // dependencies (topological-sort style).
+  llvm::SmallVector<StringRef> worklist({symbolName});
+
+  while (!worklist.empty()) {
+    StringRef name = worklist.back();
+
+    if (resolved.contains(name)) {
+      worklist.pop_back();
+      continue;
+    }
+
+    Attribute attr = mapping.get(name);
+    if (!attr)
+      return std::nullopt;
+
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+      resolved[name] = intAttr.getInt();
+      worklist.pop_back();
+      continue;
+    }
+
+    auto exprList = cast<WaveExprListAttr>(attr);
+
+    // Push unresolved dependencies so they get processed first.
+    bool pushedDeps = false;
+    for (Attribute symAttr : exprList.getSymbols()) {
+      StringRef dep = cast<WaveSymbolAttr>(symAttr).getName();
+      if (!resolved.contains(dep)) {
+        worklist.push_back(dep);
+        pushedDeps = true;
+      }
+    }
+
+    if (pushedDeps)
+      continue;
+
+    // All deps resolved -- evaluate the affine expression.
+    AffineMap map = exprList.getMap();
+    llvm::SmallVector<AffineExpr> replacements;
+    replacements.reserve(map.getNumSymbols());
+    for (Attribute symAttr : exprList.getSymbols()) {
+      int64_t val = resolved[cast<WaveSymbolAttr>(symAttr).getName()];
+      replacements.push_back(getAffineConstantExpr(val, mapping.getContext()));
+    }
+
+    AffineExpr result = map.getResult(0).replaceSymbols(replacements);
+    result = simplifyAffineExpr(result, map.getNumDims(), map.getNumSymbols());
+    auto constExpr = dyn_cast<AffineConstantExpr>(result);
+    if (!constExpr)
+      return std::nullopt;
+
+    resolved[name] = constExpr.getValue();
+    worklist.pop_back();
+  }
+
+  auto it = resolved.find(symbolName);
+  if (it == resolved.end())
     return std::nullopt;
+  return it->second;
+}
 
-  if (auto intAttr = dyn_cast<IntegerAttr>(attr))
-    return intAttr.getInt();
-
-  return std::nullopt;
+int64_t
+WaveHyperparameterAttr::getKnownSymbolValue(StringRef symbolName) const {
+  std::optional<int64_t> value = getSymbolValue(symbolName);
+  assert(value && "expected symbol to exist and be resolvable");
+  return *value;
 }
 
 bool WaveHyperparameterAttr::hasSymbol(StringRef symbolName) const {

--- a/water/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "water/Dialect/Wave/IR/WaveDialect.h"
+#include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "water/Dialect/Wave/IR/WaveAttrs.h"
@@ -21,6 +22,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/LogicalResult.h"
+#include <cstdint>
 #include <optional>
 
 using namespace mlir;
@@ -409,6 +411,90 @@ wave::WaveDialect::verifyOperationAttribute(Operation *op,
             << "defines hyperparameters when its ancestor already had";
         diag.attachNote(parent->getLoc()) << "ancestor";
         return diag;
+      }
+    }
+
+    // Verify expr_list values in the hyperparameters: each value must be an
+    // integer or a valid expr_list, and all referenced symbols must exist as
+    // entries in the same mapping.
+    for (const NamedAttribute &entry : hyperparams.getMapping()) {
+      if (llvm::isa<IntegerAttr>(entry.getValue()))
+        continue;
+
+      wave::WaveExprListAttr exprList =
+          llvm::dyn_cast<wave::WaveExprListAttr>(entry.getValue());
+      if (!exprList)
+        return op->emitError() << "hyperparameter " << entry.getName()
+                               << " must either be an integer or an expr_list";
+
+      // Each expr_list must be a single-result affine map.
+      if (exprList.getMap().getNumResults() != 1) {
+        return op->emitError()
+               << "hyperparameter " << entry.getName()
+               << " must be a single-result expr_list, but has "
+               << exprList.getMap().getNumResults() << " results";
+      }
+      for (Attribute symAttr : exprList.getSymbols()) {
+        wave::WaveSymbolAttr waveSym =
+            llvm::dyn_cast<wave::WaveSymbolAttr>(symAttr);
+        if (!waveSym) {
+          return op->emitError()
+                 << "hyperparameter " << entry.getName()
+                 << " expr_list may only contain wave symbols: " << symAttr;
+        }
+        usedSymbols.insert(waveSym.getName());
+        if (!hyperparams.getMapping().contains(waveSym.getName())) {
+          return op->emitError()
+                 << "hyperparameter " << entry.getName()
+                 << " references symbol " << waveSym
+                 << " not defined in the same hyperparameters mapping";
+        }
+      }
+    }
+
+    // Verify that derived symbols do not form cycles.
+    if (llvm::failed(wave::verifyHyperparameterAcyclicity(
+            hyperparams, op->getContext(), [&]() { return op->emitError(); })))
+      return llvm::failure();
+
+    for (const NamedAttribute &entry : hyperparams.getMapping()) {
+      wave::WaveExprListAttr exprList =
+          llvm::dyn_cast<wave::WaveExprListAttr>(entry.getValue());
+      if (!exprList)
+        continue;
+
+      AffineExpr result = exprList.getMap().getResult(0);
+
+      // The sole expression must be a ceiling division of a symbol by a
+      // constant.
+      AffineBinaryOpExpr divExpr = llvm::dyn_cast<AffineBinaryOpExpr>(result);
+      if (!divExpr || divExpr.getKind() != AffineExprKind::CeilDiv) {
+        return op->emitError()
+               << "hyperparameter " << entry.getName()
+               << " expr_list must be a ceiling division expression";
+      }
+      if (!llvm::isa<AffineSymbolExpr>(divExpr.getLHS())) {
+        return op->emitError() << "hyperparameter " << entry.getName()
+                               << " expr_list dividend must be a symbol";
+      }
+      if (!llvm::isa<AffineConstantExpr>(divExpr.getRHS())) {
+        return op->emitError() << "hyperparameter " << entry.getName()
+                               << " expr_list divisor must be a constant";
+      }
+
+      Attribute symAttr = exprList.getSymbols().back();
+      StringRef dep = llvm::cast<wave::WaveSymbolAttr>(symAttr).getName();
+      int64_t lhs = hyperparams.getKnownSymbolValue(dep);
+
+      AffineExpr rhsExpr = divExpr.getRHS();
+      int64_t rhs = llvm::cast<AffineConstantExpr>(rhsExpr).getValue();
+
+      // The dividend must be evenly divisible by the divisor.
+      if (rhs != 0 && lhs % rhs != 0) {
+        return op->emitError()
+               << "hyperparameter " << entry.getName() << " has dividend ("
+               << lhs << ") that is not evenly divisible by the divisor ("
+               << rhs << ")";
       }
     }
 

--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -2613,6 +2613,358 @@ LogicalResult wave::CastOp::verify() {
   return success();
 }
 
+/// Return true if the hyperparameter for \p sym is a WaveExprListAttr.
+static bool isExprListDim(DictionaryAttr mapping, wave::WaveSymbolAttr sym) {
+  Attribute attr = mapping.get(sym.getName());
+  return llvm::isa_and_nonnull<wave::WaveExprListAttr>(attr);
+}
+
+/// Return the indices of all scaled dimensions in a bitcast.  A scaled
+/// dimension is one whose symbol maps to a WaveExprListAttr (a derived
+/// expression) in the hyperparameters rather than a plain IntegerAttr.
+/// Returns an empty vector when no hyperparameters are available or when no
+/// expr_list dimension is found.
+static SmallVector<unsigned> getScaledDimensions(wave::BitcastOp op) {
+  wave::WaveHyperparameterAttr hyper =
+      wave::getHyperparameters(op.getOperation());
+  if (!hyper)
+    return {};
+  auto srcType =
+      llvm::dyn_cast<wave::WaveTensorType>(op.getValueToCast().getType());
+  auto dstType = llvm::dyn_cast<wave::WaveTensorType>(op.getResult().getType());
+  if (!srcType || !dstType)
+    return {};
+  ArrayRef<wave::WaveSymbolAttr> srcShape = srcType.getShape();
+  ArrayRef<wave::WaveSymbolAttr> dstShape = dstType.getShape();
+  assert(srcShape.size() == dstShape.size() &&
+         "bitcast shapes must have equal rank");
+  DictionaryAttr mapping = hyper.getMapping();
+  SmallVector<unsigned> scaledDims;
+  for (unsigned i = 0, e = srcShape.size(); i < e; ++i) {
+    if (isExprListDim(mapping, srcShape[i]) ||
+        isExprListDim(mapping, dstShape[i]))
+      scaledDims.push_back(i);
+  }
+  return scaledDims;
+}
+
+/// Verify that the scaled dimension of a bitcast is consistent with the
+/// element bitwidth ratio.  The caller must have identified a scaled dimension
+/// via getScaledDimensions(), which requires hyperparameters.
+/// \p scaledDim is the dimension index that carries the scaling.
+/// Returns success when the constraint holds.
+static LogicalResult verifyBitcastScaledDim(wave::WaveHyperparameterAttr hyper,
+                                            wave::WaveTensorType srcType,
+                                            wave::WaveTensorType dstType,
+                                            unsigned srcBits, unsigned dstBits,
+                                            unsigned scaledDim,
+                                            llvm::raw_ostream &errs) {
+  unsigned maxBW = std::max(srcBits, dstBits);
+  unsigned minBW = std::min(srcBits, dstBits);
+  if (maxBW % minBW != 0) {
+    errs << "larger element bitwidth (" << maxBW
+         << ") must be evenly divisible by the smaller (" << minBW << ")";
+    return failure();
+  }
+  if (srcBits == dstBits)
+    return success();
+
+  int64_t srcDimVal =
+      hyper.getKnownSymbolValue(srcType.getShape()[scaledDim].getName());
+  int64_t dstDimVal =
+      hyper.getKnownSymbolValue(dstType.getShape()[scaledDim].getName());
+  if (srcDimVal * srcBits != dstDimVal * dstBits) {
+    errs << "bitcast scaled dimension #" << scaledDim << " mismatch: source ("
+         << srcDimVal << ") * " << srcBits << " bits != result (" << dstDimVal
+         << ") * " << dstBits << " bits";
+    return failure();
+  }
+  return success();
+}
+
+//-----------------------------------------------------------------------------
+// BitcastOp
+//-----------------------------------------------------------------------------
+
+LogicalResult wave::BitcastOp::verify() {
+  Type valueType = getValueToCast().getType();
+  Type resultType = getResult().getType();
+
+  wave::WaveTensorType valueTensor =
+      llvm::dyn_cast<wave::WaveTensorType>(valueType);
+  wave::WaveTensorType resultTensor =
+      llvm::dyn_cast<wave::WaveTensorType>(resultType);
+
+  if (valueTensor && resultTensor && valueTensor.getFullySpecified() &&
+      resultTensor.getFullySpecified()) {
+    size_t rank = valueTensor.getRank();
+    if (rank == 0)
+      return emitOpError("rank-0 wave tensors are not supported in bitcast");
+
+    if (rank != resultTensor.getRank())
+      return emitOpError("rank of input (")
+             << rank << ") must match rank of result ("
+             << resultTensor.getRank() << ")";
+
+    unsigned srcBW = valueTensor.getElementType().getIntOrFloatBitWidth();
+    unsigned dstBW = resultTensor.getElementType().getIntOrFloatBitWidth();
+
+    // Detect which dimension is scaled.  The scaled dimension is the one
+    // backed by a WaveExprListAttr in the hyperparameters.
+    SmallVector<unsigned> scaledDims = getScaledDimensions(*this);
+    if (scaledDims.size() > 1)
+      return emitOpError("expected at most one scaled dimension (backed by "
+                         "an expr_list hyperparameter), but found ")
+             << scaledDims.size();
+    std::optional<unsigned> scaledDim =
+        scaledDims.empty() ? std::nullopt : std::optional(scaledDims[0]);
+
+    // Verify that all non-scaled dimensions match.
+    SmallVector<int> srcNonScaled, dstNonScaled;
+    for (unsigned i = 0; i < rank; ++i) {
+      if (scaledDim && i == *scaledDim)
+        continue;
+      srcNonScaled.push_back(i);
+      dstNonScaled.push_back(i);
+    }
+    if (failed(wave::detail::verifyTypesMatchingDimensions(
+            getLoc(), "input", valueTensor, srcNonScaled, "result",
+            resultTensor, dstNonScaled)))
+      return failure();
+
+    if (scaledDim) {
+      std::string errMsg;
+      llvm::raw_string_ostream errStream(errMsg);
+      wave::WaveHyperparameterAttr hyper =
+          wave::getHyperparameters(getOperation());
+      if (failed(verifyBitcastScaledDim(hyper, valueTensor, resultTensor, srcBW,
+                                        dstBW, *scaledDim, errStream)))
+        return emitOpError(errMsg);
+    } else if (srcBW != dstBW) {
+      return emitOpError("element bitwidths differ (")
+             << srcBW << " vs " << dstBW
+             << ") but no scaled dimension was found";
+    }
+
+    return success();
+  }
+
+  VectorType valueVec = llvm::dyn_cast<VectorType>(valueType);
+  VectorType resultVec = llvm::dyn_cast<VectorType>(resultType);
+  if (valueVec && resultVec) {
+    unsigned srcBitWidth = valueVec.getElementType().getIntOrFloatBitWidth();
+    unsigned dstBitWidth = resultVec.getElementType().getIntOrFloatBitWidth();
+    unsigned maxBW = std::max(srcBitWidth, dstBitWidth);
+    unsigned minBW = std::min(srcBitWidth, dstBitWidth);
+    if (maxBW % minBW != 0)
+      return emitOpError("larger element bitwidth (")
+             << maxBW << ") must be evenly divisible by the smaller (" << minBW
+             << ")";
+    int64_t srcElements = valueVec.getNumElements();
+    int64_t dstElements = resultVec.getNumElements();
+    if (srcElements * srcBitWidth != dstElements * dstBitWidth)
+      return emitOpError("total bit count must be preserved");
+  }
+
+  return success();
+}
+
+// Remap the index expression lattice for bitcast: non-scaled dimensions pass
+// through as identity, and the scaled dimension gets its symbol renamed and its
+// step (and start/stride if present) scaled by the element bitwidth ratio.
+// \p scaledDim is the index of the dimension that carries the scaling.
+static IndexExprsLatticeStorage
+scaleBitcastIndexExprs(const IndexExprsLatticeStorage &inputLattice,
+                       ArrayRef<wave::WaveSymbolAttr> fromShape,
+                       ArrayRef<wave::WaveSymbolAttr> toShape,
+                       unsigned fromBits, unsigned toBits, unsigned scaledDim,
+                       MLIRContext *ctx) {
+  if (inputLattice.isBottom() || inputLattice.isTop())
+    return inputLattice;
+
+  assert(fromShape.size() == toShape.size() &&
+         "bitcast shapes must have equal rank");
+
+  DictionaryAttr inputDict = inputLattice.getConcreteValue();
+
+  unsigned ratio =
+      (fromBits > toBits) ? (fromBits / toBits) : (toBits / fromBits);
+  bool scaleUp = fromBits > toBits;
+
+  SmallVector<NamedAttribute> newMappings;
+  newMappings.reserve(inputDict.size());
+
+  WaveSymbolAttr fromScaledSym = fromShape[scaledDim];
+  WaveSymbolAttr toScaledSym = toShape[scaledDim];
+
+  for (NamedAttribute namedAttr : inputDict) {
+    StringRef symName = namedAttr.getName().getValue();
+    auto mapping = llvm::cast<WaveIndexMappingAttr>(namedAttr.getValue());
+
+    // Non-scaled dimensions: pass through unchanged.
+    if (symName != fromScaledSym.getName()) {
+      newMappings.push_back(namedAttr);
+      continue;
+    }
+
+    // Scaled dimension: rename the symbol key and scale the step by the
+    // bitwidth ratio.  If the step has no thread dimensions (thread-independent
+    // initialization), skip this lattice to avoid producing a zero-step mapping
+    // that would conflict with a real propagated value.
+    AffineMap stepMap = mapping.getStep();
+    if (!stepMap || (stepMap.getNumDims() == 0 && stepMap.getNumSymbols() == 0))
+      return IndexExprsLatticeStorage::bottom();
+
+    auto scaleMap = [&](AffineMap map) -> AffineMap {
+      AffineExpr scaled =
+          scaleUp ? map.getResult(0) * ratio : map.getResult(0).floorDiv(ratio);
+      return AffineMap::get(map.getNumDims(), map.getNumSymbols(), scaled, ctx);
+    };
+
+    AffineMap newStep = scaleMap(stepMap);
+    auto newMapping =
+        WaveIndexMappingAttr::get(ctx, mapping.getSymbols(), mapping.getStart(),
+                                  newStep, mapping.getStride());
+
+    newMappings.push_back(NamedAttribute(
+        StringAttr::get(ctx, toScaledSym.getName()), newMapping));
+  }
+
+  if (newMappings.empty())
+    return IndexExprsLatticeStorage::bottom();
+
+  return IndexExprsLatticeStorage(DictionaryAttr::get(ctx, newMappings),
+                                  inputLattice.getPriorities(),
+                                  inputLattice.getVectorShape());
+}
+
+// Shared propagation logic for BitcastOp index expressions in both directions.
+// \p fromExprs is the source lattice, \p toExprs is the destination to update.
+// \p fromType / \p toType are the wave tensor types on the respective sides.
+// \p fromBits / \p toBits are the element bitwidths on the respective sides.
+static llvm::FailureOr<ChangeResult> propagateBitcastIndexExprs(
+    wave::BitcastOp op, llvm::ArrayRef<IndexExprsLatticeStorage> fromExprs,
+    llvm::MutableArrayRef<IndexExprsLatticeStorage> toExprs,
+    WaveTensorType fromType, WaveTensorType toType, unsigned fromBits,
+    unsigned toBits, StringRef fromName, StringRef toName, mlir::Value toValue,
+    wave::EmitErrorFn emitError) {
+  if (!fromType || !fromType.getFullySpecified() || !toType ||
+      !toType.getFullySpecified())
+    return ChangeResult::NoChange;
+
+  if (fromBits == toBits)
+    return wave::detail::identityIndexExprsPropagate(
+        fromExprs, toExprs, toValue, fromName, toName, emitError);
+
+  // Detect which dimension is scaled using the hyperparameters.
+  SmallVector<unsigned> scaledDims = getScaledDimensions(op);
+  std::optional<unsigned> scaledDim =
+      scaledDims.empty() ? std::nullopt : std::optional(scaledDims[0]);
+
+  if (!scaledDim) {
+    InFlightDiagnostic diag = emitError()
+                              << "could not determine scaled dimension for "
+                                 "BitcastOp with differing bitwidths";
+    return diag;
+  }
+
+  IndexExprsLatticeStorage scaled = scaleBitcastIndexExprs(
+      fromExprs[0], fromType.getShape(), toType.getShape(), fromBits, toBits,
+      *scaledDim, op.getContext());
+
+  IndexExprsLatticeStorage newLattice =
+      IndexExprsLatticeStorage::join(toExprs[0], scaled);
+
+  if (newLattice.isTop() && !toExprs[0].isTop() && !scaled.isTop()) {
+    InFlightDiagnostic diag = emitError()
+                              << "conflict when propagating " << fromName
+                              << " to " << toName << " lattice in BitcastOp";
+    diag.attachNote() << toName << " lattice: " << toExprs[0];
+    diag.attachNote() << fromName << " lattice: " << fromExprs[0];
+    return diag;
+  }
+
+  return updateIfChanged(toExprs[0], newLattice);
+}
+
+llvm::FailureOr<ChangeResult> wave::BitcastOp::propagateIndexExprsForward(
+    llvm::ArrayRef<wave::IndexExprsLatticeStorage> operandExprs,
+    llvm::MutableArrayRef<wave::IndexExprsLatticeStorage> resultExprs,
+    wave::EmitErrorFn emitError) {
+  WaveTensorType inputType =
+      llvm::dyn_cast<WaveTensorType>(getValueToCast().getType());
+  WaveTensorType resultType =
+      llvm::dyn_cast<WaveTensorType>(getResult().getType());
+  unsigned srcBits =
+      wave::getElementType(getValueToCast().getType()).getIntOrFloatBitWidth();
+  unsigned dstBits =
+      wave::getElementType(getResult().getType()).getIntOrFloatBitWidth();
+  return propagateBitcastIndexExprs(*this, operandExprs, resultExprs, inputType,
+                                    resultType, srcBits, dstBits, "operand",
+                                    "result", getResult(), emitError);
+}
+
+llvm::FailureOr<ChangeResult> wave::BitcastOp::propagateIndexExprsBackward(
+    llvm::MutableArrayRef<wave::IndexExprsLatticeStorage> operandExprs,
+    llvm::ArrayRef<wave::IndexExprsLatticeStorage> resultExprs,
+    wave::EmitErrorFn emitError) {
+  WaveTensorType inputType =
+      llvm::dyn_cast<WaveTensorType>(getValueToCast().getType());
+  WaveTensorType resultType =
+      llvm::dyn_cast<WaveTensorType>(getResult().getType());
+  unsigned srcBits =
+      wave::getElementType(getValueToCast().getType()).getIntOrFloatBitWidth();
+  unsigned dstBits =
+      wave::getElementType(getResult().getType()).getIntOrFloatBitWidth();
+  return propagateBitcastIndexExprs(
+      *this, resultExprs, operandExprs, resultType, inputType, dstBits, srcBits,
+      "result", "operand", getValueToCast(), emitError);
+}
+
+llvm::FailureOr<mlir::ChangeResult>
+wave::BitcastOp::propagateElementsPerThreadForward(
+    llvm::ArrayRef<wave::ElementsPerThreadLatticeValue> operandElements,
+    llvm::MutableArrayRef<wave::ElementsPerThreadLatticeValue> resultElements,
+    llvm::raw_ostream &errs, const wave::ElementsPerThreadInit &) {
+  if (operandElements[getValueToCastMutable().getOperandNumber()].isBottom())
+    return ChangeResult::NoChange;
+
+  Type srcElemType = wave::getElementType(getValueToCast().getType());
+  Type dstElemType = wave::getElementType(getResult().getType());
+  unsigned srcBitWidth = srcElemType.getIntOrFloatBitWidth();
+  unsigned dstBitWidth = dstElemType.getIntOrFloatBitWidth();
+
+  unsigned srcEpt = operandElements[0].getValue();
+  unsigned dstEpt = srcEpt * srcBitWidth / dstBitWidth;
+
+  wave::ElementsPerThreadLatticeValue expected(dstEpt);
+  return wave::detail::checkAndPropagateElementsPerThreadFromConstant(
+      expected, llvm::ArrayRef<wave::ElementsPerThreadLatticeValue>(),
+      resultElements, "computed from bitcast ratio", "", "result", errs);
+}
+
+llvm::FailureOr<mlir::ChangeResult>
+wave::BitcastOp::propagateElementsPerThreadBackward(
+    llvm::MutableArrayRef<wave::ElementsPerThreadLatticeValue> operandElements,
+    llvm::ArrayRef<wave::ElementsPerThreadLatticeValue> resultElements,
+    llvm::raw_ostream &errs, const wave::ElementsPerThreadInit &) {
+  if (resultElements[0].isBottom())
+    return ChangeResult::NoChange;
+
+  Type srcElemType = wave::getElementType(getValueToCast().getType());
+  Type dstElemType = wave::getElementType(getResult().getType());
+  unsigned srcBitWidth = srcElemType.getIntOrFloatBitWidth();
+  unsigned dstBitWidth = dstElemType.getIntOrFloatBitWidth();
+
+  unsigned dstEpt = resultElements[0].getValue();
+  unsigned srcEpt = dstEpt * dstBitWidth / srcBitWidth;
+
+  wave::ElementsPerThreadLatticeValue expected(srcEpt);
+  return wave::detail::checkAndPropagateElementsPerThreadFromConstant(
+      expected, llvm::ArrayRef<wave::ElementsPerThreadLatticeValue>(),
+      operandElements, "computed from bitcast ratio", "", "input", errs);
+}
+
 //-----------------------------------------------------------------------------
 // ReciprocalOp
 //-----------------------------------------------------------------------------

--- a/water/lib/Dialect/Wave/IR/WaveUtils.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveUtils.cpp
@@ -13,9 +13,13 @@
 #include "mlir/IR/Dialect.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/iterator.h"
 #include "llvm/Support/Casting.h"
 #include <optional>
 
@@ -172,4 +176,118 @@ LogicalResult wave::computeWavesPerBlockFromConstraints(
   }
 
   return success();
+}
+
+/// Dependency graph over hyperparameter symbols used for cycle detection via
+/// scc_iterator.  A synthetic root node (null symbol) fans out to every
+/// expr_list entry so that a single traversal covers all components.
+struct HyperparamDepGraph {
+  /// Adjacency list: symbol -> symbols it depends on.
+  llvm::DenseMap<wave::WaveSymbolAttr, llvm::SmallVector<wave::WaveSymbolAttr>>
+      deps;
+  /// All expr_list symbols, also the edge list of the synthetic root.
+  llvm::SmallVector<wave::WaveSymbolAttr> exprListKeys;
+
+  /// A node carries a back-pointer to the graph so that child_begin/child_end
+  /// can look up the adjacency list without external state.
+  struct Node {
+    const HyperparamDepGraph *graph;
+    wave::WaveSymbolAttr sym;
+    bool operator==(const Node &o) const {
+      return graph == o.graph && sym == o.sym;
+    }
+    bool operator!=(const Node &o) const { return !(*this == o); }
+  };
+
+  Node root() const { return {this, {}}; }
+
+  llvm::ArrayRef<wave::WaveSymbolAttr>
+  children(wave::WaveSymbolAttr sym) const {
+    if (!sym)
+      return exprListKeys;
+    auto it = deps.find(sym);
+    if (it == deps.end())
+      return {};
+    return it->second;
+  }
+};
+
+namespace llvm {
+
+/// Adaptor that wraps a pointer into a WaveSymbolAttr adjacency list and
+/// produces Node values carrying the graph back-pointer.
+struct HyperparamChildIterator
+    : iterator_adaptor_base<
+          HyperparamChildIterator, const wave::WaveSymbolAttr *,
+          std::random_access_iterator_tag, HyperparamDepGraph::Node,
+          std::ptrdiff_t, const HyperparamDepGraph::Node *,
+          HyperparamDepGraph::Node> {
+  const HyperparamDepGraph *graph = nullptr;
+  HyperparamChildIterator() = default;
+  HyperparamChildIterator(const wave::WaveSymbolAttr *it,
+                          const HyperparamDepGraph *g)
+      : iterator_adaptor_base(it), graph(g) {}
+  HyperparamDepGraph::Node operator*() const { return {graph, *I}; }
+};
+
+template <> struct DenseMapInfo<HyperparamDepGraph::Node> {
+  static HyperparamDepGraph::Node getEmptyKey() {
+    return {nullptr, DenseMapInfo<wave::WaveSymbolAttr>::getEmptyKey()};
+  }
+  static HyperparamDepGraph::Node getTombstoneKey() {
+    return {nullptr, DenseMapInfo<wave::WaveSymbolAttr>::getTombstoneKey()};
+  }
+  static unsigned getHashValue(const HyperparamDepGraph::Node &n) {
+    return DenseMapInfo<wave::WaveSymbolAttr>::getHashValue(n.sym);
+  }
+  static bool isEqual(const HyperparamDepGraph::Node &a,
+                      const HyperparamDepGraph::Node &b) {
+    return a.graph == b.graph && a.sym == b.sym;
+  }
+};
+
+template <> struct GraphTraits<const HyperparamDepGraph *> {
+  using NodeRef = HyperparamDepGraph::Node;
+  using ChildIteratorType = HyperparamChildIterator;
+
+  static NodeRef getEntryNode(const HyperparamDepGraph *g) { return g->root(); }
+  static ChildIteratorType child_begin(NodeRef node) {
+    return {node.graph->children(node.sym).begin(), node.graph};
+  }
+  static ChildIteratorType child_end(NodeRef node) {
+    return {node.graph->children(node.sym).end(), node.graph};
+  }
+};
+
+} // namespace llvm
+
+LogicalResult wave::verifyHyperparameterAcyclicity(
+    wave::WaveHyperparameterAttr hyperparams, MLIRContext *ctx,
+    llvm::function_ref<InFlightDiagnostic()> emitError) {
+  HyperparamDepGraph graph;
+  for (const NamedAttribute &entry : hyperparams.getMapping()) {
+    auto exprList = llvm::dyn_cast<wave::WaveExprListAttr>(entry.getValue());
+    if (!exprList)
+      continue;
+    wave::WaveSymbolAttr key =
+        wave::WaveSymbolAttr::get(ctx, entry.getName().getValue());
+    graph.exprListKeys.push_back(key);
+    auto &edges = graph.deps[key];
+    for (Attribute symAttr : exprList.getSymbols())
+      edges.push_back(llvm::cast<wave::WaveSymbolAttr>(symAttr));
+  }
+
+  const HyperparamDepGraph *graphPtr = &graph;
+  for (auto scci = llvm::scc_begin(graphPtr); !scci.isAtEnd(); ++scci) {
+    if (!scci.hasCycle())
+      continue;
+    const auto &scc = *scci;
+    llvm::SmallVector<StringRef> names;
+    for (const HyperparamDepGraph::Node &n : scc)
+      if (n.sym)
+        names.push_back(n.sym.getName());
+    return emitError() << "hyperparameter dependency cycle: "
+                       << llvm::join(names, ", ");
+  }
+  return llvm::success();
 }

--- a/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
+++ b/water/lib/Dialect/Wave/Transforms/LoweringPatterns.cpp
@@ -697,6 +697,35 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+// BitcastOp
+//===----------------------------------------------------------------------===//
+
+class BitcastOpLoweringPattern : public OpConversionPattern<wave::BitcastOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(wave::BitcastOp op, wave::BitcastOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getValueToCast();
+    Type dstType = getTypeConverter()->convertType(op.getResult().getType());
+
+    if (!dstType)
+      return rewriter.notifyMatchFailure(op, "failed to convert result type");
+
+    auto dstVecType = dyn_cast<VectorType>(dstType);
+    if (!dstVecType)
+      return rewriter.notifyMatchFailure(
+          op, "expected vector type for bitcast lowering");
+
+    auto bitcast =
+        vector::BitCastOp::create(rewriter, op.getLoc(), dstVecType, input);
+    rewriter.replaceOp(op, bitcast);
+    return success();
+  }
+};
+
 /// Evaluate a Wave expression list to constant integer values.
 /// Since the Wave dialect verifier ensures expressions contain no symbols,
 /// this only handles pure constant expressions.
@@ -1224,6 +1253,7 @@ void wave::populateWaveMiscellaneousOpsLoweringPatterns(
   patterns.add<
       // clang-format off
       ApplyExprOpLoweringPattern,
+      BitcastOpLoweringPattern,
       BroadcastOpLoweringPattern,
       CastOpLoweringPattern,
       ExtractOpLoweringPattern,

--- a/water/python/WaterExtensionNanobind.cpp
+++ b/water/python/WaterExtensionNanobind.cpp
@@ -313,25 +313,41 @@ struct PyWaveHyperparameterAttr
             }
             std::string symbolName = nb::cast<std::string>(key_handle);
 
-            // Get the value (resolved value)
+            MlirIdentifier ident = mlirIdentifierGet(
+                context->get(),
+                mlirStringRefCreate(symbolName.data(), symbolName.size()));
+
             nb::handle value_handle = item.second;
-            if (!nb::isinstance<nb::int_>(value_handle)) {
-              throw nb::type_error(
-                  "Symbol dictionary value must be an integer");
-            }
-            int64_t resolvedValue;
-            try {
-              resolvedValue = nb::cast<int64_t>(value_handle);
-            } catch (const nb::cast_error &e) {
-              throw nb::value_error("Value is too large for int64_t");
+            MlirAttribute valueAttr;
+            if (nb::isinstance<nb::int_>(value_handle)) {
+              int64_t resolvedValue;
+              try {
+                resolvedValue = nb::cast<int64_t>(value_handle);
+              } catch (const nb::cast_error &e) {
+                throw nb::value_error("Value is too large for int64_t");
+              }
+              valueAttr = mlirIntegerAttrGet(
+                  mlirIntegerTypeGet(context->get(), 64), resolvedValue);
+            } else {
+              try {
+                valueAttr = nb::cast<MlirAttribute>(value_handle);
+              } catch (const nb::cast_error &e) {
+                throw nb::type_error(
+                    "Symbol dictionary value must be an integer or an "
+                    "Attribute (e.g. WaveExprListAttr)");
+              }
+
+              // Only accept IntegerAttr or WaveExprListAttr to avoid
+              // constructing invalid #wave.hyperparameters mappings.
+              if (!mlirAttributeIsAInteger(valueAttr) &&
+                  !mlirAttributeIsAWaveExprListAttr(valueAttr)) {
+                throw nb::type_error(
+                    "Symbol dictionary value must be either an integer, an "
+                    "IntegerAttr, or a WaveExprListAttr");
+              }
             }
 
-            namedAttrs.push_back(mlirNamedAttributeGet(
-                mlirIdentifierGet(
-                    context->get(),
-                    mlirStringRefCreate(symbolName.data(), symbolName.size())),
-                mlirIntegerAttrGet(mlirIntegerTypeGet(context->get(), 64),
-                                   resolvedValue)));
+            namedAttrs.push_back(mlirNamedAttributeGet(ident, valueAttr));
           }
 
           return PyWaveHyperparameterAttr(

--- a/water/test/Dialect/Wave/attr-type-invalid.mlir
+++ b/water/test/Dialect/Wave/attr-type-invalid.mlir
@@ -173,3 +173,58 @@ water_test.wave_symbol_mapping {index_mapping = #wave.symbol_mapping<@M = #wave.
 water_test.wave_symbol_mapping {three_results_mapping = #wave.symbol_mapping<
   @M = #wave.expr_list<[#wave.symbol<"A">] -> (A)>
 >}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" must be a single-result expr_list, but has 2 results}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2, K ceildiv 4)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" expr_list may only contain wave symbols: #wave.index_symbol<T0>}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.index_symbol<T0>] -> (T0 ceildiv 2)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" references symbol #wave.symbol<"Z"> not defined in the same hyperparameters mapping}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.symbol<"Z">] -> (Z ceildiv 2)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" expr_list must be a ceiling division expression}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" expr_list must be a ceiling division expression}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, BLOCK_K = 32 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">, #wave.symbol<"BLOCK_K">] -> (K ceildiv 2 + BLOCK_K ceildiv 4)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" expr_list dividend must be a symbol}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, BLOCK_K = 32 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">, #wave.symbol<"BLOCK_K">] -> ((K + BLOCK_K) ceildiv 2)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" expr_list divisor must be a constant}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, BLOCK_K = 32 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">, #wave.symbol<"BLOCK_K">] -> (K ceildiv BLOCK_K)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter "K2" has dividend (128) that is not evenly divisible by the divisor (3)}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 3)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter dependency cycle: B, A}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{A = #wave.expr_list<[#wave.symbol<"B">] -> (B ceildiv 2)>, B = #wave.expr_list<[#wave.symbol<"A">] -> (A ceildiv 2)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter dependency cycle: Z, Y, X}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{X = #wave.expr_list<[#wave.symbol<"Y">] -> (Y ceildiv 2)>, Y = #wave.expr_list<[#wave.symbol<"Z">] -> (Z ceildiv 2)>, Z = #wave.expr_list<[#wave.symbol<"X">] -> (X ceildiv 2)>}>} {}
+
+// -----
+
+// expected-error @below {{hyperparameter dependency cycle: A}}
+module attributes {wave.hyperparameters = #wave.hyperparameters<{A = #wave.expr_list<[#wave.symbol<"A">] -> (A ceildiv 2)>}>} {}

--- a/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
@@ -1507,6 +1507,45 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
 
 // -----
 
+// Bitcast forward: i8 (8-bit) to f4 (4-bit) doubles the step on the last
+// dimension. Leading dimensions pass through unchanged.
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @bitcast_forward_scales_step
+  func.func @bitcast_forward_scales_step(
+    %src: !wave.tensor<[@M, @K2] of i8, <global>>,
+    %dst: !wave.tensor<[@M, @K] of f4E2M1FN, <global>>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>
+  } {
+    // Inject K2 step=16 on the read result.
+    %data = wave.read %src {wave_test.override_result_index = [[0, {
+        "K2" = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 2, 16, 1)>,
+        M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    }]]} : (!wave.tensor<[@M, @K2] of i8, <global>>) -> !wave.tensor<[@M, @K2] of i8, <register>>
+
+    // After bitcast i8->f4 (8-bit to 4-bit), the K2 step of 16 should become
+    // K step of 32 (doubled). M passes through unchanged.
+    // CHECK: wave.bitcast
+    // CHECK-DAG: K : <[#wave.index_symbol<T0>] -> (T0 * 2, 32, 1)>
+    // CHECK-DAG: M : <[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    %bitcasted = wave.bitcast %data
+      : !wave.tensor<[@M, @K2] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+
+    // CHECK: wave.write
+    // CHECK-DAG: K : <[#wave.index_symbol<T0>] -> (T0 * 2, 32, 1)>
+    // CHECK-DAG: M : <[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    wave.write %bitcasted, %dst
+      : !wave.tensor<[@M, @K] of f4E2M1FN, <register>>, !wave.tensor<[@M, @K] of f4E2M1FN, <global>>
+
+    return
+  }
+}
+
+// -----
+
 // Per-key priority: same priority, same expression for some keys but different
 // for others - the differing key should cause a conflict.
 
@@ -1532,6 +1571,41 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     }]]}
     : (!wave.tensor<[@M, @N] of f32>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return %result : !wave.tensor<[@M, @N] of f32>
+  }
+}
+
+// -----
+
+// Bitcast backward: f4 (4-bit) result index expressions should scale down
+// to i8 (8-bit) operand index expressions (step halved).
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @bitcast_backward_scales_step
+  func.func @bitcast_backward_scales_step(
+    %src: !wave.tensor<[@M, @K2] of i8, <global>>,
+    %dst: !wave.tensor<[@M, @K] of f4E2M1FN, <global>>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>
+  } {
+    // CHECK: wave.read
+    // CHECK-DAG: K2 : <[#wave.index_symbol<T0>] -> (T0 * 2, 16, 1)>
+    // CHECK-DAG: M : <[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    %data = wave.read %src
+      : (!wave.tensor<[@M, @K2] of i8, <global>>) -> !wave.tensor<[@M, @K2] of i8, <register>>
+
+    // Inject K step=32 on the bitcast result. Backward propagation should
+    // produce K2 step=16 (halved) on the read.
+    %bitcasted = wave.bitcast %data {wave_test.override_result_index = [[0, {
+      K = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 2, 32, 1)>,
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    }]]} : !wave.tensor<[@M, @K2] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+
+    wave.write %bitcasted, %dst
+      : !wave.tensor<[@M, @K] of f4E2M1FN, <register>>, !wave.tensor<[@M, @K] of f4E2M1FN, <global>>
+
+    return
   }
 }
 
@@ -1567,6 +1641,73 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     }]]}
     : (!wave.tensor<[@M, @N] of f32>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return %result : !wave.tensor<[@M, @N] of f32>
+  }
+}
+
+// -----
+
+// Bitcast with f4 (4-bit) to i8 (8-bit) halves the step on the last dimension.
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @bitcast_narrow_to_wide_halves_step
+  func.func @bitcast_narrow_to_wide_halves_step(
+    %src: !wave.tensor<[@M, @K] of f4E2M1FN, <global>>,
+    %dst: !wave.tensor<[@M, @K2] of i8, <global>>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>
+  } {
+    %data = wave.read %src {wave_test.override_result_index = [[0, {
+      K = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 2, 32, 1)>,
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    }]]} : (!wave.tensor<[@M, @K] of f4E2M1FN, <global>>) -> !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+
+    // After bitcast f4->i8 (4-bit to 8-bit), the K step of 32 should become
+    // K2 step of 16 (halved). M passes through unchanged.
+    // CHECK: wave.bitcast
+    // CHECK-DAG: K2 : <[#wave.index_symbol<T0>] -> (T0 * 2, 16, 1)>
+    // CHECK-DAG: M : <[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    %bitcasted = wave.bitcast %data
+      : !wave.tensor<[@M, @K] of f4E2M1FN, <register>> to !wave.tensor<[@M, @K2] of i8, <register>>
+
+    wave.write %bitcasted, %dst
+      : !wave.tensor<[@M, @K2] of i8, <register>>, !wave.tensor<[@M, @K2] of i8, <global>>
+
+    return
+  }
+}
+
+// -----
+
+// Bitcast with same bitwidth (i8 to f8E8M0FNU): step is preserved.
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @bitcast_same_bitwidth_identity
+  func.func @bitcast_same_bitwidth_identity(
+    %src: !wave.tensor<[@M, @K] of i8, <global>>,
+    %dst: !wave.tensor<[@M, @K] of f8E8M0FNU, <global>>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128}>
+  } {
+    %data = wave.read %src {wave_test.override_result_index = [[0, {
+      K = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 2, 16, 1)>,
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    }]]} : (!wave.tensor<[@M, @K] of i8, <global>>) -> !wave.tensor<[@M, @K] of i8, <register>>
+
+    // Same bitwidth: step is preserved, symbol name stays K.
+    // CHECK: wave.bitcast
+    // CHECK-DAG: K : <[#wave.index_symbol<T0>] -> (T0 * 2, 16, 1)>
+    // CHECK-DAG: M : <[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+    %bitcasted = wave.bitcast %data
+      : !wave.tensor<[@M, @K] of i8, <register>> to !wave.tensor<[@M, @K] of f8E8M0FNU, <register>>
+
+    wave.write %bitcasted, %dst
+      : !wave.tensor<[@M, @K] of f8E8M0FNU, <register>>, !wave.tensor<[@M, @K] of f8E8M0FNU, <global>>
+
+    return
   }
 }
 

--- a/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
+++ b/water/test/Dialect/Wave/lower-wave-to-mlir.mlir
@@ -1865,3 +1865,35 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     return %0 : vector<4xf32>
   }
 }
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>, #wave.normal_form<index_exprs>, #wave.normal_form<memory_only_types>, #wave.normal_form<resolved_allocations>, #wave.normal_form<ordered_syms>] {
+  // CHECK-LABEL: func.func @lower_bitcast_i8_to_f4
+  func.func @lower_bitcast_i8_to_f4() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
+    %cst_i8 = arith.constant 0 : i8
+    // CHECK: %[[SRC:.*]] = arith.constant dense<0> : vector<16xi8>
+    %src = wave.register %cst_i8 : vector<16xi8>
+
+    // CHECK-NOT: wave.bitcast
+    // CHECK: vector.bitcast %[[SRC]] : vector<16xi8> to vector<32xf4E2M1FN>
+    %res = wave.bitcast %src : vector<16xi8> to vector<32xf4E2M1FN>
+    return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>, #wave.normal_form<index_exprs>, #wave.normal_form<memory_only_types>, #wave.normal_form<resolved_allocations>, #wave.normal_form<ordered_syms>] {
+  // CHECK-LABEL: func.func @lower_bitcast_i8_to_f8e8m0
+  func.func @lower_bitcast_i8_to_f8e8m0() attributes {wave.hyperparameters = #wave.hyperparameters<{}>} {
+    %cst_i8 = arith.constant 0 : i8
+    // CHECK: %[[SRC:.*]] = arith.constant dense<0> : vector<1xi8>
+    %src = wave.register %cst_i8 : vector<1xi8>
+
+    // CHECK-NOT: wave.bitcast
+    // CHECK: vector.bitcast %[[SRC]] : vector<1xi8> to vector<1xf8E8M0FNU>
+    %res = wave.bitcast %src : vector<1xi8> to vector<1xf8E8M0FNU>
+    return
+  }
+}

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -473,6 +473,11 @@ func.func @child_alloc_with_tail_padding() {
 
 // -----
 
+// expected-error @below {{hyperparameter "A" must either be an integer or an expr_list}}
+module attributes { wave.hyperparameters = #wave.hyperparameters<{A = "hello"}> } {}
+
+// -----
+
 module attributes { wave.hyperparameters = #wave.hyperparameters<{}> } {
   // expected-error @below {{defines hyperparameters when its ancestor already had}}
   // expected-note @above {{ancestor}}
@@ -1261,6 +1266,89 @@ func.func @reshape_logical_slice_too_large(%arg0: vector<8xf32>) {
 func.func @extract_index_attr_length_mismatch(%source: !wave.tensor<[@A, @B] of f32>) {
   // expected-error @below {{index attribute length (2) does not match the number of per-value index slots (1)}}
   %0 = wave.extract %source[#wave.expr_list<[] -> (2)>] {index = [{}, {}]} : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@A] of f32>
+  return
+}
+
+// -----
+
+func.func @bitcast_rank0(%v: !wave.tensor<[] of f32, <register>>) {
+  // expected-error @below {{'wave.bitcast' op rank-0 wave tensors are not supported in bitcast}}
+  wave.bitcast %v : !wave.tensor<[] of f32, <register>> to !wave.tensor<[] of i8, <register>>
+  return
+}
+
+// -----
+
+func.func @bitcast_rank_mismatch(%v: !wave.tensor<[@A, @B] of i8, <register>>) {
+  // expected-error @below {{'wave.bitcast' op rank of input (2) must match rank of result (3)}}
+  wave.bitcast %v : !wave.tensor<[@A, @B] of i8, <register>> to !wave.tensor<[@A, @B, @C] of f4E2M1FN, <register>>
+  return
+}
+
+// -----
+
+func.func @bitcast_non_scaled_dim_mismatch(%v: !wave.tensor<[@A, @B] of i8, <register>>) {
+  // No hyperparameters, so no scaled dimension is detected.  All dimensions
+  // are verified as non-scaled and the first mismatch is reported.
+  // expected-error @below {{expected input dimension #0 (#wave.symbol<"A">) to match result dimension #0 (#wave.symbol<"C">)}}
+  wave.bitcast %v : !wave.tensor<[@A, @B] of i8, <register>> to !wave.tensor<[@C, @D] of f4E2M1FN, <register>>
+  return
+}
+
+// -----
+
+func.func @bitcast_indivisible_bitwidths(%v: !wave.tensor<[@A, @B] of i8>)
+    attributes {wave.hyperparameters = #wave.hyperparameters<{A = 16, C = 32, B = #wave.expr_list<[#wave.symbol<"C">] -> (C ceildiv 2)>}>} {
+  // expected-error @below {{larger element bitwidth (8) must be evenly divisible by the smaller (6)}}
+  wave.bitcast %v : !wave.tensor<[@A, @B] of i8> to !wave.tensor<[@A, @C] of f6E2M3FN>
+  return
+}
+
+// -----
+
+func.func @bitcast_vector_total_bits(%v: vector<8xf32>) {
+  // expected-error @below {{'wave.bitcast' op total bit count must be preserved}}
+  wave.bitcast %v : vector<8xf32> to vector<4xf32>
+  return
+}
+
+// -----
+
+func.func @bitcast_vector_indivisible(%v: vector<3xi8>) {
+  // expected-error @below {{'wave.bitcast' op larger element bitwidth (8) must be evenly divisible by the smaller (6)}}
+  wave.bitcast %v : vector<3xi8> to vector<4xf6E2M3FN>
+  return
+}
+
+// -----
+
+func.func @bitcast_hyper_invalid(%v: !wave.tensor<[@M, @N] of i8, <register>>)
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 64, N = 16, K = 16}>} {
+  // All hyperparameters are plain integers, so no scaled dimension is found
+  // and the differing symbol at dim #1 is reported as a non-scaled mismatch.
+  // expected-error @below {{expected input dimension #1 (#wave.symbol<"N">) to match result dimension #1 (#wave.symbol<"K">)}}
+  wave.bitcast %v : !wave.tensor<[@M, @N] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+  return
+}
+
+// -----
+
+func.func @bitcast_no_scaled_dim(%v: !wave.tensor<[@M, @N] of i8, <register>>) {
+  // expected-error @below {{'wave.bitcast' op element bitwidths differ (8 vs 4) but no scaled dimension was found}}
+  wave.bitcast %v : !wave.tensor<[@M, @N] of i8, <register>> to !wave.tensor<[@M, @N] of f4E2M1FN, <register>>
+  return
+}
+
+// -----
+
+func.func @bitcast_multiple_scaled_dims(%v: !wave.tensor<[@M2, @N2] of i8, <register>>)
+    attributes {wave.hyperparameters = #wave.hyperparameters<{
+      M = 64, N = 128,
+      M2 = #wave.expr_list<[#wave.symbol<"M">] -> (M ceildiv 2)>,
+      N2 = #wave.expr_list<[#wave.symbol<"N">] -> (N ceildiv 2)>,
+      K = 32}>} {
+  // expected-error @below {{'wave.bitcast' op expected at most one scaled dimension (backed by an expr_list hyperparameter), but found 2}}
+  wave.bitcast %v : !wave.tensor<[@M2, @N2] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
   return
 }
 

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -24,6 +24,37 @@ func.func @batched_mma(%a: !wave.tensor<[@B, @M, @K] of f16>,
   return %0 : !wave.tensor<[@B, @M, @N] of f32>
 }
 
+// CHECK-LABEL: @bitcast_i8_to_f4
+func.func @bitcast_i8_to_f4(%v: !wave.tensor<[@M, @K2] of i8>) -> !wave.tensor<[@M, @K] of f4E2M1FN>
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>} {
+  // CHECK: wave.bitcast
+  %0 = wave.bitcast %v : !wave.tensor<[@M, @K2] of i8> to !wave.tensor<[@M, @K] of f4E2M1FN>
+  return %0 : !wave.tensor<[@M, @K] of f4E2M1FN>
+}
+
+// CHECK-LABEL: @bitcast_i8_to_f8e8m0
+func.func @bitcast_i8_to_f8e8m0(%v: !wave.tensor<[@M, @K32] of i8>) -> !wave.tensor<[@M, @K32] of f8E8M0FNU> {
+  // CHECK: wave.bitcast
+  %0 = wave.bitcast %v : !wave.tensor<[@M, @K32] of i8> to !wave.tensor<[@M, @K32] of f8E8M0FNU>
+  return %0 : !wave.tensor<[@M, @K32] of f8E8M0FNU>
+}
+
+// CHECK-LABEL: @bitcast_hyper_valid
+func.func @bitcast_hyper_valid(%v: !wave.tensor<[@M, @N] of i8, <register>>) -> !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 64, K = 32, N = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>} {
+  // CHECK: wave.bitcast %{{.*}} : !wave.tensor<[@M, @N] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+  %0 = wave.bitcast %v : !wave.tensor<[@M, @N] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+  return %0 : !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+}
+
+// CHECK-LABEL: @bitcast_non_last_dim_scaled
+func.func @bitcast_non_last_dim_scaled(%v: !wave.tensor<[@K2, @N] of i8, <register>>) -> !wave.tensor<[@K, @N] of f4E2M1FN, <register>>
+    attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>, N = 16}>} {
+  // CHECK: wave.bitcast %{{.*}} : !wave.tensor<[@K2, @N] of i8, <register>> to !wave.tensor<[@K, @N] of f4E2M1FN, <register>>
+  %0 = wave.bitcast %v : !wave.tensor<[@K2, @N] of i8, <register>> to !wave.tensor<[@K, @N] of f4E2M1FN, <register>>
+  return %0 : !wave.tensor<[@K, @N] of f4E2M1FN, <register>>
+}
+
 // CHECK-LABEL: @extract_slice
 func.func @extract_slice(%memory: !wave.tensor<[@A, @B] of f16>) -> !wave.tensor<[@A, @B] of f16> {
   // CHECK: wave.extract_slice

--- a/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
+++ b/water/test/Dialect/Wave/propagate-elements-per-thread.mlir
@@ -744,3 +744,21 @@ func.func @reshape_backward_multiple_operands(
   return
 }
 }
+
+// -----
+
+// Test bitcast forward propagation: i8 to f4 doubles elements_per_thread
+// CHECK: normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>, #wave.normal_form<memory_only_types>]
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+// CHECK-LABEL: @bitcast_forward_propagation
+func.func @bitcast_forward_propagation(%mem: !wave.tensor<[@M, @K2] of i8, <global>>, %out_mem: !wave.tensor<[@M, @N] of f32, <global>>) attributes {wave.hyperparameters = #wave.hyperparameters<{K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>, M = 16, N = 16}>, wave.constraints = [#wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1], mma_type = #wave.mma_kind<f32_16x16x128_f8f6f4>, vector_shapes = {M = 1, N = 1, K = 128, K2 = 64}, max_bits_per_load = 128>]} {
+  // Read 16 i8 elements (K2 dimension, 16 elements per thread)
+  // CHECK: wave.read {{.*}} : (!wave.tensor<[@M, @K2] of i8, <global>>) -> vector<16xi8>
+  %data = wave.read %mem {elements_per_thread = 16} : (!wave.tensor<[@M, @K2] of i8, <global>>) -> !wave.tensor<[@M, @K2] of i8, <register>>
+
+  // Bitcast: 16 i8 -> 32 f4 (doubles EPT from 16 to 32)
+  // CHECK: wave.bitcast {{.*}} : vector<16xi8> to vector<32xf4E2M1FN>
+  %bitcasted = wave.bitcast %data : !wave.tensor<[@M, @K2] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+  return
+}
+}

--- a/water/test/Dialect/Wave/python_bindings.py
+++ b/water/test/Dialect/Wave/python_bindings.py
@@ -158,6 +158,18 @@ with ir.Context() as ctx:
     else:
         assert False, "Expected to fail with ValueError."
 
+    # Hyperparameters with expr_list values for derived symbols.
+    s0 = ir.AffineSymbolExpr.get(0)
+    k_div_2_map = ir.AffineMap.get(
+        0, 1, [ir.AffineExpr.get_ceil_div(s0, ir.AffineExpr.get_constant(2))]
+    )
+    k_div_2_expr = wave.WaveExprListAttr.get(
+        [wave.WaveSymbolAttr.get("K")], k_div_2_map
+    )
+    # CHECK: #wave.hyperparameters<{K = 128 : i64, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>
+    hyper_with_expr = wave.WaveHyperparameterAttr.get({"K": 128, "K2": k_div_2_expr})
+    print(hyper_with_expr)
+
     # CHECK: #wave.address_space<shared>
     addr_attr = wave.WaveAddressSpaceAttr.get(wave.WaveAddressSpace.Shared)
     print(addr_attr)
@@ -309,17 +321,17 @@ with ir.Context() as ctx:
     # CHECK: M
     print(M.name)
 
-    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>
     symbol_attrs = [
         wave.WaveSymbolAttr.get("M"),
         wave.WaveSymbolAttr.get("BLOCK_M"),
     ]
     s0 = ir.AffineSymbolExpr.get(0)
     s1 = ir.AffineSymbolExpr.get(1)
-    expr_map = ir.AffineMap.get(0, 2, [ir.AffineExpr.get_floor_div(s0, s1)])
+    expr_map = ir.AffineMap.get(0, 2, [ir.AffineExpr.get_ceil_div(s0, s1)])
     expr_attr = wave.WaveExprListAttr.get(symbol_attrs, expr_map)
     print(expr_attr)
-    # CHECK: ()[s0, s1] -> (s0 floordiv s1)
+    # CHECK: ()[s0, s1] -> (s0 ceildiv s1)
     print(expr_attr.map)
 
     # CHECK: #wave.expr_list<[] -> (512)>
@@ -370,52 +382,52 @@ with ir.Context() as ctx:
     # CHECK: [2, 2, 1]
     print(hardware_constr_3.waves_per_block)
 
-    # CHECK: #wave.device_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, device_dim = 0>
+    # CHECK: #wave.device_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>, device_dim = 0>
     device_constr = wave.DeviceConstraintAttr.get(
         dim="M", tile_size=expr_attr, device_dim=0
     )
     print(device_constr)
     # CHECK: #wave.symbol<"M">
     print(device_constr.dim)
-    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>
     print(device_constr.tile_size)
     # CHECK: 0
     print(device_constr.device_dim)
 
-    # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>>
+    # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>, workgroup_dim = <x>>
     wg_constr = wave.WorkgroupConstraintAttr.get(
         dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x
     )
     print(wg_constr)
 
-    # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>, workgroup_dim = <x>, primary = false>
+    # CHECK: #wave.workgroup_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>, workgroup_dim = <x>, primary = false>
     wg_constr_1 = wave.WorkgroupConstraintAttr.get(
         dim="M", tile_size=expr_attr, workgroup_dim=wg_dim_x, primary=False
     )
     print(wg_constr_1)
     # CHECK: #wave.symbol<"M">
     print(wg_constr_1.dim)
-    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>
     print(wg_constr_1.tile_size)
     # CHECK: #wave.workgroup_dim<x>
     print(wg_constr_1.workgroup_dim)
     # CHECK: False
     print(wg_constr_1.primary)
 
-    # CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>>
+    # CHECK: #wave.wave_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>>
     wg_constr_2 = wave.WaveConstraintAttr.get(dim="M", tile_size=expr_attr)
     print(wg_constr_2)
     # CHECK: #wave.symbol<"M">
     print(wg_constr_2.dim)
-    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>
     print(wg_constr_2.tile_size)
 
-    # CHECK: #wave.tiling_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>>
+    # CHECK: #wave.tiling_constraint<dim = <"M">, tile_size = <[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>>
     tiling_constr = wave.TilingConstraintAttr.get(dim="M", tile_size=expr_attr)
     print(tiling_constr)
     # CHECK: #wave.symbol<"M">
     print(tiling_constr.dim)
-    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M floordiv BLOCK_M)>
+    # CHECK: #wave.expr_list<[#wave.symbol<"M">, #wave.symbol<"BLOCK_M">] -> (M ceildiv BLOCK_M)>
     print(tiling_constr.tile_size)
 
     # CHECK: #wave.normal_form<full_func_boundary>
@@ -475,6 +487,67 @@ module attributes {transform.with_named_sequence} {
     # CHECK: normalform.module
     # CHECK-SAME: #wave.normal_form<
     print(payload_module)
+
+    # ---------------------------------------------------------------
+    # Test BitcastOp Python bindings
+    # ---------------------------------------------------------------
+
+    loc = ir.Location.unknown()
+
+    M_sym = wave.WaveSymbolAttr.get("M")
+    # CHECK: #wave.symbol<"M">
+    print(M_sym)
+    K_sym = wave.WaveSymbolAttr.get("K")
+    # CHECK: #wave.symbol<"K">
+    print(K_sym)
+    K_half_sym = wave.WaveSymbolAttr.get("K2")
+    # CHECK: #wave.symbol<"K2">
+    print(K_half_sym)
+    K_scale_sym = wave.WaveSymbolAttr.get("K32")
+    # CHECK: #wave.symbol<"K32">
+    print(K_scale_sym)
+    N_sym = wave.WaveSymbolAttr.get("N")
+    # CHECK: #wave.symbol<"N">
+    print(N_sym)
+    reg_addr = wave.WaveAddressSpaceAttr.get(wave.WaveAddressSpace.Register)
+    # CHECK: #wave.address_space<register>
+    print(reg_addr)
+
+    i8_type = wave.WaveTensorType.get(
+        [M_sym, K_half_sym], True, ir.IntegerType.get_signless(8), reg_addr
+    )
+    # CHECK: !wave.tensor<[@M, @K2] of i8, <register>>
+    print(i8_type)
+    f4_type = wave.WaveTensorType.get(
+        [M_sym, K_sym], True, ir.Type.parse("f4E2M1FN"), reg_addr
+    )
+    # CHECK: !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+    print(f4_type)
+    f8e8m0_type = wave.WaveTensorType.get(
+        [M_sym, K_scale_sym], True, ir.Type.parse("f8E8M0FNU"), reg_addr
+    )
+    # CHECK: !wave.tensor<[@M, @K32] of f8E8M0FNU, <register>>
+    print(f8e8m0_type)
+    f32_acc_type = wave.WaveTensorType.get(
+        [M_sym, N_sym], True, ir.F32Type.get(), reg_addr
+    )
+    # CHECK: !wave.tensor<[@M, @N] of f32, <register>>
+    print(f32_acc_type)
+
+    bitcast_test_module = ir.Module.parse(
+        """
+func.func @bitcast_test(%arg0: !wave.tensor<[@M, @K2] of i8, <register>>) -> !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+    attributes {wave.hyperparameters = #wave.hyperparameters<{M = 16, K = 128, K2 = #wave.expr_list<[#wave.symbol<"K">] -> (K ceildiv 2)>}>} {
+  %0 = wave.bitcast %arg0 : !wave.tensor<[@M, @K2] of i8, <register>> to !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+  return %0 : !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+}
+"""
+    )
+    # CHECK: wave.bitcast
+    # CHECK-SAME: !wave.tensor<[@M, @K2] of i8, <register>>
+    # CHECK-SAME: to
+    # CHECK-SAME: !wave.tensor<[@M, @K] of f4E2M1FN, <register>>
+    print(bitcast_test_module)
 
 
 # CHECK: wave_ok

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -63,6 +63,7 @@ from wave_lang.kernel.ops.wave_ops import (
     Allocate,
     ApplyExpr,
     BinaryOpBase,
+    BitcastOp as Bitcast,
     Extract,
     ExtractSlice,
     get_custom,
@@ -107,6 +108,7 @@ try:
     from water_mlir.water_mlir.dialects.wave import (
         AddOp,
         ApplyExprOp,
+        BitcastOp,
         SubOp,
         AllocateOp,
         BroadcastOp,
@@ -161,6 +163,7 @@ except Exception as e:
 WAVE_OP_CONSTRUCTORS = {
     "add": AddOp,
     "apply_expr": ApplyExprOp,
+    "bitcast": BitcastOp,
     "broadcast": BroadcastOp,
     "sub": SubOp,
     "allocate": AllocateOp,
@@ -197,6 +200,13 @@ DATATYPE_MAP: dict[str, Callable[[], ir.Type]] = {
     "f16": ir.F16Type.get,
     "f32": ir.F32Type.get,
     "f64": ir.F64Type.get,
+    "f8E5M2": ir.Float8E5M2Type.get,
+    "f8E5M2FNUZ": ir.Float8E5M2FNUZType.get,
+    "f8E4M3FN": ir.Float8E4M3FNType.get,
+    "f8E4M3FNUZ": ir.Float8E4M3FNUZType.get,
+    "f8E8M0FNU": ir.Float8E8M0FNUType.get,
+    "f6E2M3FN": ir.Float6E2M3FNType.get,
+    "f4E2M1FN": ir.Float4E2M1FNType.get,
     "i1": lambda: ir.IntegerType.get_signless(1),
     # 'bool' is an alias for 'i1'.
     "bool": lambda: ir.IntegerType.get_signless(1),
@@ -254,6 +264,27 @@ def _map_address_space(addr) -> WaveAddressSpaceAttr:
         return WaveAddressSpaceAttr.get(WaveAddressSpace.Unspecified)
 
 
+def _derived_dim_clean_name(expr: sympy.Expr) -> str:
+    """Return a clean MLIR-friendly name for a derived SymPy expression, or
+    the original name if the expression is already a plain symbol"""
+    if expr.is_Symbol or expr.is_Number:
+        return expr.name
+    if len(expr.free_symbols) != 1:
+        raise NotImplementedError(
+            f"expressions with more than one free symbol {expr} are not yet supported"
+        )
+    base = list(expr.free_symbols)[0]
+    _, denom = expr.as_numer_denom()
+    if isinstance(denom, sympy.Integer) and denom > 1:
+        return f"{base.name}{int(denom)}"
+    if isinstance(expr, sympy.Mul):
+        args = expr.args
+        ints = [a for a in args if a.is_Integer]
+        if len(ints) == 1:
+            return f"{base.name}{int(ints[0])}"
+    raise NotImplementedError(f"shortening expression {expr} is not yet supported")
+
+
 def _create_wave_tensor_type(
     ctx: ir.Context,
     symbolic_shape: tuple,
@@ -261,7 +292,10 @@ def _create_wave_tensor_type(
     address_space_attr: WaveAddressSpaceAttr,
 ) -> ir.Type:
     """Helper function to create a WaveTensorType from shape, dtype, and address space."""
-    shape_attrs = [WaveSymbolAttr.get(str(s)) for s in symbolic_shape]
+    shape_attrs = []
+    for s in symbolic_shape:
+        clean = _derived_dim_clean_name(s)
+        shape_attrs.append(WaveSymbolAttr.get(clean if clean else str(s)))
     element_type = _dtype_to_mlir_scalar_type(dtype)
     return WaveTensorType.get(shape_attrs, True, element_type, address_space_attr)
 
@@ -310,6 +344,17 @@ def _convert_sympy_expr_to_affine_map(
     # `Max(1, ceiling(x/2))` into `ceiling(x/2)`.
     expr = expr.subs(symbol_mapping)
     expr = sympy.simplify(expr)
+
+    # Bare symbolic fractions like BLOCK_K/32 cannot be represented as affine
+    # expressions directly. Wrap them in ceiling() so they lower to ceildiv.
+    # All Wave symbols are positive integers, so ceiling(x/n) == x/n when x is
+    # divisible by n.
+    if isinstance(expr, sympy.Mul):
+        _, denom = expr.as_numer_denom()
+        if denom != 1 and not isinstance(denom, sympy.Integer):
+            pass
+        elif isinstance(denom, sympy.Integer) and denom > 1:
+            expr = sympy.ceiling(expr)
 
     return convert_sympy_to_affine_map(
         expr, [sym.name for sym in symbol_mapping.values()]
@@ -752,6 +797,8 @@ def _emit_ops_from_graph(
                     mlir_op = op_builder(
                         result_type, *create_mlir_operands(), kind=mma_kind
                     )
+                elif isinstance(node, Bitcast):
+                    mlir_op = op_builder(result_type, get_single_mapped_value(node.arg))
                 elif isinstance(node, Reduce):
                     args = node.arg if isinstance(node.arg, Sequence) else [node.arg]
                     inputs = [get_single_mapped_value(a) for a in args]
@@ -1245,12 +1292,38 @@ def _create_kernel_module(
                         f"Unexpected non-int mapping in hyperparameters: {k} -> {v}. "
                         f"Expected all non-int values to be address spaces"
                     )
-        # Convert the symbols in subs to strings and attach as
-        # WaveHyperparameterAttr to func_op
+        # Build the hyperparameters dict: base symbols map to integers,
+        # derived dims (e.g. K/2) map to WaveExprListAttr expressions.
+        hyper_params: dict[str, int | WaveExprListAttr] = {
+            str(k): v for k, v in options.subs.items() if isinstance(v, int)
+        }
+        # Collect derived symbolic dimensions from tensor shapes across the
+        # graph.  Instead of pre-evaluating them to integers, encode the
+        # affine relationship so the C++ backend can resolve them symbolically.
+        for node in trace.walk():
+            c = get_custom(node)
+            t = getattr(c, "_type", None) or getattr(c, "type", None)
+            shapes = []
+            if t is not None:
+                shapes = getattr(t, "symbolic_shape", None) or []
+            for dim_expr in shapes:
+                clean = _derived_dim_clean_name(dim_expr)
+                if clean is None or clean in hyper_params:
+                    continue
+                free = list(dim_expr.free_symbols)
+                if len(free) != 1:
+                    continue
+                base_sym = free[0]
+                if str(base_sym) not in hyper_params:
+                    continue
+                sym_mapping = preprocess_symbols(free)
+                affine_map = _convert_sympy_expr_to_affine_map(dim_expr, sym_mapping)
+                sym_attrs = [
+                    symbol_name_to_attribute(sym.name) for sym in sym_mapping.values()
+                ]
+                hyper_params[clean] = WaveExprListAttr.get(sym_attrs, affine_map)
         func_op.operation.attributes["wave.hyperparameters"] = (
-            wave.WaveHyperparameterAttr.get(
-                {str(k): v for k, v in options.subs.items() if isinstance(v, int)}
-            )
+            wave.WaveHyperparameterAttr.get(hyper_params)
         )
 
         try:


### PR DESCRIPTION
Introduces wave.bitcast, a new Water dialect op that reinterprets the raw bits of a register-resident tensor as a different element type. Unlike a plain type cast, bitcast preserves the total bit count by scaling exactly one tensor dimension by the source-to-destination element bitwidth ratio.

New dialect pieces
- wave.bitcast op (WaveOps.td, WaveOps.cpp) with verifier, forward/backward type inference, index-expression propagation, and elements-per-thread propagation.
- Scaled dimensions: a dimension is "scaled" when its symbol maps to a WaveExprListAttr ceiling-division expression in the hyperparameters rather than a plain integer. The verifier enforces at most one such dimension per bitcast and validates the ratio against the hyperparameter values.

Hyperparameter extensions
- WaveExprListAttr — a new attribute wrapping a single-result affine map (ceiling division of a symbol by a constant) together with the referenced symbols. Encodes a derived dimension whose value is ceil(base_symbol / divisor).
- WaveHyperparameterAttr::getSymbolValue extended to resolve WaveExprListAttr entries transitively using an iterative worklist (topological-sort style), so derived symbols whose dependencies are also derived resolve correctly.
- verifyOperationAttribute extended to validate WaveExprListAttr entries: single-result, ceiling division of a symbol by a constant, divisor is an integer, dividend is evenly divisible by divisor, no cycles.

Emitter
- Detects sympy expressions of the form base / n (integer ceiling division) and emits a WaveExprListAttr so the Water type system can track the scaled dimension symbolically.

Lowering
- Pattern to lower wave.bitcast between fully-typed wave tensors to an arith.bitcast on the underlying vector.

fixes #922