### PR TITLE
Probe for matching torch version, not just live URL

### DIFF
--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 from pathlib import Path
 from urllib.error import URLError
+from urllib.parse import unquote
 from urllib.request import Request, urlopen
 
 PYTORCH_INDEX = "https://download.pytorch.org/whl/rocm{ver}"
@@ -107,7 +108,7 @@ def _version_candidates(raw: str) -> list[str]:
 # URL probing
 # ---------------------------------------------------------------------------
 
-_WHEEL_VER_RE = re.compile(r"torch-(\d+[0-9.]*(?:%2B[^-]*|(?:\+[^-]*))?)-")
+_WHEEL_VER_RE = re.compile(r'torch-(\d+(?:[.]\d+)*(?:\+[^-"\'/<\s]+)?)')
 
 
 def _parse_version_tuple(ver_str: str) -> tuple[int, ...] | None:
@@ -154,8 +155,10 @@ def _has_matching_torch(
     except (URLError, OSError, ValueError):
         return False
 
+    html = unquote(html)
+
     for m in _WHEEL_VER_RE.finditer(html):
-        ver_str = m.group(1).replace("%2B", "+")
+        ver_str = m.group(1)
         ver = _parse_version_tuple(ver_str)
         if ver is not None and lower <= ver < upper:
             return True


### PR DESCRIPTION
The gen-pytorch-rocm-requirements.py script was selecting the first wheel source whose URL responded to an HTTP HEAD, without checking whether it actually contained a torch version matching the spec. When the PyTorch Foundation rocm7.2 index only carries torch>=2.11 but TORCH_SPEC requires <2.9, the install silently failed and fell back to a CUDA build from PyPI.

Replace the HTTP HEAD probe with one that fetches the package listing and verifies a matching torch wheel exists before selecting a source. This lets the script correctly fall through to the AMD --find-links repo when the PyTorch index lacks a compatible version.