### PR TITLE
[wave2water] handle missing water_id gracefully

### DIFF
--- a/lit_tests/kernel/wave/infer_index_exprs.py
+++ b/lit_tests/kernel/wave/infer_index_exprs.py
@@ -52,6 +52,45 @@ def _get_matrix_add_kernel():
     return matrix_add, hyperparams
 
 
+def _get_matrix_add_implicit_broadcast_kernel():
+    """Matrix addition with implicit broadcast on the RHS.
+
+    We should safely ignore the broadcast during Water inference.
+    """
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    ADDRESS_SPACE = tkl.sym.GLOBAL_ADDRESS_SPACE
+    dtype = tkl.f16
+
+    constraints = [
+        wave.HardwareConstraint(threads_per_wave=64, vector_shapes={M: 4, N: 1}),
+        wave.WorkgroupConstraint(M, BLOCK_M, 0),
+        wave.WorkgroupConstraint(N, BLOCK_N, 1),
+    ]
+
+    @wave.wave(constraints)
+    def matrix_add_implicit_broadcast(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, dtype],
+        b: tkl.Memory[M, ADDRESS_SPACE, dtype],
+        c: tkl.Memory[M, N, ADDRESS_SPACE, dtype],
+    ):
+        a_reg = wave.read(a)
+        b_reg = wave.read(b)
+        c_reg = a_reg + b_reg
+        wave.write(c_reg, c)
+
+    hyperparams = {
+        M: 128,
+        N: 128,
+        BLOCK_M: 16,
+        BLOCK_N: 16,
+        ADDRESS_SPACE: GLOBAL_ADDRESS_SPACE,
+    }
+    return matrix_add_implicit_broadcast, hyperparams
+
+
 def _get_mma_chain_kernel():
     # Input sizes
     M = tkl.sym.M
@@ -104,8 +143,12 @@ def _get_mma_chain_kernel():
     return mma_chain, hyperparams
 
 
-def testMatrixAdd():
-    kernel, params = _get_matrix_add_kernel()
+def testMatrixAdd(implicit_broadcast: bool):
+    kernel, params = (
+        _get_matrix_add_implicit_broadcast_kernel()
+        if implicit_broadcast
+        else _get_matrix_add_kernel()
+    )
     options = WaveCompileOptions(
         subs=params,
         run_bench=False,
@@ -165,6 +208,7 @@ def testMmaChain():
 
 
 if __name__ == "__main__":
-    testMatrixAdd()
+    testMatrixAdd(implicit_broadcast=False)
+    testMatrixAdd(implicit_broadcast=True)
     testMmaChain()
     testGemm()

--- a/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
+++ b/wave_lang/kernel/wave/analysis/index_sequence_analysis.py
@@ -37,6 +37,7 @@ from ...ops.wave_ops import (
     GetResult,
     IterArg,
     Iterate,
+    Reshape,
     TensorLoadToLDS,
     MMA,
     MMABase,
@@ -281,7 +282,8 @@ def _set_water_id(trace: CapturedTrace):
 def _reset_water_id(trace: CapturedTrace):
     """Remove the previously set unique identifier for each node in the trace."""
     for node in trace.walk(lambda x: x):
-        delattr(node, "_water_id")
+        if hasattr(node, "_water_id"):
+            delattr(node, "_water_id")
 
 
 def _check_index_difference_is_zero(
@@ -313,9 +315,16 @@ def _check_water_indices(trace: CapturedTrace, inferred: dict[str, IndexSequence
     those to find the index inferred by Water.
     """
     for node in trace.walk(lambda x: x):
-        water_id = getattr(node, "_water_id")
+        water_id = getattr(node, "_water_id", None)
         custom = get_custom(node)
         if isinstance(custom, (Placeholder, Output)):
+            continue
+        # Broadcast and Reshape may be inserted by pywave, and separately by
+        # water emitter on-the-fly, making them not have water ids. This means
+        # the MLIR equivalent pass is only doing propagation, not conflict
+        # resolution. When we want to replace the pass, we need to keep conflict
+        # resolution separate.
+        if water_id is None and isinstance(custom, (Broadcast, Reshape)):
             continue
         if water_id not in inferred:
             raise RuntimeError(


### PR DESCRIPTION
Pywave may insert broadcasts and reshapes during the index inference and
they won't have water_id, or index expressions for that matter.
