### PR TITLE
Revert "Bump IREE requirement pins to their latest versions."

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -7,5 +7,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.12.0rc20260325
-iree-base-runtime==3.12.0rc20260325
+iree-base-compiler==3.12.0rc20260324
+iree-base-runtime==3.12.0rc20260324


### PR DESCRIPTION
Reverts iree-org/wave#1187

This is breaking some tests, but wasn't caught by CI because of a race in merges.