### PR TITLE
Fix isMultiWaveKernel() to detect multi-wave kernels with wgX > 64

### DIFF
--- a/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -671,30 +671,9 @@ public:
   }
 
   /// Check if this is a multi-wave kernel (more than 64 threads per workgroup)
-  /// Multi-wave means workgroup_size_y > 1 or workgroup_size_z > 1
-  /// (We assume wave size of 64 and workgroup_size_x is always a multiple of
-  /// 64)
   bool isMultiWaveKernel() const {
-    // Get workgroup_size attribute (using const-safe accessor)
-    mlir::ArrayAttr workgroupSizeAttr =
-        program->getAttrOfType<mlir::ArrayAttr>("workgroup_size");
-
-    if (!workgroupSizeAttr || workgroupSizeAttr.size() < 2)
-      return false;
-
-    int64_t wgY = 1, wgZ = 1;
-    if (auto intAttr =
-            llvm::dyn_cast<mlir::IntegerAttr>(workgroupSizeAttr[1])) {
-      wgY = intAttr.getInt();
-    }
-    if (workgroupSizeAttr.size() >= 3) {
-      if (auto intAttr =
-              llvm::dyn_cast<mlir::IntegerAttr>(workgroupSizeAttr[2])) {
-        wgZ = intAttr.getInt();
-      }
-    }
-    // Multi-wave if y > 1 or z > 1 (matching Python abi.py convention)
-    return wgY > 1 || wgZ > 1;
+    auto [wgX, wgY, wgZ] = getWorkgroupSize();
+    return (wgX * wgY * wgZ) > 64;
   }
 
   /// Get workgroup size as (x, y, z) tuple

--- a/waveasm/test/Translate/translate-gpu-threadid.mlir
+++ b/waveasm/test/Translate/translate-gpu-threadid.mlir
@@ -1,6 +1,7 @@
 // RUN: waveasm-translate --target=gfx942 %s 2>&1 | FileCheck %s
 
-// Test gpu.thread_id translation to v_mbcnt instructions
+// Test gpu.thread_id translation: single-wave uses v_mbcnt,
+// multi-wave (wgX > 64) uses v_and_b32 on hardware v0.
 
 module {
   gpu.module @test_kernel {
@@ -11,5 +12,18 @@ module {
       %tid_x = gpu.thread_id x
       gpu.return
     }
+  }
+
+  // Multi-wave kernel: 256 threads in X dimension requires reading
+  // workitem_id_x from v0 instead of computing lane_id via v_mbcnt.
+  func.func @threadid_x_multiwave() attributes {
+    translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [256, 1, 1] subgroup_size = 64>
+  } {
+    // CHECK: waveasm.program @threadid_x_multiwave
+    // CHECK: waveasm.precolored.vreg
+    // CHECK: waveasm.v_and_b32
+    // CHECK-NOT: waveasm.v_mbcnt_lo_u32_b32
+    %tid_x = gpu.thread_id x
+    return
   }
 }


### PR DESCRIPTION
isMultiWaveKernel() only checked workgroup_size_y > 1 or _z > 1, missing kernels like [256, 1, 1] that pack 4 waves into the X dimension. This caused gpu.thread_id to emit v_mbcnt (lane_id 0-63) instead of reading hardware v0 (workitem_id_x 0-255), so every wave saw the same thread IDs and wrote to the same output region.