### PR TITLE
[water] attach vector shapes to ops

### DIFF
--- a/water/include/water/Dialect/Wave/IR/WaveDialect.td
+++ b/water/include/water/Dialect/Wave/IR/WaveDialect.td
@@ -46,6 +46,9 @@ def WaveDialect : Dialect {
     // Name of the inherent attribute for op index expressions;
     const static constexpr ::llvm::StringLiteral kIndexWaveExprListAttrName = "index";
 
+    // Name of the inherent attribute for op vector shape.
+    const static constexpr ::llvm::StringLiteral kVectorShapeAttrName = "vector_shape";
+
     // Name of the attribute specifying the number of elements per thread.
     const static constexpr ::llvm::StringLiteral kElementsPerThreadAttrName =
         "wave.elements_per_thread";

--- a/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
+++ b/water/include/water/Dialect/Wave/IR/WaveInterfaces.h
@@ -56,6 +56,11 @@ mlir::ParseResult parseWaveIndexDict(mlir::OpAsmParser &parser,
 void printWaveIndexDict(mlir::OpAsmPrinter &printer, mlir::Operation *op,
                         mlir::ArrayAttr arr);
 
+mlir::ParseResult parseWaveVectorShapeDictList(mlir::OpAsmParser &parser,
+                                               mlir::ArrayAttr &out);
+void printWaveVectorShapeDictList(mlir::OpAsmPrinter &printer,
+                                  mlir::Operation *op, mlir::ArrayAttr arr);
+
 //-----------------------------------------------------------------------------
 // WaveInferTypeOpInterface and implementation traits
 //-----------------------------------------------------------------------------

--- a/water/include/water/Dialect/Wave/IR/WaveOps.td
+++ b/water/include/water/Dialect/Wave/IR/WaveOps.td
@@ -40,10 +40,13 @@ def WaveMemoryType : Type<Or<[WaveTensorInMemory.predicate, AnyMemRef.predicate]
 class WaveOp<string mnemonic, list<Trait> traits = []>
     : Op<WaveDialect, mnemonic, !listconcat(traits, [HasWaveIndexMapping])> {
   dag commonArguments = (ins
-    Arg<OptionalAttr<DictArrayAttr>, "Index expression">:$index
+    Arg<OptionalAttr<DictArrayAttr>, "Index expression">:$index,
+    Arg<OptionalAttr<DictArrayAttr>, "Per-value vector shape dictionaries">:$vector_shape
   );
 
-  string commonArgumentsSyntax = "( `index` custom<WaveIndexDict>($index)^ )?";
+  string commonArgumentsSyntax =
+      "( `index` custom<WaveIndexDict>($index)^ )?"
+      "( `vector_shape` custom<WaveVectorShapeDictList>($vector_shape)^ )?";
 }
 
 //-----------------------------------------------------------------------------

--- a/water/lib/Dialect/Wave/IR/WaveDialect.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveDialect.cpp
@@ -93,6 +93,27 @@ static llvm::LogicalResult verifyAttributeHyperparamUses(
   // TODO: we need a first-class attribute for this mapping, at which point this
   // special-casing will disappear as the walker below would also visit symbols
   // used as dictionary keys.
+  if (namedAttr.getName().strref() == wave::WaveDialect::kVectorShapeAttrName) {
+    auto arrayDict = llvm::dyn_cast<ArrayAttr>(namedAttr.getValue());
+    if (!arrayDict)
+      return llvm::success();
+    for (Attribute a : arrayDict) {
+      auto dict = llvm::dyn_cast<DictionaryAttr>(a);
+      if (!dict)
+        continue;
+      for (const NamedAttribute &entry : dict) {
+        usedSymbols.insert(entry.getName().strref());
+        if (hyperparam.getMapping().contains(entry.getName().strref()))
+          continue;
+        InFlightDiagnostic diag = emitError()
+                                  << "uses symbolic value " << entry.getName()
+                                  << " not provided as a hyperparameter";
+        attachAvailableSymbolsNote(diag, hyperparam);
+        return llvm::failure();
+      }
+    }
+    return llvm::success();
+  }
   if (namedAttr.getName().strref() ==
       wave::WaveDialect::kIndexWaveExprListAttrName) {
     auto attr = namedAttr.getValue();

--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -41,11 +41,59 @@ wave::WaveHyperparameterAttr wave::getHyperparameters(Operation *op) {
 //-----------------------------------------------------------------------------
 
 LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
-  // The attribute is optional.
+  // Expected number of per-value index / vector_shape slots (same convention as
+  // the `index` attribute).
+  size_t expectedSlotCount = 0;
+  if (auto iface = dyn_cast<wave::WaveInferIndexExprsOpInterface>(op)) {
+    llvm::SmallVector<Value> values;
+    iface.getIndexExprValuesAndDescriptions(values);
+    expectedSlotCount = values.size();
+  } else {
+    expectedSlotCount = op->getNumResults();
+  }
+
+  auto verifyVectorShapeArray = [&](ArrayAttr vsArr) -> LogicalResult {
+    if (vsArr.size() != expectedSlotCount)
+      return op->emitError("'vector_shape' attribute length (")
+             << vsArr.size() << ") does not match the number of per-value "
+             << "slots (" << expectedSlotCount << ")";
+    for (Attribute nestedAttr : vsArr) {
+      auto dict = dyn_cast<DictionaryAttr>(nestedAttr);
+      if (!dict)
+        return op->emitError(
+            "'vector_shape' array elements must be dictionaries");
+      for (NamedAttribute na : dict) {
+        auto intAttr = dyn_cast<IntegerAttr>(na.getValue());
+        if (!intAttr)
+          return op->emitError("vector_shape entry ")
+                 << na.getName() << " must be an integer attribute";
+        if (!intAttr.getType().isSignlessInteger(64))
+          return op->emitError("vector_shape entry ")
+                 << na.getName()
+                 << " must be a 64-bit signless integer attribute, got "
+                 << intAttr.getType();
+      }
+    }
+    return success();
+  };
+
+  if (Attribute vsAttr = op->getAttr(WaveDialect::kVectorShapeAttrName)) {
+    auto vsArr = dyn_cast<ArrayAttr>(vsAttr);
+    if (!vsArr)
+      return op->emitError(
+          "'vector_shape' attribute must be an array of dictionaries");
+    if (failed(verifyVectorShapeArray(vsArr)))
+      return failure();
+  }
+
+  // The index attribute is optional.
   Attribute attribute =
       op->getAttr(wave::WaveDialect::kIndexWaveExprListAttrName);
-  if (!attribute)
+  if (!attribute) {
+    // `vector_shape` without `index` is still validated above against slot
+    // count.
     return success();
+  }
 
   auto arr = dyn_cast<ArrayAttr>(attribute);
   if (!arr)
@@ -159,24 +207,21 @@ LogicalResult wave::verifyWaveIndexMappings(Operation *op) {
   // getIndexExprValuesAndDescriptions. Otherwise, default to the number of op
   // results.
 
-  if (auto iface = dyn_cast<wave::WaveInferIndexExprsOpInterface>(op)) {
-    llvm::SmallVector<Value> values;
-    iface.getIndexExprValuesAndDescriptions(values);
-    if (values.size() != arr.size()) {
-      return op->emitError()
-             << WaveDialect::kIndexWaveExprListAttrName << " attribute length ("
-             << arr.size() << ") does not match the number of index expression "
-             << "values (" << values.size() << ")";
-    }
-  } else {
-    SmallVector<Value> values;
-    wave::detail::defaultGetIndexExprValuesAndDescriptions(op, values);
-    if (values.size() != arr.size()) {
-      return op->emitError() << "index attribute length (" << arr.size()
-                             << ") does not match the number of op results ("
-                             << values.size() << ")";
-    }
+  if (arr.size() != expectedSlotCount) {
+    return op->emitError() << WaveDialect::kIndexWaveExprListAttrName
+                           << " attribute length (" << arr.size()
+                           << ") does not match the number of per-value index "
+                           << "slots (" << expectedSlotCount << ")";
   }
+
+  if (Attribute vsAttr = op->getAttr(WaveDialect::kVectorShapeAttrName)) {
+    auto vsArr = cast<ArrayAttr>(vsAttr);
+    if (vsArr.size() != arr.size())
+      return op->emitError("'vector_shape' attribute length (")
+             << vsArr.size() << ") does not match 'index' attribute length ("
+             << arr.size() << ")";
+  }
+
   return success();
 }
 
@@ -241,6 +286,68 @@ void wave::printWaveIndexDict(OpAsmPrinter &printer, Operation *op,
   printer.getStream() << "[";
   llvm::interleaveComma(arr, printer.getStream(), [&](Attribute a) {
     printOne(llvm::cast<DictionaryAttr>(a));
+  });
+  printer.getStream() << "]";
+}
+
+// ODS custom directive: parseWaveVectorShapeDictList /
+// printWaveVectorShapeDictList
+ParseResult wave::parseWaveVectorShapeDictList(OpAsmParser &parser,
+                                               ArrayAttr &out) {
+  auto parseSingleDict = [&](DictionaryAttr &dictOut) -> ParseResult {
+    SmallVector<NamedAttribute, 4> entries;
+    if (parser.parseLBrace())
+      return failure();
+    auto parseEntry = [&]() -> ParseResult {
+      StringRef symbolName;
+      if (parser.parseKeyword(&symbolName) || parser.parseColon())
+        return failure();
+      Attribute value;
+      if (failed(parser.parseAttribute(value)))
+        return failure();
+      auto intAttr = dyn_cast<IntegerAttr>(value);
+      if (!intAttr || !intAttr.getType().isSignlessInteger(64))
+        return parser.emitError(parser.getCurrentLocation())
+               << "expected 64-bit signless integer attribute for "
+                  "vector_shape entry";
+      entries.emplace_back(parser.getBuilder().getStringAttr(symbolName),
+                           value);
+      return success();
+    };
+    if (parser.parseCommaSeparatedList(parseEntry) || parser.parseRBrace())
+      return failure();
+    dictOut = parser.getBuilder().getDictionaryAttr(entries);
+    return success();
+  };
+
+  SmallVector<Attribute> dicts;
+  if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Square,
+                                     [&]() -> ParseResult {
+                                       DictionaryAttr dict;
+                                       if (failed(parseSingleDict(dict)))
+                                         return failure();
+                                       dicts.push_back(dict);
+                                       return success();
+                                     }))
+    return failure();
+  out = parser.getBuilder().getArrayAttr(dicts);
+  return success();
+}
+
+void wave::printWaveVectorShapeDictList(OpAsmPrinter &printer, Operation *op,
+                                        ArrayAttr arr) {
+  auto printOne = [&](DictionaryAttr dict) {
+    printer.getStream() << "{";
+    llvm::interleaveComma(
+        dict, printer.getStream(), [&](NamedAttribute namedAttr) {
+          printer.getStream() << namedAttr.getName().getValue() << " : ";
+          printer.printAttribute(namedAttr.getValue());
+        });
+    printer.getStream() << "}";
+  };
+  printer.getStream() << "[";
+  llvm::interleaveComma(arr, printer.getStream(), [&](Attribute a) {
+    printOne(cast<DictionaryAttr>(a));
   });
   printer.getStream() << "]";
 }

--- a/water/lib/Dialect/Wave/Transforms/ExpandVariadicReductions.cpp
+++ b/water/lib/Dialect/Wave/Transforms/ExpandVariadicReductions.cpp
@@ -41,9 +41,10 @@ struct ExpandVariadicReduction : public OpRewritePattern<ReductionOp> {
     Value acc = op.getInit();
     Value result;
     for (Value input : inputs) {
-      auto newOp = ReductionOp::create(
-          rewriter, op.getLoc(), op.getResult().getType(), input, acc,
-          op.getScopeAttr(), op.getAxisAttr(), op.getIndexAttr());
+      auto newOp =
+          ReductionOp::create(rewriter, op.getLoc(), op.getResult().getType(),
+                              input, acc, op.getScopeAttr(), op.getAxisAttr(),
+                              op.getIndexAttr(), op.getVectorShapeAttr());
       result = newOp.getResult();
       acc = result;
     }

--- a/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
+++ b/water/lib/Dialect/Wave/Transforms/InferTypes.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <functional>
 #include <type_traits>
 
 using namespace mlir;
@@ -1983,6 +1984,32 @@ wave::addWaveIndexExprsAnalyses(DataFlowSolver &solver,
   return delayedErrorEmitterInfo;
 }
 
+/// If any slot has a vector shape, every slot must have one; otherwise emit an
+/// error. Empty shape dictionaries are not used as placeholders on the IR.
+static LogicalResult collectPerValueVectorShapeAttrs(
+    Operation *op, llvm::ArrayRef<wave::IndexExprsLatticeStorage> slots,
+    llvm::function_ref<void(llvm::raw_ostream &, unsigned)> describeSlot,
+    llvm::SmallVectorImpl<Attribute> &shapeDicts) {
+  bool anyPresent =
+      llvm::any_of(slots, [](const wave::IndexExprsLatticeStorage &l) {
+        return l.getVectorShape() != nullptr;
+      });
+  if (!anyPresent)
+    return success();
+  shapeDicts.reserve(shapeDicts.size() + slots.size());
+  for (const auto [i, lat] : llvm::enumerate(slots)) {
+    DictionaryAttr vs = lat.getVectorShape();
+    if (!vs) {
+      llvm::SmallString<64> buf;
+      llvm::raw_svector_ostream os(buf);
+      describeSlot(os, i);
+      return op->emitError() << "missing vector shape for " << buf.str();
+    }
+    shapeDicts.push_back(vs);
+  }
+  return success();
+}
+
 LogicalResult wave::setWaveIndexExprAnalysisResults(
     Operation *top, const DataFlowSolver &solver,
     const DelayedErrorEmitterInfo &delayedErrorInfo) {
@@ -2057,8 +2084,19 @@ LogicalResult wave::setWaveIndexExprAnalysisResults(
                   indexExprs)))
             return WalkResult::interrupt();
 
+          MLIRContext *ctx = iface->getContext();
+          SmallVector<wave::IndexExprsLatticeStorage> mmaSlots =
+              llvm::to_vector(operandLattices);
+          mmaSlots.push_back(getLatticeValue(mma.getResult()));
+          SmallVector<Attribute> shapeDicts;
+          if (failed(collectPerValueVectorShapeAttrs(
+                  mma, mmaSlots, descriptionGenerator, shapeDicts)))
+            return WalkResult::interrupt();
           iface->setAttr(wave::WaveDialect::kIndexWaveExprListAttrName,
-                         ArrayAttr::get(iface->getContext(), indexExprs));
+                         ArrayAttr::get(ctx, indexExprs));
+          if (!shapeDicts.empty())
+            iface->setAttr(wave::WaveDialect::kVectorShapeAttrName,
+                           ArrayAttr::get(ctx, shapeDicts));
           return WalkResult::advance();
         }
 
@@ -2087,8 +2125,19 @@ LogicalResult wave::setWaveIndexExprAnalysisResults(
         }
         // Only set the index expressions if there were no failures.
         if (!hadFailures) {
+          MLIRContext *ctx = iface->getContext();
+          SmallVector<wave::IndexExprsLatticeStorage> slots =
+              llvm::map_to_vector(valuesForIndexExpr,
+                                  [&](Value v) { return getLatticeValue(v); });
+          SmallVector<Attribute> shapeDicts;
+          if (failed(collectPerValueVectorShapeAttrs(
+                  iface, slots, descriptionGenerator, shapeDicts)))
+            return WalkResult::interrupt();
           iface->setAttr(wave::WaveDialect::kIndexWaveExprListAttrName,
-                         ArrayAttr::get(iface->getContext(), indexExprs));
+                         ArrayAttr::get(ctx, indexExprs));
+          if (!shapeDicts.empty())
+            iface->setAttr(wave::WaveDialect::kVectorShapeAttrName,
+                           ArrayAttr::get(ctx, shapeDicts));
         }
 
         return WalkResult::advance();

--- a/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs-lattice.mlir
@@ -1144,10 +1144,11 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.add
     // CHECK-SAME: index
     // CHECK-SAME: M : <[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
+    // CHECK-SAME: vector_shape [{M : 4 : i64}]
     // The vectorShape should be preserved and match.
     %result = wave.add %a, %b {wave_test.override_operand_index = [
-      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i32}],
-      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i32}]
+      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i64}],
+      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i64}]
     ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
@@ -1173,9 +1174,10 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.add
     // CHECK-SAME: index
     // CHECK-SAME: M : <[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
+    // CHECK-SAME: vector_shape [{M : 8 : i64}]
     // The vectorShape from operand 0 should be preserved.
     %result = wave.add %a, %b {wave_test.override_operand_index = [
-      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 8 : i32}],
+      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 8 : i64}],
       {M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}
     ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
@@ -1200,8 +1202,8 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // expected-note @below {{operand #0 lattice:}}
     // expected-note @below {{operand #1 lattice:}}
     %result = wave.add %a, %b {wave_test.override_operand_index = [
-      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i32}],
-      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 8 : i32}]
+      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 4 : i64}],
+      [{M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>}, {M = 8 : i64}]
     ]}
     : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
     return %result : !wave.tensor<[@M] of f32>
@@ -1448,5 +1450,60 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     }]]}
     : (!wave.tensor<[@M, @N] of f32>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
     return %result : !wave.tensor<[@M, @N] of f32>
+  }
+}
+
+// -----
+
+// Overriding result lattice without specifying vector shape results in an error.
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] attributes { wave_test.disable_forward } {
+  func.func @mma_missing_result_vector_shape(
+    %a: !wave.tensor<[@M, @K] of f16>,
+    %b: !wave.tensor<[@N, @K] of f16>,
+    %c: !wave.tensor<[@M, @N] of f32>
+  ) -> !wave.tensor<[@M, @N] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<
+        threads_per_wave = 64,
+        waves_per_block = [2, 3, 4],
+        mma_type = #wave.mma_kind<f32_16x16x16_f16>,
+        vector_shapes = {M = 16 : i64, N = 16 : i64, K = 16 : i64}>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128, K = 64}>
+  } {
+    // expected-error @below {{missing vector shape for result}}
+    %m = wave.mma %a, %b, %c {
+      kind = #wave.mma_kind<f32_16x16x16_f16>,
+      wave_test.override_result_index = [[1, {
+        M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (((T0 mod 64) floordiv 16) * 4, 4, 16)>,
+        N = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 mod 16, 1, 1)>
+      }]]
+    } : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
+    return %m : !wave.tensor<[@M, @N] of f32>
+  }
+}
+
+
+// -----
+
+// The test infer pass writes `vector_shape` from lattice storage (via overrides).
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @pass_emits_vector_shape
+  func.func @pass_emits_vector_shape(
+    %a: !wave.tensor<[@M] of f32>,
+    %b: !wave.tensor<[@M] of f32>
+  ) -> !wave.tensor<[@M] of f32> attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<threads_per_wave = 64, waves_per_block = [1, 1, 1]>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128}>
+  } {
+    // CHECK: wave.add
+    // CHECK-SAME: vector_shape [{M : 7 : i64}]
+    %result = wave.add %a, %b {wave_test.override_result_index = [[{
+      M = #wave.index_mapping<[#wave.index_symbol<T0>] -> (T0 * 40, 1, 1)>
+    }, {M = 7 : i64}]]}
+    : (!wave.tensor<[@M] of f32>, !wave.tensor<[@M] of f32>) -> !wave.tensor<[@M] of f32>
+    return %result : !wave.tensor<[@M] of f32>
   }
 }

--- a/water/test/Dialect/Wave/infer-index-exprs.mlir
+++ b/water/test/Dialect/Wave/infer-index-exprs.mlir
@@ -86,6 +86,35 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
 
 // -----
 
+// MMA is the only Wave op with four per-value index / vector_shape slots.
+normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
+  // CHECK-LABEL: @mma_emits_four_vector_shape_slots
+  func.func @mma_emits_four_vector_shape_slots(
+    %a: !wave.tensor<[@M, @K] of f16>,
+    %b: !wave.tensor<[@N, @K] of f16>,
+    %c: !wave.tensor<[@M, @N] of f32>
+  ) attributes {
+    wave.constraints = [
+      #wave.hardware_constraint<
+        threads_per_wave = 64,
+        waves_per_block = [2, 3, 4],
+        mma_type = #wave.mma_kind<f32_16x16x16_f16>,
+        vector_shapes = {M = 1 : i64, N = 1 : i64, K = 8 : i64}>
+    ],
+    wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128, K = 64}>
+  } {
+    // CHECK: wave.mma
+    // Four per-value dicts: lhs (M,K), rhs (K,N), acc (M,N), result (M,N); MMA
+    // kind fixes M/N/K vector sizes at 16 : i64 regardless of hardware hints.
+    // CHECK-SAME: vector_shape [{K : 16 : i64, M : 16 : i64}, {K : 16 : i64, N : 16 : i64}, {M : 16 : i64, N : 16 : i64}, {M : 16 : i64, N : 16 : i64}]
+    wave.mma %a, %b, %c {kind = #wave.mma_kind<f32_16x16x16_f16>}
+      : (!wave.tensor<[@M, @K] of f16>, !wave.tensor<[@N, @K] of f16>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32>
+    return
+  }
+}
+
+// -----
+
 // Batched (3D) MMA: batch dimension B is leading; M, N, K indexing is as in 2D.
 normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
   // CHECK: @batched_mma
@@ -1099,20 +1128,24 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.read
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK-DAG: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %a_reg = wave.read %a : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32, <register>>
     // CHECK: wave.read
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK-DAG: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %b_reg = wave.read %b : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // CHECK: wave.add
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK-DAG: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %sum = wave.add %a_reg, %b_reg : (!wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK-DAG: vector_shape [{M : 4 : i64, N : 1 : i64}]
     wave.write %sum, %output : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     return
@@ -1139,6 +1172,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * 8 + WG0 * BLOCK_M, 8, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK-DAG: vector_shape [{M : 4 : i64, N : 1 : i64}]
     wave.write %reg, %output {elements_per_thread = 8} : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     return
@@ -1165,6 +1199,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (T0 mod 64 + WG0 * BLOCK_M, 1, 16)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 8, 1)>
+    // CHECK-SAME: vector_shape [{M : 4 : i64, N : 16 : i64}]
     wave.write %reg, %output {elements_per_thread = 8} : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     return
@@ -1195,6 +1230,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK-DAG: B : <[] -> (0, 1, 1)>
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %a_reg = wave.read %a : (!wave.tensor<[@B, @M, @N] of f32>) -> !wave.tensor<[@B, @M, @N] of f32, <register>>
 
     // Write should preserve the same index expressions
@@ -1202,6 +1238,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK-DAG: B : <[] -> (0, 1, 1)>
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     wave.write %a_reg, %output : !wave.tensor<[@B, @M, @N] of f32, <register>>, !wave.tensor<[@B, @M, @N] of f32>
 
     return
@@ -1232,27 +1269,32 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.read
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %a_reg = wave.read %a : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // CHECK: wave.read
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %b_reg = wave.read %b : (!wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // CHECK: wave.add
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     %sum = wave.add %a_reg, %b_reg : (!wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32, <register>>) -> !wave.tensor<[@M, @N] of f32, <register>>
 
     // Both writes establish the same index expressions
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     wave.write %sum, %out1 : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> ((T0 mod 64) * (BLOCK_M ceildiv 64) + WG0 * BLOCK_M, BLOCK_M ceildiv 64, 1)>
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.symbol<"BLOCK_N">] -> (WG1 * BLOCK_N, 1, 1)>
+    // CHECK: vector_shape [{M : 4 : i64, N : 1 : i64}]
     wave.write %a_reg, %out2 : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     return
@@ -1276,11 +1318,13 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.read
     // CHECK-DAG: P : <[] -> (0, 1, 1)>
     // CHECK-DAG: Q : <[] -> (0, 1, 1)>
+    // CHECK: vector_shape [{P : 1 : i64, Q : 1 : i64}]
     %a_reg = wave.read %a : (!wave.tensor<[@P, @Q] of f32>) -> !wave.tensor<[@P, @Q] of f32, <register>>
 
     // CHECK: wave.write
     // CHECK-DAG: P : <[] -> (0, 1, 1)>
     // CHECK-DAG: Q : <[] -> (0, 1, 1)>
+    // CHECK: vector_shape [{P : 1 : i64, Q : 1 : i64}]
     wave.write %a_reg, %output : !wave.tensor<[@P, @Q] of f32, <register>>, !wave.tensor<[@P, @Q] of f32>
 
     return
@@ -1309,7 +1353,11 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     ],
     wave.hyperparameters = #wave.hyperparameters<{M = 128, N = 128, K = 64, BLOCK_M = 64 : i64, BLOCK_N = 64 : i64}>
   } {
+    // CHECK: wave.read
+    // CHECK: vector_shape [{K : 16 : i64, M : 16 : i64}]
     %a_reg = wave.read %a : (!wave.tensor<[@M, @K] of f16>) -> !wave.tensor<[@M, @K] of f16, <register>>
+    // CHECK: wave.read
+    // CHECK: vector_shape [{K : 16 : i64, N : 16 : i64}]
     %b_reg = wave.read %b : (!wave.tensor<[@N, @K] of f16>) -> !wave.tensor<[@N, @K] of f16, <register>>
     %mma = wave.mma %a_reg, %b_reg, %c {kind = #wave.mma_kind<f32_16x16x16_f16>}
       : (!wave.tensor<[@M, @K] of f16, <register>>, !wave.tensor<[@N, @K] of f16, <register>>, !wave.tensor<[@M, @N] of f32>) -> !wave.tensor<[@M, @N] of f32, <register>>
@@ -1319,6 +1367,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
     // CHECK: wave.write
     // CHECK-DAG: M : <[#wave.index_symbol<WG0>, #wave.index_symbol<T0>, #wave.symbol<"BLOCK_M">] -> (((T0 mod 64) floordiv 16) * 4 + WG0 * BLOCK_M
     // CHECK-DAG: N : <[#wave.index_symbol<WG1>, #wave.index_symbol<T0>, #wave.index_symbol<T1>, #wave.symbol<"BLOCK_N">] -> (T0 mod 16 + WG1 * BLOCK_N
+    // CHECK: vector_shape [{M : 16 : i64, N : 16 : i64}]
     wave.write %mma, %output : !wave.tensor<[@M, @N] of f32, <register>>, !wave.tensor<[@M, @N] of f32>
 
     return

--- a/water/test/Dialect/Wave/ops-invalid.mlir
+++ b/water/test/Dialect/Wave/ops-invalid.mlir
@@ -555,7 +555,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
 
 normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
   func.func @index_length_mismatch(%mem: !wave.tensor<[@M] of f16, <global>>) {
-    // expected-error @below {{index attribute length (0) does not match the number of index expression values (1)}}
+    // expected-error @below {{index attribute length (0) does not match the number of per-value index slots (1)}}
     %0 = wave.read %mem index [] : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
   }
@@ -566,7 +566,7 @@ normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full
 normalform.module [#wave.normal_form<full_func_boundary>, #wave.normal_form<full_op_types>] {
   func.func @read_index_multiple_dicts(%mem: !wave.tensor<[@M] of f16, <global>>)
   attributes {wave.hyperparameters = #wave.hyperparameters<{M = 128}>} {
-    // expected-error @below {{index attribute length (2) does not match the number of index expression values (1)}}
+    // expected-error @below {{index attribute length (2) does not match the number of per-value index slots (1)}}
     %0 = wave.read %mem index [{M : <[] -> (<NULL>, 4, <NULL>)>}, {M : <[] -> (<NULL>, 4, <NULL>)>}]
       : (!wave.tensor<[@M] of f16, <global>>) -> !wave.tensor<[@M] of f16, <register>>
     return
@@ -1259,7 +1259,27 @@ func.func @reshape_logical_slice_too_large(%arg0: vector<8xf32>) {
 // -----
 
 func.func @extract_index_attr_length_mismatch(%source: !wave.tensor<[@A, @B] of f32>) {
-  // expected-error @below {{index attribute length (2) does not match the number of op results (1)}}
+  // expected-error @below {{index attribute length (2) does not match the number of per-value index slots (1)}}
   %0 = wave.extract %source[#wave.expr_list<[] -> (2)>] {index = [{}, {}]} : (!wave.tensor<[@A, @B] of f32>) -> !wave.tensor<[@A] of f32>
   return
+}
+
+// -----
+
+func.func @vector_shape_entry_must_be_i64(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<[@A, @B] of bf16>) attributes {
+  wave.hyperparameters = #wave.hyperparameters<{A = 8, B = 8}>
+} {
+  // expected-error @below {{expected 64-bit signless integer attribute for vector_shape entry}}
+  %0 = wave.add %lhs, %rhs vector_shape [{A : 4 : i32}] : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %0 : !wave.tensor<[@A, @B] of bf16>
+}
+
+// -----
+
+func.func @vector_shape_entry_index_type_rejected(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<[@A, @B] of bf16>) attributes {
+  wave.hyperparameters = #wave.hyperparameters<{A = 8, B = 8}>
+} {
+  // expected-error @below {{expected 64-bit signless integer attribute for vector_shape entry}}
+  %0 = wave.add %lhs, %rhs vector_shape [{A : 4 : index}] : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %0 : !wave.tensor<[@A, @B] of bf16>
 }

--- a/water/test/Dialect/Wave/ops.mlir
+++ b/water/test/Dialect/Wave/ops.mlir
@@ -83,6 +83,16 @@ func.func @unary(%value: !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B
   return %1 : !wave.tensor<[@A, @B] of bf16>
 }
 
+// CHECK-LABEL: @vector_shape_roundtrip
+func.func @vector_shape_roundtrip(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16> attributes {
+  wave.hyperparameters = #wave.hyperparameters<{A = 8, B = 8}>
+} {
+  // CHECK: wave.add
+  // CHECK-SAME: vector_shape [{A : 4 : i64, B : 2 : i64}]
+  %0 = wave.add %lhs, %rhs vector_shape [{A : 4 : i64, B : 2 : i64}] : (!wave.tensor<[@A, @B] of bf16>, !wave.tensor<[@A, @B] of bf16>) -> !wave.tensor<[@A, @B] of bf16>
+  return %0 : !wave.tensor<[@A, @B] of bf16>
+}
+
 // CHECK-LABEL: @binary
 func.func @binary(%lhs: !wave.tensor<[@A, @B] of bf16>, %rhs: !wave.tensor<any of bf16>) -> !wave.tensor<[@A, @B] of bf16> {
   // CHECK: wave.add


### PR DESCRIPTION
This is similar to index expressions and should arguably be integrated
with them. For now, attaching these as attributes for consistency with
pywave.

Signed-off-by: Alex Zinenko <git@ozinenko.com>
