### PR TITLE
Add lizard cyclomatic complexity check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,24 @@ repos:
         name: Run clang-format on C/C++/etc. files
         exclude_types: ["jupyter", "json"]
 
+# Cyclomatic complexity check.
+-   repo: local
+    hooks:
+    -   id: lizard
+        name: lizard-complexity-check
+        entry: lizard -l python -l cpp --CCN 50 --length 300 -W whitelizard.txt -w
+        language: python
+        additional_dependencies: ["lizard~=1.17.0"]
+        types_or: [python, c, c++]
+        exclude: |
+            (?x)^(
+                water/llvm-install/|
+                .*_ops_gen\.py$|
+                .*_gen\.py$|
+                tests/|
+                examples/
+            )
+
 # Sort file and library lists in CMake files.
 -   repo: https://github.com/Hardcode84/3
     rev: v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "mypy~=1.8.0",
     "pre-commit~=4.5.1",
     "ruff~=0.12.8",
+    "lizard~=1.17.0",
 ]
 docs = [
     "sphinx~=8.1.3",

--- a/whitelizard.txt
+++ b/whitelizard.txt
@@ -1,0 +1,39 @@
+# Existing violations grandfathered in.
+# Remove entries as functions get refactored below threshold.
+# Thresholds: CCN 50, length 300.
+
+# Python - templates and schedules (long but low-branching kernel definitions).
+get_extend_attention_kernel
+get_extend_attention_rpe_kernel
+get_paged_decode_attention_kernels
+get_streamk_gemm_kernel
+get_hybrid_streamk_gemm_kernel
+get_speculative_sampling_kernel
+get_mxfp4_dbuf_mixed_pingpong_schedule
+get_mxfp4_dbuf_mixed_pingpong_schedule.mxfp4_dbuf_schedule
+get_mxfp4_dbuf_mixed_pingpong_shuffle_schedule
+get_mxfp4_asymmetric_schedule
+get_mxfp4_asymmetric_schedule.mxfp4_dbuf_schedule
+
+# Python - compiler / codegen.
+_emit_ops_from_graph
+gen_sympy_index
+isolated_test_call
+
+# Python - scripts (qualified with file to avoid matching other main functions).
+wave_lang/kernel/wave/perf/bench_mxfp4_comparison.py:main
+wave_lang/kernel/wave/asm/scripts/compare_backends.py:main
+
+# C++ - waveasm handlers (big type-dispatch switches).
+waveasm::handleAMDGPUMfma
+waveasm::handleFatRawBufferCast
+waveasm::handleGatherToLds
+waveasm::handleAffineApply
+
+# C++ - waveasm core passes.
+waveasm::computeLiveness
+waveasm::TranslationContext::emitSRDPrologue
+handleVectorStore
+LinearScanPass::processProgram
+waveasm::KernelGenerator::generateOp
+waveasm::InstructionRegistry::InstructionRegistry


### PR DESCRIPTION
Gate new code on CCN <= 50 and length <= 300. Existing violations are grandfathered via whitelizard.txt. Excludes vendored LLVM headers, generated code, tests, and examples.