### PR TITLE
standardize torch version bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "ml_dtypes",
     "numpy",
     "sympy",
-    "torch>=2.6,<2.10",
+    "torch>=2.6,<2.9",
     "typing_extensions",
 ]
 


### PR DESCRIPTION
All of our requirements files have a maximum bound of torch <2.9, except our pyproject.toml was different (<2.10). Since a switch to 2.10 in the requirements files broke CI previously, this standardizes by inistead bringing pyproject.toml down to <2.9.
See https://github.com/iree-org/wave/pull/1150