### PR TITLE
[wave2water] Fix Reshape type violation and enable full attention MLIR roundtrip

### DIFF
--- a/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
+++ b/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
@@ -224,39 +224,9 @@ def attention_progressive_roundtrip():
         compile_to_mlir=True,
     )
 
-    # Passes whose MLIR roundtrip is known to fail for the attention kernel.
-    # See: https://github.com/iree-org/wave/issues/1019
-    expected_failures = frozenset(
-        {
-            "in_thread_transpose",
-            "global_to_shared_gathers",
-            "minimize_global_loads",
-            "preshuffle_scale_to_shared",
-            "specialize_kernel",
-            "gather_to_shared",
-            "gather_to_shared_swizzling",
-            "mark_hardware_transpose_candidates",
-            "apply_shared_memory_indexing_corrections",
-            "partition_ops_with_gpr_offsets",
-            "partition_strided_operators",
-            "remove_chained_extractslice",
-            "decompose_reduce_ops",
-            "decompose_scan_ops",
-            "decompose_topk_ops",
-            "schedule_graph",
-            "schedule_reordering",
-            "minimize_shared_allocs",
-            "add_shared_memory_barriers",
-            "add_cluster_barriers",
-            "compute_shared_memory_usage",
-            "partition_gather_like_ops",
-            "generate_bounds_exprs",
-            "guard_g2s_with_bounds_check",
-            "merge_contiguous_reads",
-            "location_check_pass",
-            "simplify_indices",
-        }
-    )
+    # Passes whose MLIR roundtrip is known to fail for this kernel.
+    # Currently, we expect all passes to pass the roundtrip for this kernel.
+    expected_failures = frozenset()
 
     # CHECK: {{[0-9]+}} OK, {{[0-9]+}} XFAIL, 0 XPASS, 0 FAIL
     _run_progressive_roundtrip(attention, options, expected_failures)

--- a/wave_lang/kernel/wave/in_thread_transpose.py
+++ b/wave_lang/kernel/wave/in_thread_transpose.py
@@ -320,7 +320,8 @@ def create_transpose_writes(
                 propagate_tag(write.fx_node, value)
                 values.append(value)
 
-            value = Reshape(values, store_elems_per_thread).add_to_graph(
+            target_shape = {dst_symbolic_shape[-1]: store_elems_per_thread}
+            value = Reshape(values, target_shape).add_to_graph(
                 write.graph, loc=write.location
             )
             value.type = Register[(*dst_symbolic_shape, write.register_type.dtype)]

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -1020,17 +1020,12 @@ def _emit_ops_from_graph(
                         ),
                     )
                 elif isinstance(node, Reshape):
-                    # FIXME(#873): temporary fix to work around a malformed op.
-                    if isinstance(node.target_vector_shape, int):
-                        target_vector_shape = {
-                            node.type.symbolic_shape[-1]: node.target_vector_shape
-                        }
-                    else:
-                        target_vector_shape = node.target_vector_shape
                     mlir_op = op_builder(
                         result_type,
                         source=create_mlir_operands(),
-                        target_vector_shape=_convert_vector_shapes(target_vector_shape),
+                        target_vector_shape=_convert_vector_shapes(
+                            node.target_vector_shape
+                        ),
                         logical_slice=node.logical_slice,
                         num_slices=node.num_slices,
                     )

--- a/wave_lang/kernel/wave/utils/graph_utils.py
+++ b/wave_lang/kernel/wave/utils/graph_utils.py
@@ -813,15 +813,30 @@ def _check_graphs_equivalent(
     lhs_nodes = list(lhs.nodes)
     rhs_nodes = list(rhs.nodes)
 
-    # Filter transparent wrapper ops that may appear asymmetrically.
+    # Filter semantically irrelevant wrapper ops that may appear
+    # asymmetrically between the two traces.
     #
-    # GetResult: filtered from rhs when the lhs is pre-canonical
-    # (add_get_results has not yet run; the MLIR importer always produces
-    # GetResult wrappers).
+    # GetResult with no users is dead code: it extracts an iterate
+    # result that nothing consumes.  The two traces may disagree on
+    # whether these exist because (a) some compilation passes erase
+    # dead GetResult nodes while others don't, and (b) the MLIR
+    # importer always creates one per iterate result. Dropping them
+    # from both sides before comparison is equivalent to DCE and
+    # ensures we only compare semantically meaningful nodes.
+    # TODO: Eventually we should handle this in a canonicalization pass.
+    #
+    # Pre-canonical special case: before add_get_results has run, the
+    # lhs has no GetResult nodes at all, so drop all rhs GetResults.
     lhs_has_iterate = any(isinstance(get_custom(n), Iterate) for n in lhs_nodes)
     lhs_has_getresult = any(isinstance(get_custom(n), GetResult) for n in lhs_nodes)
     if lhs_has_iterate and not lhs_has_getresult:
         rhs_nodes = [n for n in rhs_nodes if not isinstance(get_custom(n), GetResult)]
+    else:
+        _is_dead_get_result = (
+            lambda n: isinstance(get_custom(n), GetResult) and not n.users
+        )
+        lhs_nodes = [n for n in lhs_nodes if not _is_dead_get_result(n)]
+        rhs_nodes = [n for n in rhs_nodes if not _is_dead_get_result(n)]
 
     # Broadcast: always filtered from both sides; either trace may
     # contain explicit broadcasts at different positions.


### PR DESCRIPTION
Fix `in_thread_transpose` passing a bare `int` to `Reshape.target_vector_shape` where the type annotation requires `dict[IndexSymbol, int]`. This was the only call site violating the contract (e.g. `decompose_scan_ops.py` does it correctly). Removes the FIXME(#873) workaround in `water_emitter.py` that was sidestepping over this.

In the graph comparison, filter dead `GetResult` nodes from both sides before comparing. These nodes are semantically irrelevant and may appear asymmetrically: Only some wave passes erase them, so they may pop up at different pipeline stages.  The MLIR importer always recreates one per iterate result.

Together, these fixes resolve all outstanding round-trip failures for the attention kernel. 
Fixes #1019 