### PR TITLE
[asm] Cherry pick: Generalize WAR hazard detection and improve liveness sort order + tests and fixes

### DIFF
--- a/waveasm/lib/Transforms/Liveness.cpp
+++ b/waveasm/lib/Transforms/Liveness.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "waveasm/Transforms/Liveness.h"
-#include "waveasm/Dialect/WaveASMInterfaces.h"
 #include "waveasm/Dialect/WaveASMOps.h"
 #include "waveasm/Dialect/WaveASMTypes.h"
 
@@ -50,12 +49,26 @@ static bool hasWARHazard(Value iterArg, Value blockArg,
   if (isa<BlockArgument>(iterArg))
     return false;
   auto *defOp = iterArg.getDefiningOp();
-  if (!defOp)
-    return false;
+  assert(defOp && "non-BlockArgument Value must have a defining op");
 
-  // Check for def/use overlap: if the iter_arg is defined at a point
-  // where block_arg still has subsequent uses, tying them creates a
-  // WAR hazard.
+  // Single-element buffer loads (ubyte/sbyte/ushort/sshort): the block_arg
+  // is consumed indirectly through vector.bitcast / vector.extract that
+  // share the same physical register. These transitive uses don't appear
+  // in usePoints, so unconditionally untie to be safe.
+  auto opName = defOp->getName().getStringRef();
+  if (opName.contains("buffer_load") && !opName.contains("_lds")) {
+    if (opName.contains("_ubyte") || opName.contains("_sbyte") ||
+        opName.contains("_ushort") || opName.contains("_sshort")) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  WAR hazard (single-element load): " << opName << "\n");
+      return true;
+    }
+  }
+
+  // General case: check for def/use overlap. If the iter_arg is defined
+  // at a point where block_arg still has subsequent uses (strictly after,
+  // since same-point means read-before-write), tying them creates a WAR
+  // hazard.
   auto iterDefIt = info.defPoints.find(iterArg);
   auto baUseIt = info.usePoints.find(blockArg);
   if (iterDefIt != info.defPoints.end() && baUseIt != info.usePoints.end()) {
@@ -698,7 +711,8 @@ LivenessInfo computeLiveness(ProgramOp program) {
   // At the same start point, allocate larger and more constrained ranges
   // first to reduce fragmentation — a 16-wide aligned range has very few
   // valid slots, so giving it priority prevents smaller ranges from
-  // blocking its only valid position.
+  // blocking its only valid position. Final tie-break: longer ranges first,
+  // since they are harder to fit around existing allocations.
   auto sortByStart = [](const LiveRange &a, const LiveRange &b) {
     if (a.start != b.start)
       return a.start < b.start;

--- a/waveasm/test/Transforms/scalar-war-hazard.mlir
+++ b/waveasm/test/Transforms/scalar-war-hazard.mlir
@@ -1,0 +1,311 @@
+// RUN: waveasm-translate --waveasm-linear-scan %s 2>&1 | FileCheck %s
+//
+// Tests for generalized WAR hazard detection.
+//
+// The old hasBufferLoadWARHazard only detected WAR hazards when the iter_arg
+// was defined by a buffer_load. The new hasWARHazard detects overlap for ANY
+// defining op, and changes the comparison from >= to > (same-point use is
+// safe because the read happens before the write in the same instruction).
+
+//===----------------------------------------------------------------------===//
+// Test 1: Scalar WAR : s_add_u32 iter_arg with block_arg used after def
+//===----------------------------------------------------------------------===//
+//
+// The most common real-world scenario: in unrolled loops, CSE merges an
+// affine.apply (e.g. iv+2 for bounds check) with the IV increment (also
+// iv+2 for step=2). The merged s_add_u32 sits mid-body. If the allocator
+// ties it to the IV block_arg, the increment clobbers the IV before later
+// instructions read it.
+//
+// BEFORE fix: hasBufferLoadWARHazard returns false (s_add_u32 is not
+//   buffer_load) → allocator ties → silent data corruption.
+// AFTER fix:  hasWARHazard detects %iv has uses after %next_iv's def →
+//   allocator keeps them separate.
+
+// CHECK-LABEL: waveasm.program @scalar_war_hazard
+waveasm.program @scalar_war_hazard
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c2 = waveasm.constant 2 : !waveasm.imm<2>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  // CHECK: waveasm.s_mov_b32 {{.*}} -> !waveasm.psreg<[[INIT_IV:[0-9]+]]>
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK: waveasm.loop
+  %iv_out = waveasm.loop(%iv = %init_iv)
+      : (!waveasm.sreg) -> (!waveasm.sreg) {
+
+    // Iter_arg defined EARLY : WAR hazard source.
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[INIT_IV]]>{{.*}}!waveasm.imm<2>
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c2
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+
+    // Block_arg %iv used AFTER %next_iv is defined : WAR victim.
+    // If tied, this reads iv+2 instead of iv.
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[INIT_IV]]>{{.*}}!waveasm.imm<1>
+    %offset:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 2: VGPR WAR : v_add_u32 iter_arg with VGPR block_arg used after def
+//===----------------------------------------------------------------------===//
+//
+// Same hazard pattern but with VGPRs: the iter_arg is a v_add_u32 (not a
+// buffer_load), and the block_arg is used afterward by v_mul_lo_u32.
+//
+// BEFORE fix: Not detected (v_add_u32 is not buffer_load).
+// AFTER fix:  Detected via def/use overlap.
+
+// CHECK-LABEL: waveasm.program @vgpr_war_hazard
+waveasm.program @vgpr_war_hazard
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: waveasm.v_mov_b32 {{.*}} -> !waveasm.pvreg<[[INIT_VAL:[0-9]+]]>
+  %init_val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  // CHECK: waveasm.loop
+  %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    // VGPR iter_arg defined EARLY.
+    // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[INIT_VAL]]>{{.*}} -> !waveasm.pvreg<
+    %new_val = waveasm.v_add_u32 %val, %v0
+        : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    // VGPR block_arg %val used AFTER %new_val defined : WAR hazard.
+    // CHECK: waveasm.v_mul_lo_u32 {{.*}}!waveasm.pvreg<[[INIT_VAL]]>{{.*}} -> !waveasm.pvreg<
+    %late_use = waveasm.v_mul_lo_u32 %val, %v0
+        : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    %next_i:2 = waveasm.s_add_u32 %i, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg
+        iter_args(%next_i#0, %new_val) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 3: No hazard : block_arg only used AT the iter_arg def point (>= vs >)
+//===----------------------------------------------------------------------===//
+//
+// The block_arg %iv is ONLY used as the operand of the s_add_u32 that
+// defines the iter_arg. defPoints[%next_iv] == usePoints[%iv], so:
+//   Old >=: flags hazard (wrong : overly conservative)
+//   New > : no hazard (correct : read-before-write at same point)
+//
+// This is the standard loop-counter pattern. If the generalized check used
+// >= instead of >, it would incorrectly untie every loop IV increment,
+// wasting a register on each loop.
+//
+// The test verifies tying is preserved: %next_iv gets the SAME physical
+// register as %init_iv (the block_arg's allocation).
+
+// CHECK-LABEL: waveasm.program @no_hazard_same_point
+waveasm.program @no_hazard_same_point
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  // CHECK: waveasm.s_mov_b32 {{.*}} -> !waveasm.psreg<[[IV:[0-9]+]]>
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  %iv_out = waveasm.loop(%iv = %init_iv)
+      : (!waveasm.sreg) -> (!waveasm.sreg) {
+
+    // %iv's ONLY use is as the operand of this instruction.
+    // Same program point as the def of %next_iv → no hazard with >.
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}} -> !waveasm.psreg<[[IV]]>
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    // Work that does NOT use %iv : only uses %next_iv.
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 4: Mixed : MFMA accumulator tying preserved alongside scalar WAR
+//===----------------------------------------------------------------------===//
+//
+// A realistic loop with BOTH an MFMA accumulator chain (should stay tied)
+// and a scalar IV with a WAR hazard (should be untied). This is the most
+// critical test: it verifies the fix is selective : only the hazardous pair
+// is untied while the MFMA tying (essential for performance) is preserved.
+//
+// The > comparison is what makes this work:
+//   MFMA: defPoints[%new_acc] == usePoints[%acc] (same instruction) → no hazard
+//   IV:   defPoints[%next_iv] < usePoints[%iv] (used afterward) → hazard
+
+// CHECK-LABEL: waveasm.program @mixed_mfma_and_scalar_war
+waveasm.program @mixed_mfma_and_scalar_war
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c2 = waveasm.constant 2 : !waveasm.imm<2>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: waveasm.v_mov_b32 {{.*}} -> !waveasm.pvreg<[[ACC:[0-9]+]], 4>
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  // CHECK: waveasm.loop
+  %iv_out, %acc_out = waveasm.loop(%iv = %init_iv, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+
+    // --- Scalar IV: WAR hazard ---
+    // Define iter_arg for %iv EARLY.
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c2
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+
+    // --- MFMA accumulator: no hazard ---
+    // %acc used as operand and %new_acc defined at the SAME program point.
+    // With >: same-point → no hazard → tying preserved.
+    // CHECK: waveasm.v_mfma_f32_16x16x16_f16 {{.*}} -> !waveasm.pvreg<[[ACC]], 4>
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4>
+        -> !waveasm.vreg<4, 4>
+
+    // --- Scalar IV: WAR victim ---
+    // Uses %iv AFTER %next_iv defined → triggers WAR.
+    %offset:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg
+        iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 5: Multiple block_arg uses after iter_arg def
+//===----------------------------------------------------------------------===//
+//
+// Stress test: the block_arg %iv is used THREE times after the iter_arg
+// %next_iv is defined. Each use would read the wrong value if tied.
+// The hazard check finds the first use > def and returns true immediately.
+
+// CHECK-LABEL: waveasm.program @multiple_post_def_uses
+waveasm.program @multiple_post_def_uses
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c2 = waveasm.constant 2 : !waveasm.imm<2>
+  %c3 = waveasm.constant 3 : !waveasm.imm<3>
+  %c4 = waveasm.constant 4 : !waveasm.imm<4>
+  %c100 = waveasm.constant 100 : !waveasm.imm<100>
+
+  // CHECK: waveasm.s_mov_b32 {{.*}} -> !waveasm.psreg<[[IV:[0-9]+]]>
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  // CHECK: waveasm.loop
+  %iv_out = waveasm.loop(%iv = %init_iv)
+      : (!waveasm.sreg) -> (!waveasm.sreg) {
+
+    // Iter_arg defined first.
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c4
+        : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg, !waveasm.sreg
+
+    // Three subsequent uses of %iv : all read wrong value if tied.
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<1>
+    %off1:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<2>
+    %off2:2 = waveasm.s_add_u32 %iv, %c2
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+    // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<3>
+    %off3:2 = waveasm.s_add_u32 %iv, %c3
+        : !waveasm.sreg, !waveasm.imm<3> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %off3#0, %c100
+        : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test 6: No hazard : iter_arg defined AFTER all block_arg uses (negative)
+//===----------------------------------------------------------------------===//
+//
+// All uses of %iv come BEFORE %next_iv is defined. No overlap, no hazard.
+// The allocator should tie them (same physical register) both before and
+// after the fix. This is a regression guard: the generalized check must
+// NOT over-trigger when the order is safe.
+
+// CHECK-LABEL: waveasm.program @no_war_def_after_all_uses
+waveasm.program @no_war_def_after_all_uses
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<> {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  // CHECK: waveasm.v_mov_b32 {{.*}} -> !waveasm.pvreg<[[SUM:[0-9]+]]>
+  %init_sum = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %sum_out = waveasm.loop(%i = %init_i, %sum = %init_sum)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    // All uses of %sum come FIRST : before the iter_arg is defined.
+    %doubled = waveasm.v_add_u32 %sum, %sum
+        : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
+
+    // Iter_arg defined AFTER the last use of %sum → no WAR hazard.
+    // Should be tied: same physical register as init.
+    // CHECK: waveasm.v_add_u32 {{.*}} -> !waveasm.pvreg<[[SUM]]>
+    %new_sum = waveasm.v_add_u32 %doubled, %v0
+        : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    %next_i:2 = waveasm.s_add_u32 %i, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg
+        iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/war-hazard-emit.mlir
+++ b/waveasm/test/Transforms/war-hazard-emit.mlir
@@ -1,0 +1,215 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s | FileCheck %s
+//
+// Emit-assembly tests for generalized WAR hazard detection.
+//
+// When the allocator untied an iter_arg from its block_arg (WAR hazard), the
+// emitter inserts s_mov_b32/v_mov_b32 back-edge copies before s_cbranch_scc1.
+// When tied (no hazard), no copy is needed : the iter_arg already lives in
+// the block_arg register.
+//
+// Tests A and B FAIL on main (no copy : iter_arg incorrectly tied to block_arg).
+// Test C PASSES on both (no hazard : iter_arg correctly tied, no copy).
+// Test D FAILS on main (no scalar copy : all incorrectly tied).
+
+//===----------------------------------------------------------------------===//
+// Test A: Scalar WAR -> s_mov_b32 back-edge copy
+//===----------------------------------------------------------------------===//
+//
+// s_add_u32 iter_arg defined mid-body, block_arg %iv used afterward.
+// After fix: untied -> emitter inserts s_mov_b32 before s_cbranch_scc1.
+// On main:   tied   -> no copy -> CHECK for s_mov_b32 FAILS.
+
+// CHECK-LABEL: emit_scalar_war_copy:
+waveasm.program @emit_scalar_war_copy
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c2 = waveasm.constant 2 : !waveasm.imm<2>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  %iv_out = waveasm.loop(%iv = %init_iv)
+      : (!waveasm.sreg) -> (!waveasm.sreg) {
+
+    // Iter_arg defined EARLY : WAR hazard source.
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c2
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+
+    // Block_arg %iv used AFTER %next_iv defined.
+    %offset:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+  }
+
+  // CHECK:      s_cmp_lt_u32
+  // Back-edge copy: iter_arg register -> block_arg register (untied).
+  // On main this copy is absent because both share the same register.
+  // CHECK:      s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+  // CHECK-NEXT: s_cbranch_scc1
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test B: VGPR WAR -> v_mov_b32 back-edge copy
+//===----------------------------------------------------------------------===//
+//
+// v_add_u32 iter_arg defined early, VGPR block_arg %val used afterward.
+// After fix: untied -> emitter inserts v_mov_b32 before s_cbranch_scc1.
+// On main:   tied   -> no copy -> CHECK for v_mov_b32 FAILS.
+
+// CHECK-LABEL: emit_vgpr_war_copy:
+waveasm.program @emit_vgpr_war_copy
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+
+  %init_i = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
+
+  %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
+      : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
+
+    // VGPR iter_arg defined EARLY : WAR hazard source.
+    %new_val = waveasm.v_add_u32 %val, %v0
+        : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    // VGPR block_arg %val used AFTER %new_val defined.
+    %late_use = waveasm.v_mul_lo_u32 %val, %v0
+        : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
+
+    %next_i:2 = waveasm.s_add_u32 %i, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg
+        iter_args(%next_i#0, %new_val) : !waveasm.sreg, !waveasm.vreg
+  }
+
+  // CHECK:      s_cmp_lt_u32
+  // Back-edge copy: VGPR iter_arg register -> block_arg register (untied).
+  // On main this copy is absent because both share the same register.
+  // CHECK:      v_mov_b32 v{{[0-9]+}}, v{{[0-9]+}}
+  // CHECK-NEXT: s_cbranch_scc1
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test C: No hazard - no back-edge copy (passes on both main and fix)
+//===----------------------------------------------------------------------===//
+//
+// Block_arg %iv is ONLY used as the operand of the s_add_u32 that defines
+// the iter_arg. Same program point: with > no hazard - tied - no copy.
+// This also passes on main (buffer_load filter skips s_add_u32 - tied).
+//
+// Regression guard: the generalized check must NOT untie every loop counter.
+
+// CHECK-LABEL: emit_no_copy_same_point:
+waveasm.program @emit_no_copy_same_point
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+
+  %iv_out = waveasm.loop(%iv = %init_iv)
+      : (!waveasm.sreg) -> (!waveasm.sreg) {
+
+    // %iv's ONLY use is as the operand of this instruction.
+    // Same point as the def of %next_iv -> says no hazard - tied.
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+  }
+
+  // No back-edge copy: iter_arg and block_arg share the same register.
+  // CHECK:      s_cmp_lt_u32
+  // CHECK-NOT:  s_mov_b32 s{{[0-9]+}}, s
+  // CHECK-NOT:  v_mov_b32
+  // CHECK:      s_cbranch_scc1
+
+  waveasm.s_endpgm
+}
+
+//===----------------------------------------------------------------------===//
+// Test D: Mixed MFMA + scalar : selective back-edge copy
+//===----------------------------------------------------------------------===//
+//
+// MFMA accumulator iter_arg: same-point def/use -> says no hazard -> tied.
+// Scalar IV iter_arg: block_arg used AFTER def -> hazard -> untied.
+//
+// After fix: ONLY the scalar iter_arg gets an s_mov_b32 copy.
+//            The MFMA accumulator has NO v_mov_b32 copies (4-wide tied).
+// On main:   BOTH are tied -> no copies at all -> s_mov_b32 CHECK FAILS.
+//
+// This is the most critical test: it proves the fix is selective
+// it catches the scalar WAR while preserving MFMA tying.
+
+// CHECK-LABEL: emit_mixed_selective:
+waveasm.program @emit_mixed_selective
+  target = #waveasm.target<#waveasm.gfx950, 5>
+  abi = #waveasm.abi<>
+  attributes {vgprs = 32 : i64, sgprs = 32 : i64} {
+
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c2 = waveasm.constant 2 : !waveasm.imm<2>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+  %a = waveasm.precolored.vreg 0, 4 : !waveasm.pvreg<0, 4>
+  %b = waveasm.precolored.vreg 4, 4 : !waveasm.pvreg<4, 4>
+
+  %init_iv = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
+  %init_acc = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg<4, 4>
+
+  %iv_out, %acc_out = waveasm.loop(%iv = %init_iv, %acc = %init_acc)
+      : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
+
+    // Scalar IV iter_arg defined EARLY : WAR hazard source.
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c2
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+
+    // MFMA: %acc used and %new_acc defined at SAME point -> no hazard.
+    %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
+        : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4>
+        -> !waveasm.vreg<4, 4>
+
+    // Block_arg %iv used AFTER %next_iv defined : WAR victim.
+    %offset:2 = waveasm.s_add_u32 %iv, %c1
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+
+    %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+    waveasm.condition %cond : !waveasm.sreg
+        iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+  }
+
+  // CHECK:      s_cmp_lt_u32
+  // No VGPR copies : MFMA accumulator is correctly tied (same-point, > check).
+  // CHECK-NOT:  v_mov_b32
+  // Only scalar copy : WAR hazard untied the IV iter_arg from its block_arg.
+  // On main this copy is absent because the scalar iter_arg is also tied.
+  // CHECK:      s_mov_b32 s{{[0-9]+}}, s{{[0-9]+}}
+  // CHECK-NEXT: s_cbranch_scc1
+
+  waveasm.s_endpgm
+}


### PR DESCRIPTION
- Cherry-picks [125cdc2](https://github.com/iree-org/wave/commit/125cdc213593411768ea494088e2f12eb81849c7) ("Generalize WAR hazard detection and improve liveness sort order") which extends WAR hazard detection beyond buffer_load to cover any iter_arg/block_arg overlap, and improves live range sort order to reduce fragmentation during allocation.
- Adds 10 lit tests across two files covering the new behavior:
> - scalar-war-hazard.mlir — 6 register-allocation behavior tests (SGPR WAR, VGPR WAR, same-point no-hazard, mixed MFMA+scalar, multiple post-def uses, negative case)
> - war-hazard-emit.mlir — 4 emit-assembly tests that verify back-edge copy insertion and produce different output before vs after the fix
- Applies fixes on top of the cherry-pick:
> - Removes dead #include "WaveASMInterfaces.h"
> - Restores unconditional untie for single-element buffer loads (_ubyte/_sbyte/_ushort/_sshort) whose transitive uses through bitcast/extract are not captured by usePoints
> - Replaces dead if (!defOp) return false with assert(defOp) since a non-BlockArgument Value always has a defining op
> - Adds tie-break rationale to the sort comparator comment