### PR TITLE
Bump IREE RC version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "dill",
-    "iree-base-compiler~=3.11.0rc",
-    "iree-base-runtime~=3.11.0rc",
+    "iree-base-compiler~=3.12.0rc",
+    "iree-base-runtime~=3.12.0rc",
     "ml_dtypes",
     "numpy",
     "sympy",


### PR DESCRIPTION
## Summary
- Bumps `iree-base-compiler` and `iree-base-runtime` from `~=3.11.0rc` to `~=3.12.0rc` in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)