### PR TITLE
Reapply "fix torch specs in requirements files" (#1150)

### DIFF
--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -29,7 +29,7 @@ from urllib.request import Request, urlopen
 PYTORCH_INDEX = "https://download.pytorch.org/whl/rocm{ver}"
 AMD_FIND_LINKS = "https://repo.radeon.com/rocm/manylinux/rocm-rel-{ver}/"
 
-TORCH_SPEC = "torch>=2.6"
+TORCH_SPEC = "torch>=2.6,<2.10"
 
 # ---------------------------------------------------------------------------
 # ROCm version detection

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<2.9
+torch>=2.6,<2.10

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/rocm6.4
-torch>=2.6,<2.9
+torch>=2.6,<2.10


### PR DESCRIPTION
This reverts commit 336951908cda11f2e1674878d046bfbc1b7290fa.

See if this passes.
If not, let's split it into multiple components:  adding an upper bound to the generator is required whether or not we can bump the torch version number. But also if we don't bump the torch version number, we should make the version number in pyproject.toml consistent.