### PR TITLE
Add reads_merged flag to track scale read merge status in E2E tests

### DIFF
--- a/tests/kernel/wave/asm/test_waveasm_e2e.py
+++ b/tests/kernel/wave/asm/test_waveasm_e2e.py
@@ -1499,14 +1499,12 @@ def test_dbuf_4wave_mxfp4_gemm_cpp_backend(
         expect_fail(
             "C++ ASM backend exceeds VGPR limit (341 needed) for "
             "128x256x256 (4,1) with scheduled pipeline",
-            is_crashing=True,
         )
 
     # Linearized reads with dynamic dims produce complex floor/Mod
     # expressions that cause VGPR overflow or numerical mismatches
     # across all block configurations in the MXFP4 preshuffle pipeline.
     skip_linearize = dynamic_dims
-
 
     _dbuf_mxfp4_helper(
         shape=shape,


### PR DESCRIPTION
Adds a reads_merged parameter to _dbuf_mxfp4_helper and the 4-wave MXFP4 preshuffle E2E tests. The flag records whether merge_contiguous_reads successfully merges all vector<1xi8> scale loads into wider vectors. Tests assert that the actual merge status matches the declared flag, catching both regressions (merged->unmerged) and improvements (unmerged->merged) that need flag updates.