### PR TITLE
Revert "fix torch specs in requirements files"

### DIFF
--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -29,7 +29,7 @@ from urllib.request import Request, urlopen
 PYTORCH_INDEX = "https://download.pytorch.org/whl/rocm{ver}"
 AMD_FIND_LINKS = "https://repo.radeon.com/rocm/manylinux/rocm-rel-{ver}/"
 
-TORCH_SPEC = "torch>=2.6,<2.10"
+TORCH_SPEC = "torch>=2.6"
 
 # ---------------------------------------------------------------------------
 # ROCm version detection

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<2.10
+torch>=2.6,<2.9

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/rocm6.4
-torch>=2.6,<2.10
+torch>=2.6,<2.9


### PR DESCRIPTION
Reverts iree-org/wave#1134. Let's see if this somehow broke wave runtime tests.