### PR TITLE
standardize torch version bounds, bumping up to 2.10

### DIFF
--- a/gen-pytorch-rocm-requirements.py
+++ b/gen-pytorch-rocm-requirements.py
@@ -30,7 +30,7 @@ from urllib.request import Request, urlopen
 PYTORCH_INDEX = "https://download.pytorch.org/whl/rocm{ver}"
 AMD_FIND_LINKS = "https://repo.radeon.com/rocm/manylinux/rocm-rel-{ver}/"
 
-TORCH_SPEC = "torch>=2.6,<2.9"
+TORCH_SPEC = "torch>=2.6,<2.10"
 
 # ---------------------------------------------------------------------------
 # ROCm version detection

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.6,<2.9
+torch>=2.6,<2.10


### PR DESCRIPTION
All of our requirements files have a maximum bound of torch <2.9, except our pyproject.toml was different (<2.10). This standardizes them by bumping up to 2.10 everywhere. Previously a bump up broke CI, but I want to try again without the other changes that were in the last PR that did this, and see whether they are real failures or just flakey tests.