### PR TITLE
[asm] Thread SCC carry from S_ADD_U32 into S_ADDC_U32 as explicit operand

### DIFF
--- a/waveasm/include/waveasm/Dialect/WaveASMOps.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMOps.td
@@ -99,18 +99,25 @@ class SALUBinaryOp<string mnemonic, list<Trait> traits = []>
 }
 
 // SALU Binary with carry/SCC: dst, scc = op(src0, src1)
-// s_add_u32 and s_addc_u32 set SCC (carry flag) as a side effect.
+// s_add_u32 sets SCC (carry flag) as a side effect.
 // We model SCC as an explicit sreg result so the verifier can prevent
 // reordering ops that corrupt the carry chain.
-// TODO: The scc result should be fed as an explicit operand to s_addc_u32
-// when used in an add-with-carry chain (s_add_u32 → s_addc_u32), creating
-// a true SSA dependency. Currently the chain is only enforced by emission
-// ordering, not by the SSA graph.
 class SALUBinaryWithCarryOp<string mnemonic, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, !listconcat([WaveASM_ArithmeticOp], traits)> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
   let results = (outs WaveASM_AnySGPR:$dst, WaveASM_AnySGPR:$scc);
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($dst) `,` type($scc)";
+}
+
+// SALU Binary with carry in and carry out: dst, scc = op(src0, src1, scc_in)
+// s_addc_u32 reads SCC as carry-in and sets SCC as carry-out.
+// The scc_in operand creates an explicit SSA dependency on the preceding
+// s_add_u32, ensuring the carry chain cannot be reordered.
+class SALUBinaryWithCarryInOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_ArithmeticOp], traits)> {
+  let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1, WaveASM_AnySGPR:$scc_in);
+  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_AnySGPR:$scc);
+  let assemblyFormat = "$src0 `,` $src1 `,` $scc_in attr-dict `:` type($src0) `,` type($src1) `,` type($scc_in) `->` type($dst) `,` type($scc)";
 }
 
 // SALU Compare: returns condition in SCC.
@@ -724,7 +731,8 @@ def WaveASM_S_SEXT_I32_I16 : SALUUnaryOp<"s_sext_i32_i16">;
 
 // Arithmetic with carry (sets SCC)
 def WaveASM_S_ADD_U32 : SALUBinaryWithCarryOp<"s_add_u32">;
-def WaveASM_S_ADDC_U32 : SALUBinaryWithCarryOp<"s_addc_u32">;
+// Add with carry-in: reads SCC from a preceding s_add_u32.
+def WaveASM_S_ADDC_U32 : SALUBinaryWithCarryInOp<"s_addc_u32">;
 def WaveASM_S_ADD_I32 : SALUBinaryWithCarryOp<"s_add_i32">;
 def WaveASM_S_SUB_U32 : SALUBinaryWithCarryOp<"s_sub_u32">;
 def WaveASM_S_SUB_I32 : SALUBinaryWithCarryOp<"s_sub_i32">;

--- a/waveasm/lib/Transforms/ArithLegalization.cpp
+++ b/waveasm/lib/Transforms/ArithLegalization.cpp
@@ -186,7 +186,8 @@ static void legalizeAddI64(Value lhs, Value rhs, ArithAddOp op,
     auto addLo = S_ADD_U32::create(builder, loc, sregTy, sregTy, lhsLo, rhsLo);
     loResult = addLo.getDst();
     // s_addc_u32: hi + hi + carry in from SCC.
-    auto addHi = S_ADDC_U32::create(builder, loc, sregTy, sregTy, lhsHi, rhsHi);
+    auto addHi = S_ADDC_U32::create(builder, loc, sregTy, sregTy, lhsHi, rhsHi,
+                                    addLo.getScc());
     hiResult = addHi.getDst();
   }
 

--- a/waveasm/lib/Transforms/AssemblyEmitter.cpp
+++ b/waveasm/lib/Transforms/AssemblyEmitter.cpp
@@ -858,21 +858,28 @@ std::optional<std::string> KernelGenerator::generateOp(Operation *op) {
           })
 
       // SALU arithmetic ops that set SCC: emit dst and operands, skip scc.
-      .Case<S_ADD_U32, S_ADDC_U32, S_ADD_I32, S_SUB_U32, S_SUB_I32>(
+      .Case<S_ADD_U32, S_ADD_I32, S_SUB_U32, S_SUB_I32>(
           [&](auto addOp) -> std::optional<std::string> {
             llvm::StringRef opName = addOp->getName().getStringRef();
             llvm::StringRef mnemonic = opName;
-            if (opName.starts_with("waveasm.")) {
+            if (opName.starts_with("waveasm."))
               mnemonic = opName.drop_front(8);
-            }
             llvm::SmallVector<std::string> operands;
-            // Only emit the first result (dst), not the second (scc)
+            // Only emit the first result (dst), not the second (scc).
             operands.push_back(resolveValue(addOp.getDst()));
-            for (Value operand : addOp->getOperands()) {
+            for (Value operand : addOp->getOperands())
               operands.push_back(resolveValue(operand));
-            }
             return formatter.format(mnemonic, operands);
           })
+
+      // S_ADDC_U32: emit dst, src0, src1. Skip scc result and scc_in operand.
+      .Case<S_ADDC_U32>([&](S_ADDC_U32 addcOp) -> std::optional<std::string> {
+        llvm::SmallVector<std::string> operands;
+        operands.push_back(resolveValue(addcOp.getDst()));
+        operands.push_back(resolveValue(addcOp.getSrc0()));
+        operands.push_back(resolveValue(addcOp.getSrc1()));
+        return formatter.format("s_addc_u32", operands);
+      })
 
       // V_CMP_* operations: write to VCC implicitly, need explicit vcc in asm.
       .Case<V_CMP_EQ_U32, V_CMP_NE_U32, V_CMP_LT_U32, V_CMP_LE_U32,

--- a/waveasm/lib/Transforms/TranslateFromLLVMDialect.cpp
+++ b/waveasm/lib/Transforms/TranslateFromLLVMDialect.cpp
@@ -464,13 +464,11 @@ static LogicalResult handleMakeBufferRsrc(ROCDL::MakeBufferRsrcOp op,
         offHi = ConstantOp::create(builder, loc, ctx.createImmType(0), 0);
 
       // Adjust base: S_ADD_U32 sets SCC, S_ADDC_U32 reads it.
-      // TODO: thread the SCC result from S_ADD_U32 into S_ADDC_U32 as an
-      // explicit operand. Currently S_ADDC_U32 has no SCC input in TableGen,
-      // so the carry dependency is only enforced by emission ordering.
       SRegType sccTy = ctx.createSRegType();
-      word0 =
-          S_ADD_U32::create(builder, loc, sregTy, sccTy, word0, offLo).getDst();
-      word1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy, word1, offHi)
+      auto addLo = S_ADD_U32::create(builder, loc, sregTy, sccTy, word0, offLo);
+      word0 = addLo.getDst();
+      word1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy, word1, offHi,
+                                 addLo.getScc())
                   .getDst();
     }
 

--- a/waveasm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/waveasm/lib/Transforms/TranslateFromMLIR.cpp
@@ -652,12 +652,12 @@ Value emitSRDBaseAdjustment(const TranslationContext::PendingSRDBaseAdjust &adj,
 
   // Adjust SRD base: s_add_u32 (sets SCC) + s_addc_u32 (reads SCC).
   auto sccTy = ctx.createSRegType();
-  Value adjWord0 =
-      S_ADD_U32::create(builder, loc, sregTy, sccTy, srcWord0, byteOffLo)
-          .getDst();
-  Value adjWord1 =
-      S_ADDC_U32::create(builder, loc, sregTy, sccTy, srcWord1, byteOffHi)
-          .getDst();
+  auto addLo =
+      S_ADD_U32::create(builder, loc, sregTy, sccTy, srcWord0, byteOffLo);
+  Value adjWord0 = addLo.getDst();
+  Value adjWord1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy, srcWord1,
+                                      byteOffHi, addLo.getScc())
+                       .getDst();
 
   // Build word 2 (num_records).
   Value word2;

--- a/waveasm/test/Transforms/arith-legalization.mlir
+++ b/waveasm/test/Transforms/arith-legalization.mlir
@@ -157,9 +157,9 @@ waveasm.program @test_add_i64_salu
   // CHECK-DAG: [[A_HI:%.*]] = waveasm.precolored.sreg 1 : !waveasm.sreg
   // CHECK-DAG: [[B_LO:%.*]] = waveasm.precolored.sreg 2 : !waveasm.sreg
   // CHECK-DAG: [[B_HI:%.*]] = waveasm.precolored.sreg 3 : !waveasm.sreg
-  // Carry chain: s_add_u32 (lo) then s_addc_u32 (hi).
-  // CHECK: [[LO:%.*]], %{{.*}} = waveasm.s_add_u32 [[A_LO]], [[B_LO]]
-  // CHECK-NEXT: [[HI:%.*]], %{{.*}} = waveasm.s_addc_u32 [[A_HI]], [[B_HI]]
+  // Carry chain: s_add_u32 (lo) feeds SCC into s_addc_u32 (hi).
+  // CHECK: [[LO:%.*]], [[SCC:%.*]] = waveasm.s_add_u32 [[A_LO]], [[B_LO]]
+  // CHECK-NEXT: [[HI:%.*]], %{{.*}} = waveasm.s_addc_u32 [[A_HI]], [[B_HI]], [[SCC]]
   // CHECK: waveasm.pack [[LO]], [[HI]]
   %add = waveasm.arith.add %a, %b : (!waveasm.sreg<2, 2>, !waveasm.sreg<2, 2>) -> !waveasm.sreg<2, 2>
 

--- a/waveasm/test/Transforms/translate-from-llvm-bare-ptr-gep-chain.mlir
+++ b/waveasm/test/Transforms/translate-from-llvm-bare-ptr-gep-chain.mlir
@@ -13,8 +13,8 @@
 // CHECK: waveasm.arith.readfirstlane
 // CHECK: [[OFF_LO:%.*]] = waveasm.arith.trunc
 // CHECK: [[OFF_HI:%.*]] = waveasm.extract %{{.*}}[1]
-// CHECK: waveasm.s_add_u32 %{{.*}}, [[OFF_LO]]
-// CHECK: waveasm.s_addc_u32 %{{.*}}, [[OFF_HI]]
+// CHECK: %{{.*}}, [[SCC:%.*]] = waveasm.s_add_u32 %{{.*}}, [[OFF_LO]]
+// CHECK: waveasm.s_addc_u32 %{{.*}}, [[OFF_HI]], [[SCC]]
 // CHECK: waveasm.pack
 
 // Buffer GEP voffset starts at 0: tid (truncated) + col_bytes (truncated).


### PR DESCRIPTION
Add SALUBinaryWithCarryInOp class with an scc_in operand that creates a true SSA dependency between s_add_u32 and s_addc_u32 in carry chains. Previously the ordering was only enforced by emission order, not the IR.