### PR TITLE
[water] dont blindly override index lattice values

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveOps.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveOps.cpp
@@ -1106,6 +1106,44 @@ static void mixInThreadIndependentConstraints(
   }
 }
 
+// Joins the given lattice with another lattice in place and handles conflicts.
+// If the lattice is already top, or the join result does not change the
+// lattice, the function returns success. If joining produces top (i.e., an
+// undecidable or conflicting result) that differs from the original, an error
+// is emitted using the provided emitError function.
+static LogicalResult
+joinIndexExprsLatticeInPlace(wave::IndexExprsLatticeStorage &lattice,
+                             StringRef latticeName,
+                             const wave::IndexExprsLatticeStorage &other,
+                             StringRef otherName, wave::EmitErrorFn emitError) {
+  if (lattice.isTop())
+    return success();
+
+  IndexExprsLatticeStorage joined =
+      IndexExprsLatticeStorage::join(lattice, other);
+  if (joined == lattice)
+    return success();
+  if (joined.isTop()) {
+    InFlightDiagnostic diag = emitError()
+                              << "conflict for " << latticeName
+                              << " index expression when propagating from "
+                              << otherName << " lattice";
+    diag.attachNote() << "original " << latticeName << " lattice: " << lattice;
+    diag.attachNote() << otherName << " lattice: " << other;
+    return diag;
+  }
+
+#ifndef NDEBUG
+  assert(IndexExprsLatticeStorage::join(joined, lattice) == joined &&
+         "join should not move the lattice backward");
+  assert(IndexExprsLatticeStorage::join(joined, other) == joined &&
+         "join should not move the lattice forward");
+#endif
+
+  lattice.unsafeSet(joined);
+  return success();
+}
+
 // Initialize the index expression lattices for the result of the MMA operation.
 // This sets index expressions to values derived from the MMA operation kind and
 // wavefront-in-workgroup configuration (thread-dependent) as well as workgroup
@@ -1137,11 +1175,12 @@ LogicalResult MmaOp::initializeIndexExprsForward(
   mixInThreadIndependentConstraints(
       *this, initObject.hardwareConstraint.getThreadsPerWave(), indexingSymbols,
       initObject.symbolConstraints, symbolMappings);
-  resultExprs[0].unsafeSet(wave::IndexExprsLatticeStorage(
-      DictionaryAttr::get(getContext(), symbolMappings),
-      wave::IndexExprsLatticeStorage::kMmaPriority));
-
-  return llvm::success();
+  return joinIndexExprsLatticeInPlace(
+      resultExprs[0], "MMA result",
+      wave::IndexExprsLatticeStorage(
+          DictionaryAttr::get(getContext(), symbolMappings),
+          wave::IndexExprsLatticeStorage::kMmaPriority),
+      "implied by MMA kind", emitError);
 }
 
 // Initialize the index expression lattices for the operands of the MMA
@@ -1209,19 +1248,29 @@ LogicalResult MmaOp::initializeIndexExprsBackward(
         return attr.getName() != mSymbol.getName();
       });
 
-  operandExprs[getLhsMutable().getOperandNumber()] =
-      wave::IndexExprsLatticeStorage(
-          DictionaryAttr::get(getContext(), lhsSymbolMappings),
-          wave::IndexExprsLatticeStorage::kMmaPriority);
-  operandExprs[getRhsMutable().getOperandNumber()] =
-      wave::IndexExprsLatticeStorage(
-          DictionaryAttr::get(getContext(), rhsSymbolMappings),
-          wave::IndexExprsLatticeStorage::kMmaPriority);
-  operandExprs[getAccumulatorMutable().getOperandNumber()] =
-      wave::IndexExprsLatticeStorage(
-          DictionaryAttr::get(getContext(), accumulatorSymbolMappings),
-          wave::IndexExprsLatticeStorage::kMmaPriority);
-  return llvm::success();
+  if (failed(joinIndexExprsLatticeInPlace(
+          operandExprs[getLhsMutable().getOperandNumber()], "LHS",
+          wave::IndexExprsLatticeStorage(
+              DictionaryAttr::get(getContext(), lhsSymbolMappings),
+              wave::IndexExprsLatticeStorage::kMmaPriority),
+          "implied by MMA kind", emitError)))
+    return failure();
+  if (failed(joinIndexExprsLatticeInPlace(
+          operandExprs[getRhsMutable().getOperandNumber()], "RHS",
+          wave::IndexExprsLatticeStorage(
+              DictionaryAttr::get(getContext(), rhsSymbolMappings),
+              wave::IndexExprsLatticeStorage::kMmaPriority),
+          "implied by MMA kind", emitError)))
+    return failure();
+  if (failed(joinIndexExprsLatticeInPlace(
+          operandExprs[getAccumulatorMutable().getOperandNumber()],
+          "accumulator",
+          wave::IndexExprsLatticeStorage(
+              DictionaryAttr::get(getContext(), accumulatorSymbolMappings),
+              wave::IndexExprsLatticeStorage::kMmaPriority),
+          "implied by MMA kind", emitError)))
+    return failure();
+  return success();
 }
 
 // Special case for MMA where we also want to have index expressions
@@ -2358,12 +2407,21 @@ LogicalResult WriteOp::initializeIndexExprsBackward(
   mixInThreadIndependentConstraints(
       *this, initObject.hardwareConstraint.getThreadsPerWave(),
       tensorType.getShape(), initObject.symbolConstraints, indexMappings);
-  operandExprs[getValueToStoreMutable().getOperandNumber()] =
-      IndexExprsLatticeStorage(DictionaryAttr::get(getContext(), indexMappings),
-                               IndexExprsLatticeStorage::kWritePriority);
-  operandExprs[getMemoryMutable().getOperandNumber()] =
-      IndexExprsLatticeStorage(DictionaryAttr::get(getContext(), indexMappings),
-                               IndexExprsLatticeStorage::kWritePriority);
+  if (failed(joinIndexExprsLatticeInPlace(
+          operandExprs[getValueToStoreMutable().getOperandNumber()],
+          "value to store",
+          IndexExprsLatticeStorage(
+              DictionaryAttr::get(getContext(), indexMappings),
+              IndexExprsLatticeStorage::kWritePriority),
+          "implied by write operation", emitError)))
+    return failure();
+  if (failed(joinIndexExprsLatticeInPlace(
+          operandExprs[getMemoryMutable().getOperandNumber()], "memory",
+          IndexExprsLatticeStorage(
+              DictionaryAttr::get(getContext(), indexMappings),
+              IndexExprsLatticeStorage::kWritePriority),
+          "implied by write operation", emitError)))
+    return failure();
 
   return success();
 }

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -1298,6 +1298,25 @@ private:
     propagateIfChanged(lattice, ChangeResult::Change);
   }
 
+  void safeSet(IndexExprsLattice *lattice, IndexExprsLatticeStorage value) {
+    if (lattice->getValue() == value)
+      return;
+#ifndef NDEBUG
+    IndexExprsLatticeStorage joined =
+        IndexExprsLatticeStorage::join(lattice->getValue(), value);
+    assert(IndexExprsLatticeStorage::join(joined, lattice->getValue()) ==
+               joined &&
+           "join should not move the lattice backward, did you forget to join "
+           "with the original lattice value in an interface method "
+           "implementation?");
+    assert(
+        IndexExprsLatticeStorage::join(joined, value) == joined &&
+        "join should not move the lattice forward, did you forget to join with "
+        "the original lattice value in an interface method implementation?");
+#endif
+    unsafeSet(lattice, value);
+  }
+
 public:
   explicit IndexExprsForwardAnalysis(
       DataFlowSolver &solver,
@@ -1345,25 +1364,9 @@ public:
             IndexExprsLattice *latticeObject = getLatticeElement(result);
             LDBG() << "  result #" << result.getResultNumber()
                    << " original: " << *latticeObject;
-            unsafeSet(latticeObject, lattice);
+            safeSet(latticeObject, lattice);
             LDBG() << "  result #" << result.getResultNumber()
                    << " updated: " << *latticeObject;
-          }
-        }
-
-        // Set block arguments to bottom initially so they can be join'ed
-        // with actual lattices coming from other operations.
-        for (Region &region : op->getRegions()) {
-          for (Block &block : region) {
-            for (Value value : block.getArguments()) {
-              if (!llvm::isa<wave::WaveTensorType>(value.getType()))
-                continue;
-
-              LDBG() << "setting block argument lattice " << value << " from "
-                     << PrintNoRegions(op) << " to bottom";
-              unsafeSet(getLatticeElement(value),
-                        IndexExprsLatticeStorage::bottom());
-            }
           }
         }
 
@@ -1388,10 +1391,14 @@ public:
                     wave::applyConstraint(tilingConstraint)}});
               LDBG() << "setting iterate block argument lattice " << capture
                      << " from " << PrintNoRegions(iterateOp) << " to " << dict;
-              unsafeSet(
-                  getLatticeElement(capture),
-                  wave::IndexExprsLatticeStorage(
-                      dict, wave::IndexExprsLatticeStorage::kLowestPriority));
+              IndexExprsLattice *captureLattice = getLatticeElement(capture);
+              safeSet(
+                  captureLattice,
+                  wave::IndexExprsLatticeStorage::join(
+                      captureLattice->getValue(),
+                      wave::IndexExprsLatticeStorage(
+                          dict,
+                          wave::IndexExprsLatticeStorage::kLowestPriority)));
             }
           }
         }
@@ -1504,15 +1511,7 @@ public:
 
     for (auto &&[resultLattice, lattice] :
          llvm::zip_equal(resultLattices, results)) {
-      // In release mode, just set the lattice value instead of calling join.
-      // The interface should have returned the correctly joined lattice and we
-      // don't want to re-join it and don't need the expensive check of the
-      // lattice direction.
-#ifndef NDEBUG
-      propagateIfChanged(lattice, lattice->join(resultLattice));
-#else
-      unsafeSet(lattice, resultLattice);
-#endif
+      safeSet(lattice, resultLattice);
     }
     return llvm::success();
   }
@@ -1628,6 +1627,25 @@ private:
     propagateIfChanged(lattice, ChangeResult::Change);
   }
 
+  void safeSet(IndexExprsLattice *lattice, IndexExprsLatticeStorage value) {
+    if (lattice->getValue() == value)
+      return;
+#ifndef NDEBUG
+    IndexExprsLatticeStorage joined =
+        IndexExprsLatticeStorage::join(lattice->getValue(), value);
+    assert(IndexExprsLatticeStorage::join(joined, lattice->getValue()) ==
+               joined &&
+           "join should not move the lattice backward, did you forget to join "
+           "with the original lattice value in an interface method "
+           "implementation?");
+    assert(
+        IndexExprsLatticeStorage::join(joined, value) == joined &&
+        "join should not move the lattice forward, did you forget to join with "
+        "the original lattice value in an interface method implementation?");
+#endif
+    unsafeSet(lattice, value);
+  }
+
 public:
   IndexExprsBackwardAnalysis(
       DataFlowSolver &solver, SymbolTableCollection &symbolTable,
@@ -1656,7 +1674,7 @@ public:
       if (llvm::failed(initObject))
         return llvm::failure();
 
-      parent->walk([&](Operation *op) -> WalkResult {
+      WalkResult walkResult = parent->walk([&](Operation *op) -> WalkResult {
         if (op->hasTrait<wave::RequiresSidewaysBackwardPropagationOpTrait>()) {
           for (Value operand : op->getOperands())
             addDependency(getLatticeElement(operand), getProgramPointAfter(op));
@@ -1683,23 +1701,16 @@ public:
                llvm::enumerate(op->getOperands(), operandExprs)) {
             IndexExprsLattice *latticeObject = getLatticeElement(operand);
             LDBG() << "  operand #" << i << " original: " << *latticeObject;
-            unsafeSet(latticeObject, lattice);
+            safeSet(latticeObject, lattice);
             LDBG() << "  operand #" << i << " updated: " << *latticeObject;
           }
           return WalkResult::advance();
-        } else if (op->hasTrait<OpTrait::IsTerminator>()) {
-          // Set terminator operands to bottom initially so they can be join'ed
-          // with actual lattices coming from other operations.
-          for (Value operand : op->getOperands()) {
-            if (!llvm::isa<wave::WaveTensorType>(operand.getType()))
-              continue;
-            unsafeSet(getLatticeElement(operand),
-                      IndexExprsLatticeStorage::bottom());
-          }
         }
 
         return WalkResult::advance();
       });
+      if (walkResult.wasInterrupted())
+        return failure();
     }
 
     if (overrideInitialization) {
@@ -1740,16 +1751,10 @@ public:
              << " to op operand " << PrintNoRegions(iterateOp);
       LDBG() << "block argument lattice: " << *blockArgLattice;
       LDBG() << "lattice: " << *lattice;
-#ifndef NDEBUG
-      propagateIfChanged(
-          lattice, lattice->join(blockArgLattice->getValue().withoutIterSymbols(
-                       iterateOp.getIterator())));
-#else
       IndexExprsLatticeStorage joined = IndexExprsLatticeStorage::join(
           lattice->getValue(), blockArgLattice->getValue().withoutIterSymbols(
                                    iterateOp.getIterator()));
-      unsafeSet(lattice, joined);
-#endif
+      safeSet(lattice, joined);
       LDBG() << "new lattice: " << *lattice;
       return;
     }
@@ -1770,13 +1775,9 @@ public:
              << position << " to terminator operand " << yieldOp;
       LDBG() << "result lattice: " << *resultLattice;
       LDBG() << "lattice: " << *lattice;
-#ifndef NDEBUG
-      propagateIfChanged(lattice, lattice->join(resultLattice->getValue()));
-#else
       IndexExprsLatticeStorage joined = IndexExprsLatticeStorage::join(
           lattice->getValue(), resultLattice->getValue());
-      unsafeSet(lattice, joined);
-#endif
+      safeSet(lattice, joined);
       LDBG() << "new lattice: " << *lattice;
       return;
     }
@@ -1862,15 +1863,7 @@ public:
 
     for (auto &&[operandLattice, lattice] :
          llvm::zip_equal(operandLattices, operands)) {
-      // In release mode, just set the lattice value instead of calling join.
-      // The interface should have returned the correctly joined lattice and we
-      // don't want to re-join it and don't need the expensive check of the
-      // lattice direction.
-#ifndef NDEBUG
-      propagateIfChanged(lattice, lattice->join(operandLattice));
-#else
-      unsafeSet(lattice, operandLattice);
-#endif
+      safeSet(lattice, operandLattice);
     }
     return llvm::success();
   }

--- a/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
@@ -45,9 +45,9 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
       #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
     ]
   } {
-    // expected-error @below {{conflict when propagating to LHS from result in MmaOp}}
-    // expected-note @below {{LHS lattice}}
-    // expected-note @below {{result lattice}}
+    // expected-error @below {{conflict for LHS index expression when propagating from implied by MMA kind lattice}}
+    // expected-note @below {{implied by MMA kind lattice}}
+    // expected-note @below {{original LHS lattice}}
     %r = wave.mma %lhs, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>,
       wave_test.override_result_index = [[3,
         {K = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 32, 1, 1)>}
@@ -1039,5 +1039,130 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     ]} : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
 
     return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @forward_joins_with_backward
+  func.func @forward_joins_with_backward(
+    %a: !wave.tensor<[@M] of f32>,
+    %output: !wave.tensor<[@M] of f32>
+  ) -> !wave.tensor<[@M] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1],
+                                mma_type = #wave.mma_kind<f32_16x16x16_f16>, vector_shapes = {M = 32}>
+    ]
+  } {
+    // Only provide the start expression for "read". It will have to join with the whole
+    // index expression for write during initialization and set non-null step and stride.
+    // CHECK: wave.read
+    // CHECK-SAME: index
+    // CHECK-SAME: M : <[#wave.index_symbol<T0>] -> (T0 * 16, 1, 1)>
+    %a_reg = wave.read %a {wave_test.override_result_index = [[1, {
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 16, <NULL>, <NULL>)>
+    }]]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+
+    // Add a write operation for %a_reg to the %output function argument
+    // CHECK: wave.write
+    // CHECK-SAME: index
+    // CHECK-SAME: M : <[#wave.index_symbol<T0>] -> (T0 * 16, 1, 1)>
+    wave.write %a_reg, %output : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
+
+    return %a_reg : !wave.tensor<[@M] of f32>
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  func.func @forward_backward_conflict(
+    %a: !wave.tensor<[@M] of f32>,
+    %b: !wave.tensor<[@M] of f32>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1],
+                                mma_type = #wave.mma_kind<f32_16x16x16_f16>, vector_shapes = {M = 32}>,
+      #wave.workgroup_constraint<dim = <"M">, tile_size = <[] -> (64)>, workgroup_dim = <x>>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128}>
+  } {
+    // Set the result lattice to one with a different offset than what is implied by
+    // write, which should trigger an error.
+    %a_reg = wave.read %a {wave_test.override_result_index = [[1, {
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 16, 32, 32)>
+    }]]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+
+    // expected-error @below {{conflict for value to store index expression when propagating from implied by write operation lattice}}
+    // expected-note @below {{original value to store lattice}}
+    // expected-note @below {{implied by write operation lattice}}
+    wave.write %a_reg, %b : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
+
+    return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  func.func @write_memory_vs_implied(
+    %a: !wave.tensor<[@M] of f32>,
+    %b: !wave.tensor<[@M] of f32>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1],
+                                mma_type = #wave.mma_kind<f32_16x16x16_f16>, vector_shapes = {M = 32}>,
+      #wave.workgroup_constraint<dim = <"M">, tile_size = <[] -> (64)>, workgroup_dim = <x>>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128}>
+  } {
+    %a_reg = wave.read %a : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+    %b_bad = wave.read %b {wave_test.override_result_index = [[1, {
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 16, 32, 32)>
+    }]]} : (!wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+
+    // Override the value-to-store operand with the index expression implied by
+    // write to avoid sideways propagation. This will hit an error during
+    // initializaiton rather than during propagation.
+    // expected-error @below {{conflict for memory index expression when propagating from implied by write operation lattice}}
+    // expected-note @below {{original memory lattice}}
+    // expected-note @below {{implied by write operation lattice}}
+    wave.write %a_reg, %b_bad {wave_test.override_operand_index = [[1, {
+      M = #wave.index_mapping<[#wave.index_symbol<WG0>, #wave.index_symbol<T0>] -> (T0 mod 64 + WG0 * 64, 1, 1)>
+      }]]} : !wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>
+
+    return
+  }
+}
+
+// -----
+
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  func.func @mma_lhs_vs_implied(
+    %lhs: !wave.tensor<[@M, @K] of f16>,
+    %rhs: !wave.tensor<[@N, @K] of f16>,
+    %acc: !wave.tensor<[@M, @N] of f32>
+  ) -> !wave.tensor<[@M, @N] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1],
+                                mma_type = #wave.mma_kind<f32_16x16x16_f16>,
+                                vector_shapes = {M = 16, N = 16, K = 16}>,
+      #wave.workgroup_constraint<dim = <"M">, tile_size = <[] -> (64)>, workgroup_dim = <x>>,
+      #wave.workgroup_constraint<dim = <"N">, tile_size = <[] -> (64)>, workgroup_dim = <y>>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128, K = 128}>
+  } {
+    %lhs_bad = wave.read %lhs {wave_test.override_result_index = [[3, {
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 16, 32, 32)>
+    }]]} : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16>
+
+    // expected-error @below {{conflict for LHS index expression when propagating from implied by MMA kind lattice}}
+    // expected-note @below {{original LHS lattice}}
+    // expected-note @below {{implied by MMA kind lattice}}
+    %r = wave.mma %lhs_bad, %rhs, %acc {kind = #wave.mma_kind<f32_16x16x16_f16>}
+         : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>)
+         -> !wave.tensor<[@M, @N] of f32>
+    return %r : !wave.tensor<[@M, @N] of f32>
   }
 }


### PR DESCRIPTION
Several places in the index expression analysis have been directly
overriding pre-existing lattice values, in particular for:

 - block arguments during forward initialization, with bottom;
 - terminator operands during backward initialization, with bottom;
 - op operands during backward initialization, with the value returned
   by the interface call.

This may and effectively does move back on the lattice, which may cause
problems with analysis convergence or consistency. Furthermore, since
the lattice are shared between forward and backward analyses,
initialization of one of them may override the previously set lattice
value.

The two former cases were attempts to defend against the awkward
upstream setup where lattices are initialized to the top value for
block arguments during per-op initialization. This isn't needed since we
have a mechanism inside `setToEntry/ExitState` to avoid that and
initialize to bottom during per-op initizliation. Drop that.

The latter case is due to interface implementations overriding the
pre-existing values instead of joining them. While this may be justified
in some cases, we need to ensure the lattice doesn't go back from values
already available. More generally, initialization triggers some
propagation and so does lattice sharing between analyses. Therefore,
initialization must also join with the pre-existing values and
potentially report errors. Guard against lattice direction changes in
debug mode.

Make sure error messages are emitted if joining lattices in
initialization results in the top state. Some of these are difficult to
trigger directly without complex test scaffolding, so we make an
intentional decision to only test a subset of messages. In particular,
initalization for backward pass will run after (1)
default-initialization for forward that visits all operations; (2)
initializaiton for forward; (3) default-initialization for backward that
visits all operations again; and triggerring an error message means none
of the above should have detected the conflict first. A potential
solution to that is to meld initalization and visitation functions, but
it comes with higher code complexity of visitation functions and
potentially higher cost.