### PR TITLE
remove the static pytorch-rocm-requirements.txt, always use generator

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -210,7 +210,8 @@ jobs:
         if: ${{ env.HAS_GPU == 'true' && env.IS_CDNA4 == 'false' }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r pytorch-rocm-requirements.txt
+          ./gen-pytorch-rocm-requirements.py -o /tmp/pytorch-rocm-requirements.txt
+          pip install -r /tmp/pytorch-rocm-requirements.txt
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -e ".[dev]"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           - name: linux-mi325
             version: "3.11"
             runs-on: linux-mi325-1gpu-ossci-iree-org
-            pytorch_requirements: "pytorch-rocm-requirements.txt"
+            pytorch_requirements: "gen-rocm"
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 60
     env:
@@ -74,7 +74,12 @@ jobs:
           # from non default locations first. Additionally, installing
           # cpu/rocm-specific pytorch wheels first avoids installing
           # unnecessary libraries included in default pytorch.
-          pip install --no-compile -r ${{ matrix.pytorch_requirements }}
+          if [ "${{ matrix.pytorch_requirements }}" = "gen-rocm" ]; then
+            ./gen-pytorch-rocm-requirements.py -o /tmp/pytorch-rocm-requirements.txt
+            pip install --no-compile -r /tmp/pytorch-rocm-requirements.txt
+          else
+            pip install --no-compile -r ${{ matrix.pytorch_requirements }}
+          fi
           pip install --no-cache-dir -r requirements-iree-pinned.txt
           pip install -e ".[dev]"
 

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -59,7 +59,8 @@ jobs:
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
-          pip install -r pytorch-rocm-requirements.txt
+          ./gen-pytorch-rocm-requirements.py -o /tmp/pytorch-rocm-requirements.txt
+          pip install -r /tmp/pytorch-rocm-requirements.txt
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -e ".[dev]"
 

--- a/README.md
+++ b/README.md
@@ -65,16 +65,14 @@ Before installing Wave, ensure you have the following prerequisites:
    Before installing Wave, ensure you have the appropriate ROCm-enabled PyTorch dependencies:
 
 
-   ```bash
-   pip install -r pytorch-rocm-requirements.txt
-   ```
-
-   or, to auto-detect the installed ROCm version:
-
    ```sh
-   ./gen-pytorch-rocm-requirements.py > requirements-pytorch-rocm-generated.txt
+   ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
    pip install -r requirements-pytorch-rocm-generated.txt
    ```
+
+   The script auto-detects the installed ROCm version and selects the
+   appropriate PyTorch wheel source.  Run `./gen-pytorch-rocm-requirements.py --help`
+   for options (e.g. `--rocm-version` to override detection).
 
 2. **Install Wave**
 
@@ -112,7 +110,8 @@ Before installing Wave, ensure you have the following prerequisites:
    source .venv/bin/activate
    pip install --upgrade pip
    pip install -r requirements-iree-pinned.txt
-   pip install -r pytorch-rocm-requirements.txt
+   ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
+   pip install -r requirements-pytorch-rocm-generated.txt
    pip install -e ".[dev]"
    ```
 

--- a/docs/wave/getting_started.rst
+++ b/docs/wave/getting_started.rst
@@ -27,7 +27,12 @@ For Users
 
    .. code-block:: bash
 
-      pip install -r pytorch-rocm-requirements.txt
+      ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
+      pip install -r requirements-pytorch-rocm-generated.txt
+
+   The script auto-detects the installed ROCm version and selects the
+   appropriate PyTorch wheel source.  Run ``./gen-pytorch-rocm-requirements.py --help``
+   for options (e.g. ``--rocm-version`` to override detection).
 
 2. **Install Wave**
 
@@ -63,7 +68,8 @@ For Developers
       source .venv/bin/activate
       pip install --upgrade pip
       pip install -r requirements-iree-pinned.txt
-      pip install -r pytorch-rocm-requirements.txt
+      ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
+      pip install -r requirements-pytorch-rocm-generated.txt
       pip install -e ".[dev]"
 
    *Note:*

--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -82,7 +82,7 @@ def _detect_rocm_version() -> str:
 # Version string candidates
 # ---------------------------------------------------------------------------
 
-_VER_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?$")
+_VER_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?(?:[-+].+)?$")
 
 
 def _version_candidates(raw: str) -> list[str]:

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,2 +1,0 @@
---index-url https://download.pytorch.org/whl/rocm6.4
-torch>=2.6,<2.9


### PR DESCRIPTION
The static file hardcoded ROCm 6.4, which breaks on other ROCm versions. Use gen-pytorch-rocm-requirements.py everywhere (IE in documentation, CI) instead, which auto-detects the installed ROCm version and probes for a matching PyTorch wheel source.

This is a follow-up to the discussion in https://github.com/iree-org/wave/pull/1134