### PR TITLE
[wave2water] Add MXFP4 support to fx_emitter and fix roundtrip comparison

### DIFF
--- a/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
+++ b/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
@@ -35,6 +35,7 @@ from wave_lang.kernel.wave.mlir_converter.mlir_converter import (
     format_diagnostics,
     PersistentEmitter,
 )
+from wave_lang.kernel.wave.scheduling.schedule_enums import SchedulingType
 from wave_lang.kernel.wave.schedules import get_mxfp4_dbuf_schedule
 from wave_lang.kernel.wave.templates.attention_common import AttentionShape
 from wave_lang.kernel.wave.templates.gemm import get_gemm_kernel
@@ -257,38 +258,12 @@ def mxfp4_gemm_progressive_roundtrip():
     schedule = get_mxfp4_dbuf_schedule(use_stagger=False)
     options.compile_to_mlir = True
     options.linearize_reads = False
+    options.use_global_to_shared = False
+    options.schedule = SchedulingType.NONE
 
     # Passes whose MLIR roundtrip is known to fail for this kernel.
-    # - run_manual_schedule: crashes (partition_by_dim expects expanded K).
-    # - gather_to_shared and later: GatherToLDS nodes have type=None,
-    #   causing issubclass() failures in the water_emitter.
-    expected_failures = frozenset(
-        {
-            "gather_to_shared",
-            "gather_to_shared_swizzling",
-            "mark_hardware_transpose_candidates",
-            "apply_shared_memory_indexing_corrections",
-            "partition_ops_with_gpr_offsets",
-            "partition_strided_operators",
-            "remove_chained_extractslice",
-            "decompose_reduce_ops",
-            "decompose_scan_ops",
-            "decompose_topk_ops",
-            "run_manual_schedule",
-            "guard_g2s_with_bounds_check",
-            "schedule_reordering",
-            "minimize_shared_allocs",
-            "coalesce_wide_stores",
-            "add_shared_memory_barriers",
-            "add_cluster_barriers",
-            "compute_shared_memory_usage",
-            "simplify_indices",
-            "partition_gather_like_ops",
-            "generate_bounds_exprs",
-            "merge_contiguous_reads",
-            "location_check_pass",
-        }
-    )
+    # Currently, we expect all passes to pass the roundtrip for this kernel.
+    expected_failures = frozenset()
 
     # CHECK: {{[0-9]+}} OK, {{[0-9]+}} XFAIL, 0 XPASS, 0 FAIL
-    _run_progressive_roundtrip(gemm, options, expected_failures, schedule=schedule)
+    _run_progressive_roundtrip(gemm, options, expected_failures)

--- a/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
+++ b/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
@@ -28,6 +28,7 @@ from wave_lang.kernel.wave.constraints import (
     HardwareConstraint,
     MMAType,
     TilingConstraint,
+    WaveConstraint,
 )
 from wave_lang.kernel.wave.mlir_converter.diagnostics import error_diagnostics
 from wave_lang.kernel.wave.mlir_converter.mlir_converter import (
@@ -48,6 +49,7 @@ from wave_lang.kernel.wave.utils.graph_utils import (
     assert_constraints_equivalent,
     compare_hardware_constraints_for_mlir_roundtrip,
     compare_tiling_constraints_for_mlir_roundtrip,
+    compare_wave_constraints_for_mlir_roundtrip,
 )
 
 
@@ -83,7 +85,9 @@ def _try_roundtrip(
             custom_comparators={
                 HardwareConstraint: compare_hardware_constraints_for_mlir_roundtrip,
                 TilingConstraint: compare_tiling_constraints_for_mlir_roundtrip,
+                WaveConstraint: compare_wave_constraints_for_mlir_roundtrip,
             },
+            subs=options.subs,
         )
 
         return Success()
@@ -255,41 +259,11 @@ def mxfp4_gemm_progressive_roundtrip():
     options.linearize_reads = False
 
     # Passes whose MLIR roundtrip is known to fail for this kernel.
-    # Passes 1-11: emitter lacks ScaledMmaOp in the Water MLIR dialect.
-    # Passes 12-44: BLOCK_M/2 from wave_shape=(2,2) produces an invalid
-    #   fraction in the sympy-to-affine index converter.
-    # Pass 38: run_manual_schedule crashes (partition_by_dim expects expanded K).
-    # Passes 45-49: type metadata corruption after simplify_indices
-    #   (issubclass() arg 1 must be a class).
+    # - run_manual_schedule: crashes (partition_by_dim expects expanded K).
+    # - gather_to_shared and later: GatherToLDS nodes have type=None,
+    #   causing issubclass() failures in the water_emitter.
     expected_failures = frozenset(
         {
-            "debug_log_hoist",
-            "initialize_iter_args",
-            "create_induction_vars",
-            "initialize_reductions",
-            "finalize_indices",
-            "substitute_vector_shapes",
-            "add_get_results",
-            "infer_types",
-            "construct_index_mapping",
-            "debug_log_write_replace",
-            "promote_placeholders",
-            "set_node_indices",
-            "reorder_workgroups",
-            "expand_graph",
-            "set_post_expansion_indices",
-            "remove_chained_getresult",
-            "decompose_vmma_ops",
-            "decompose_dot_mma",
-            "hoist_loop_invariant_ops",
-            "tensor_load_to_shared",
-            "multicast",
-            "fuse_tensor_loads",
-            "in_thread_transpose",
-            "global_to_shared_gathers",
-            "minimize_global_loads",
-            "preshuffle_scale_to_shared",
-            "specialize_kernel",
             "gather_to_shared",
             "gather_to_shared_swizzling",
             "mark_hardware_transpose_candidates",

--- a/tests/mlir_wave_iface/attr_type_converter_test.py
+++ b/tests/mlir_wave_iface/attr_type_converter_test.py
@@ -46,8 +46,8 @@ if is_water_available():
     from mlir_converter.attr_type_converter import (
         _convert_affine_expr_to_sympy_expr,
         _convert_index_mapping_attr_to_sympy,
-        _convert_index_mapping_dict_to_sympy,
-        convert_index_mapping_array_to_sympy,
+        convert_index_mapping_dict_to_sympy,
+        convert_mma_index_to_sympy,
         _make_piecewise_sequence,
         ITER_SYMBOL_NAME_WAVE_PREFIX,
     )
@@ -307,11 +307,10 @@ class TestConvertIndexMappingAttrToSympy:
 
 
 class TestConvertIndexMappingDictToSympy:
-    """Tests for _convert_index_mapping_dict_to_sympy function."""
+    """Tests for convert_index_mapping_dict_to_sympy function."""
 
     def test_single_mapping(self):
         """Test conversion of dict with single index mapping."""
-        # Create a simple index mapping
         symbols = [wave.WaveSymbolAttr.get("M")]
         s0 = ir.AffineSymbolExpr.get(0)
         start_map = ir.AffineMap.get(0, 1, [s0])
@@ -321,10 +320,8 @@ class TestConvertIndexMappingDictToSympy:
             symbols, start_map, step_map, stride_map
         )
 
-        # Create dict attribute
-        dict_attr = ir.DictAttr.get({"dim0": mapping_attr})
-
-        result = _convert_index_mapping_dict_to_sympy(dict_attr)
+        dict_attr = wave.WaveSymbolMappingAttr.get({"dim0": mapping_attr})
+        result = convert_index_mapping_dict_to_sympy(dict_attr)
 
         assert isinstance(result, dict)
         assert index_symbol("dim0") in result
@@ -334,7 +331,6 @@ class TestConvertIndexMappingDictToSympy:
 
     def test_multiple_mappings(self):
         """Test conversion of dict with multiple index mappings."""
-        # Create first mapping
         symbols1 = [wave.WaveSymbolAttr.get("M")]
         s0 = ir.AffineSymbolExpr.get(0)
         mapping1 = wave.WaveIndexMappingAttr.get(
@@ -344,7 +340,6 @@ class TestConvertIndexMappingDictToSympy:
             ir.AffineMap.get(0, 1, [ir.AffineConstantExpr.get(1)]),
         )
 
-        # Create second mapping
         symbols2 = [wave.WaveSymbolAttr.get("N")]
         mapping2 = wave.WaveIndexMappingAttr.get(
             symbols2,
@@ -353,8 +348,8 @@ class TestConvertIndexMappingDictToSympy:
             ir.AffineMap.get(0, 1, [ir.AffineConstantExpr.get(2)]),
         )
 
-        dict_attr = ir.DictAttr.get({"m": mapping1, "n": mapping2})
-        result = _convert_index_mapping_dict_to_sympy(dict_attr)
+        dict_attr = wave.WaveSymbolMappingAttr.get({"m": mapping1, "n": mapping2})
+        result = convert_index_mapping_dict_to_sympy(dict_attr)
 
         assert len(result) == 2
         assert index_symbol("m") in result
@@ -397,12 +392,11 @@ class TestMakePiecewiseSequence:
         assert isinstance(result.stride, sympy.Piecewise)
 
 
-class TestConvertIndexMappingArrayToSympy:
-    """Tests for convert_index_mapping_array_to_sympy function."""
+class TestConvertIndexMappingToSympy:
+    """Tests for convert_index_mapping_dict_to_sympy and convert_mma_index_to_sympy."""
 
-    def test_non_mma_op_single_mapping(self):
-        """Test conversion for non-MMA operations (expects single mapping)."""
-        # Create a simple mapping
+    def test_single_mapping(self):
+        """Test conversion for a single WaveSymbolMappingAttr."""
         symbols = [wave.WaveSymbolAttr.get("M")]
         s0 = ir.AffineSymbolExpr.get(0)
         mapping = wave.WaveIndexMappingAttr.get(
@@ -412,12 +406,8 @@ class TestConvertIndexMappingArrayToSympy:
             ir.AffineMap.get(0, 1, [ir.AffineConstantExpr.get(1)]),
         )
 
-        dict_attr = ir.DictAttr.get({"dim": mapping})
-        array_attr = ir.ArrayAttr.get([dict_attr])
-
-        # We don't need anything from the operation except its name, so use an empty module.
-        dummy_op = ir.Operation.create("builtin.module", loc=ir.Location.unknown())
-        result = convert_index_mapping_array_to_sympy(dummy_op, array_attr)
+        mapping_attr = wave.WaveSymbolMappingAttr.get({"dim": mapping})
+        result = convert_index_mapping_dict_to_sympy(mapping_attr)
 
         assert isinstance(result, dict)
         assert index_symbol("dim") in result
@@ -475,17 +465,21 @@ class TestConvertIndexMappingArrayToSympy:
             ir.AffineMap.get(0, 1, [c1]),
         )
 
-        # Note that result mapping is the same as the accumulator mapping.
-        lhs_dict = ir.DictAttr.get({"M": lhs_m_mapping, "K": lhs_k_mapping})
-        rhs_dict = ir.DictAttr.get({"N": rhs_n_mapping, "K": rhs_k_mapping})
-        acc_dict = ir.DictAttr.get({"M": acc_m_mapping, "N": acc_n_mapping})
-        result_dict = ir.DictAttr.get({"M": acc_m_mapping, "N": acc_n_mapping})
+        lhs_dict = wave.WaveSymbolMappingAttr.get(
+            {"M": lhs_m_mapping, "K": lhs_k_mapping}
+        )
+        rhs_dict = wave.WaveSymbolMappingAttr.get(
+            {"N": rhs_n_mapping, "K": rhs_k_mapping}
+        )
+        acc_dict = wave.WaveSymbolMappingAttr.get(
+            {"M": acc_m_mapping, "N": acc_n_mapping}
+        )
+        result_dict = wave.WaveSymbolMappingAttr.get(
+            {"M": acc_m_mapping, "N": acc_n_mapping}
+        )
 
         array_attr = ir.ArrayAttr.get([lhs_dict, rhs_dict, acc_dict, result_dict])
-
-        # Create a mock MMA operation, we only need the name, it doesn't even need to verify correctly.
-        dummy_mma_op = ir.Operation.create("wave.mma", loc=ir.Location.unknown())
-        result = convert_index_mapping_array_to_sympy(dummy_mma_op, array_attr)
+        result = convert_mma_index_to_sympy(array_attr)
 
         assert isinstance(result, dict)
         assert len(result) == 3  # M, N, K
@@ -580,42 +574,21 @@ class TestConvertIndexMappingArrayToSympy:
             ir.AffineMap.get(0, 1, [c1]),
         )
 
-        lhs_dict = ir.DictAttr.get(
-            {
-                "b1": b1_mapping,
-                "b2": b2_mapping,
-                "M": lhs_m_mapping,
-                "K": lhs_k_mapping,
-            }
+        lhs_dict = wave.WaveSymbolMappingAttr.get(
+            {"b1": b1_mapping, "b2": b2_mapping, "M": lhs_m_mapping, "K": lhs_k_mapping}
         )
-        rhs_dict = ir.DictAttr.get(
-            {
-                "b1": b1_mapping,
-                "b2": b2_mapping,
-                "N": rhs_n_mapping,
-                "K": rhs_k_mapping,
-            }
+        rhs_dict = wave.WaveSymbolMappingAttr.get(
+            {"b1": b1_mapping, "b2": b2_mapping, "N": rhs_n_mapping, "K": rhs_k_mapping}
         )
-        acc_dict = ir.DictAttr.get(
-            {
-                "b1": b1_mapping,
-                "b2": b2_mapping,
-                "M": acc_m_mapping,
-                "N": acc_n_mapping,
-            }
+        acc_dict = wave.WaveSymbolMappingAttr.get(
+            {"b1": b1_mapping, "b2": b2_mapping, "M": acc_m_mapping, "N": acc_n_mapping}
         )
-        result_dict = ir.DictAttr.get(
-            {
-                "b1": b1_mapping,
-                "b2": b2_mapping,
-                "M": acc_m_mapping,
-                "N": acc_n_mapping,
-            }
+        result_dict = wave.WaveSymbolMappingAttr.get(
+            {"b1": b1_mapping, "b2": b2_mapping, "M": acc_m_mapping, "N": acc_n_mapping}
         )
 
         array_attr = ir.ArrayAttr.get([lhs_dict, rhs_dict, acc_dict, result_dict])
-        dummy_mma_op = ir.Operation.create("wave.mma", loc=ir.Location.unknown())
-        result = convert_index_mapping_array_to_sympy(dummy_mma_op, array_attr)
+        result = convert_mma_index_to_sympy(array_attr)
 
         assert isinstance(result, dict)
         assert set(result.keys()) == {
@@ -643,3 +616,95 @@ class TestConvertIndexMappingArrayToSympy:
             (1, ~index_symbol(MMA_ACC_SYMBOL_NAME)),
             (16, index_symbol(MMA_ACC_SYMBOL_NAME)),
         )
+
+    def test_scaled_mma_six_entries(self):
+        """ScaledMMA: 6-entry layout with lhs_scale/rhs_scale carrying an extra dim."""
+        m_sym = wave.WaveSymbolAttr.get("M")
+        n_sym = wave.WaveSymbolAttr.get("N")
+        k_sym = wave.WaveSymbolAttr.get("K")
+        s_sym = wave.WaveSymbolAttr.get("S")
+
+        s0 = ir.AffineSymbolExpr.get(0)
+        c16 = ir.AffineConstantExpr.get(16)
+        c1 = ir.AffineConstantExpr.get(1)
+        c4 = ir.AffineConstantExpr.get(4)
+
+        m_mapping = wave.WaveIndexMappingAttr.get(
+            [m_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c16]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+        k_mapping = wave.WaveIndexMappingAttr.get(
+            [k_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c16]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+        n_mapping = wave.WaveIndexMappingAttr.get(
+            [n_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c16]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+        acc_m_mapping = wave.WaveIndexMappingAttr.get(
+            [m_sym],
+            ir.AffineMap.get(0, 1, [c16 - s0]),
+            ir.AffineMap.get(0, 1, [c1]),
+            ir.AffineMap.get(0, 1, [c16]),
+        )
+        acc_n_mapping = wave.WaveIndexMappingAttr.get(
+            [n_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c16]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+        s_mapping = wave.WaveIndexMappingAttr.get(
+            [s_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c4]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+        scale_k_mapping = wave.WaveIndexMappingAttr.get(
+            [k_sym],
+            ir.AffineMap.get(0, 1, [s0]),
+            ir.AffineMap.get(0, 1, [c16]),
+            ir.AffineMap.get(0, 1, [c1]),
+        )
+
+        lhs_dict = wave.WaveSymbolMappingAttr.get({"M": m_mapping, "K": k_mapping})
+        lhs_scale_dict = wave.WaveSymbolMappingAttr.get(
+            {"S": s_mapping, "K": scale_k_mapping}
+        )
+        rhs_dict = wave.WaveSymbolMappingAttr.get({"N": n_mapping, "K": k_mapping})
+        rhs_scale_dict = wave.WaveSymbolMappingAttr.get(
+            {"S": s_mapping, "K": scale_k_mapping}
+        )
+        acc_dict = wave.WaveSymbolMappingAttr.get(
+            {"M": acc_m_mapping, "N": acc_n_mapping}
+        )
+        result_dict = wave.WaveSymbolMappingAttr.get(
+            {"M": acc_m_mapping, "N": acc_n_mapping}
+        )
+
+        array_attr = ir.ArrayAttr.get(
+            [
+                lhs_dict,
+                lhs_scale_dict,
+                rhs_dict,
+                rhs_scale_dict,
+                acc_dict,
+                result_dict,
+            ]
+        )
+        result = convert_mma_index_to_sympy(array_attr, has_scale_operands=True)
+
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {
+            index_symbol("M"),
+            index_symbol("N"),
+            index_symbol("K"),
+            index_symbol("S"),
+        }
+        assert isinstance(result[index_symbol("M")].start, sympy.Piecewise)
+        assert result[index_symbol("S")] == IndexSequence(sym.S, 4, 1)

--- a/tests/mlir_wave_iface/attr_type_converter_test.py
+++ b/tests/mlir_wave_iface/attr_type_converter_test.py
@@ -46,7 +46,7 @@ if is_water_available():
     from mlir_converter.attr_type_converter import (
         _convert_affine_expr_to_sympy_expr,
         _convert_index_mapping_attr_to_sympy,
-        convert_index_mapping_dict_to_sympy,
+        convert_symbol_mapping_attr_to_sympy,
         convert_mma_index_to_sympy,
         _make_piecewise_sequence,
         ITER_SYMBOL_NAME_WAVE_PREFIX,
@@ -306,8 +306,8 @@ class TestConvertIndexMappingAttrToSympy:
         assert result.stride is None
 
 
-class TestConvertIndexMappingDictToSympy:
-    """Tests for convert_index_mapping_dict_to_sympy function."""
+class TestConvertSymbolMappingAttrToSympy:
+    """Tests for convert_symbol_mapping_attr_to_sympy."""
 
     def test_single_mapping(self):
         """Test conversion of dict with single index mapping."""
@@ -320,8 +320,8 @@ class TestConvertIndexMappingDictToSympy:
             symbols, start_map, step_map, stride_map
         )
 
-        dict_attr = wave.WaveSymbolMappingAttr.get({"dim0": mapping_attr})
-        result = convert_index_mapping_dict_to_sympy(dict_attr)
+        attr = wave.WaveSymbolMappingAttr.get({"dim0": mapping_attr})
+        result = convert_symbol_mapping_attr_to_sympy(attr)
 
         assert isinstance(result, dict)
         assert index_symbol("dim0") in result
@@ -348,8 +348,8 @@ class TestConvertIndexMappingDictToSympy:
             ir.AffineMap.get(0, 1, [ir.AffineConstantExpr.get(2)]),
         )
 
-        dict_attr = wave.WaveSymbolMappingAttr.get({"m": mapping1, "n": mapping2})
-        result = convert_index_mapping_dict_to_sympy(dict_attr)
+        attr = wave.WaveSymbolMappingAttr.get({"m": mapping1, "n": mapping2})
+        result = convert_symbol_mapping_attr_to_sympy(attr)
 
         assert len(result) == 2
         assert index_symbol("m") in result
@@ -393,7 +393,7 @@ class TestMakePiecewiseSequence:
 
 
 class TestConvertIndexMappingToSympy:
-    """Tests for convert_index_mapping_dict_to_sympy and convert_mma_index_to_sympy."""
+    """Tests for convert_symbol_mapping_attr_to_sympy and convert_mma_index_to_sympy."""
 
     def test_single_mapping(self):
         """Test conversion for a single WaveSymbolMappingAttr."""
@@ -407,7 +407,7 @@ class TestConvertIndexMappingToSympy:
         )
 
         mapping_attr = wave.WaveSymbolMappingAttr.get({"dim": mapping})
-        result = convert_index_mapping_dict_to_sympy(mapping_attr)
+        result = convert_symbol_mapping_attr_to_sympy(mapping_attr)
 
         assert isinstance(result, dict)
         assert index_symbol("dim") in result
@@ -618,7 +618,11 @@ class TestConvertIndexMappingToSympy:
         )
 
     def test_scaled_mma_six_entries(self):
-        """ScaledMMA: 6-entry layout with lhs_scale/rhs_scale carrying an extra dim."""
+        """ScaledMMA: 6-entry layout with lhs_scale/rhs_scale carrying an extra dim.
+
+        Contrasts `has_scale_operands=True` (this test) with the default four-operand
+        MMA path on the same tensor-side mappings: only the scaled call introduces S.
+        """
         m_sym = wave.WaveSymbolAttr.get("M")
         n_sym = wave.WaveSymbolAttr.get("N")
         k_sym = wave.WaveSymbolAttr.get("K")
@@ -697,6 +701,17 @@ class TestConvertIndexMappingToSympy:
                 result_dict,
             ]
         )
+
+        mma_tensor_only = convert_mma_index_to_sympy(
+            ir.ArrayAttr.get([lhs_dict, rhs_dict, acc_dict, result_dict])
+        )
+        assert index_symbol("S") not in mma_tensor_only
+        assert set(mma_tensor_only.keys()) == {
+            index_symbol("M"),
+            index_symbol("N"),
+            index_symbol("K"),
+        }
+
         result = convert_mma_index_to_sympy(array_attr, has_scale_operands=True)
 
         assert isinstance(result, dict)
@@ -707,4 +722,6 @@ class TestConvertIndexMappingToSympy:
             index_symbol("S"),
         }
         assert isinstance(result[index_symbol("M")].start, sympy.Piecewise)
+        # S comes only from lhs_scale / rhs_scale mappings, not the primary lhs dict.
+        assert index_symbol("S") not in convert_symbol_mapping_attr_to_sympy(lhs_dict)
         assert result[index_symbol("S")] == IndexSequence(sym.S, 4, 1)

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -865,6 +865,11 @@ def _fixup_region_node_common(
         fixed_init_args.append(fixed_arg)
 
     region_node.update_arg(init_args_field, fixed_init_args)
+    
+    # Expansion may multiply carried values. `Iterate.type` must match init_arg
+    # arity. `infer_types` ran before `expand_graph`, so refresh from the
+    # updated init_args here.
+    region_node.infer_type()
 
     for result_index, get_item in region_info.get_results.items():
         get_item.graph.inserting_before(get_item.fx_node)

--- a/wave_lang/kernel/wave/expansion/expansion.py
+++ b/wave_lang/kernel/wave/expansion/expansion.py
@@ -865,7 +865,7 @@ def _fixup_region_node_common(
         fixed_init_args.append(fixed_arg)
 
     region_node.update_arg(init_args_field, fixed_init_args)
-    
+
     # Expansion may multiply carried values. `Iterate.type` must match init_arg
     # arity. `infer_types` ran before `expand_graph`, so refresh from the
     # updated init_args here.

--- a/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
+++ b/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
@@ -295,7 +295,7 @@ def _convert_index_mapping_attr_to_sympy(
     return IndexSequence(start, step, stride)
 
 
-def convert_index_mapping_dict_to_sympy(
+def convert_symbol_mapping_attr_to_sympy(
     mapping_attr: wave.WaveSymbolMappingAttr,
     derived_dims: dict[str, IndexExpr] | None = None,
 ) -> dict[IndexSymbol, IndexSequence]:
@@ -371,25 +371,30 @@ def convert_mma_index_to_sympy(
     (LHS vs ACC have different access patterns); N, K, and batch dims
     are consistent across operands.
     """
-    dd = derived_dims
     if has_scale_operands:
         assert (
             len(array_attr) == 6
         ), f"Expected 6 index mapping entries for ScaledMMA, got {len(array_attr)}"
-        lhs_index = convert_index_mapping_dict_to_sympy(array_attr[0], dd)
-        lhs_scale_index = convert_index_mapping_dict_to_sympy(array_attr[1], dd)
-        rhs_index = convert_index_mapping_dict_to_sympy(array_attr[2], dd)
-        rhs_scale_index = convert_index_mapping_dict_to_sympy(array_attr[3], dd)
-        acc_index = convert_index_mapping_dict_to_sympy(array_attr[4], dd)
-        result_index = convert_index_mapping_dict_to_sympy(array_attr[5], dd)
+        (
+            lhs_index,
+            lhs_scale_index,
+            rhs_index,
+            rhs_scale_index,
+            acc_index,
+            result_index,
+        ) = tuple(
+            convert_symbol_mapping_attr_to_sympy(mapping, derived_dims)
+            for mapping in array_attr
+        )
+
     else:
         assert (
             len(array_attr) == 4
         ), f"Expected 4 index mapping entries for MMA, got {len(array_attr)}"
-        lhs_index = convert_index_mapping_dict_to_sympy(array_attr[0], dd)
-        rhs_index = convert_index_mapping_dict_to_sympy(array_attr[1], dd)
-        acc_index = convert_index_mapping_dict_to_sympy(array_attr[2], dd)
-        result_index = convert_index_mapping_dict_to_sympy(array_attr[3], dd)
+        lhs_index = convert_symbol_mapping_attr_to_sympy(array_attr[0], derived_dims)
+        rhs_index = convert_symbol_mapping_attr_to_sympy(array_attr[1], derived_dims)
+        acc_index = convert_symbol_mapping_attr_to_sympy(array_attr[2], derived_dims)
+        result_index = convert_symbol_mapping_attr_to_sympy(array_attr[3], derived_dims)
 
     bmk_symbols = set(lhs_index.keys())
     bnk_symbols = set(rhs_index.keys())
@@ -422,6 +427,8 @@ def convert_mma_index_to_sympy(
                 f"{lhs_scale_index[sym]} vs {rhs_scale_index[sym]}"
             )
         scale_only = set(lhs_scale_index.keys()) - set(combined.keys())
-        for sym in scale_only:
+        # Appended after tensor M/N/K/batch (see docstring). Sort for stable
+        # insertion order.
+        for sym in sorted(scale_only, key=str):
             combined[sym] = lhs_scale_index[sym]
     return combined

--- a/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
+++ b/wave_lang/kernel/wave/mlir_converter/attr_type_converter.py
@@ -27,6 +27,7 @@ from water_mlir.water_mlir.dialects import wave
 # This is fine since it doesn't depend on IREE transitively.
 from wave_lang.support.indexing import (
     MMA_ACC_SYMBOL_NAME,
+    IndexExpr,
     IndexSequence,
     index_symbol,
     IndexSymbol,
@@ -294,10 +295,19 @@ def _convert_index_mapping_attr_to_sympy(
     return IndexSequence(start, step, stride)
 
 
-def _convert_index_mapping_dict_to_sympy(
+def convert_index_mapping_dict_to_sympy(
     mapping_attr: wave.WaveSymbolMappingAttr,
+    derived_dims: dict[str, IndexExpr] | None = None,
 ) -> dict[IndexSymbol, IndexSequence]:
-    """Convert a WaveSymbolMappingAttr containing WaveIndexMappingAttr to a dictionary of Wave IndexSequences."""
+    """Convert a single WaveSymbolMappingAttr to a dict of IndexSequences.
+
+    When `derived_dims` is provided, derived dimension keys (e.g. `K32`)
+    are mapped back to their base symbol (e.g. `K`). This reverses the
+    emit-side `_remap_scaled_index_keys` which renames base-symbol keys
+    to match the MLIR type's dimension names. The base symbol is recovered
+    as the sole free symbol of the derived expression, mirroring the
+    constraint enforced by `_derived_dim_clean_name` on the emit side.
+    """
     result = {}
     for i in range(len(mapping_attr)):
         item = mapping_attr[i]
@@ -310,7 +320,17 @@ def _convert_index_mapping_dict_to_sympy(
         assert isinstance(
             value, wave.WaveIndexMappingAttr
         ), f"Unsupported index mapping attribute: {value}"
-        result[index_symbol(key)] = _convert_index_mapping_attr_to_sympy(value)
+        if derived_dims and key in derived_dims:
+            expr = derived_dims[key]
+            free = list(expr.free_symbols)
+            assert len(free) == 1, (
+                f"Derived dim '{key}' = {expr} has {len(free)} free symbols; "
+                f"expected exactly 1 (as enforced by _derived_dim_clean_name)"
+            )
+            sym = free[0]
+        else:
+            sym = index_symbol(key)
+        result[sym] = _convert_index_mapping_attr_to_sympy(value)
     return result
 
 
@@ -338,29 +358,39 @@ def _make_piecewise_sequence(
     )
 
 
-def convert_index_mapping_array_to_sympy(
-    op: ir.Operation, array_attr: ir.ArrayAttr, element: int = 0
+def convert_mma_index_to_sympy(
+    array_attr: ir.ArrayAttr,
+    derived_dims: dict[str, IndexExpr] | None = None,
+    has_scale_operands: bool = False,
 ) -> dict[IndexSymbol, IndexSequence]:
-    assert element == 0 or isinstance(op.opview, wave.IterateOp)
+    """Reconstruct a combined MMA index dict from per-operand index arrays.
 
-    if isinstance(op.opview, wave.IterateOp):
-        assert element < len(array_attr)
-        return _convert_index_mapping_dict_to_sympy(array_attr[element])
-
-    # TODO: for some reason, isinstance(op.opview, MmaOp) is not working. Something is off with dialect loading/registration.
-    if op.name != "wave.mma":
+    MMA ops carry separate index mappings per operand. This function converts
+    each mapping, infers M/N/K/batch roles via set algebra on the dimension
+    keys, and builds a single combined dict. Only M gets a Piecewise
+    (LHS vs ACC have different access patterns); N, K, and batch dims
+    are consistent across operands.
+    """
+    dd = derived_dims
+    if has_scale_operands:
         assert (
-            len(array_attr) == 1
-        ), f"Expected exactly one index mapping attribute for non-MMA op: {op}"
-        return _convert_index_mapping_dict_to_sympy(array_attr[0])
+            len(array_attr) == 6
+        ), f"Expected 6 index mapping entries for ScaledMMA, got {len(array_attr)}"
+        lhs_index = convert_index_mapping_dict_to_sympy(array_attr[0], dd)
+        lhs_scale_index = convert_index_mapping_dict_to_sympy(array_attr[1], dd)
+        rhs_index = convert_index_mapping_dict_to_sympy(array_attr[2], dd)
+        rhs_scale_index = convert_index_mapping_dict_to_sympy(array_attr[3], dd)
+        acc_index = convert_index_mapping_dict_to_sympy(array_attr[4], dd)
+        result_index = convert_index_mapping_dict_to_sympy(array_attr[5], dd)
+    else:
+        assert (
+            len(array_attr) == 4
+        ), f"Expected 4 index mapping entries for MMA, got {len(array_attr)}"
+        lhs_index = convert_index_mapping_dict_to_sympy(array_attr[0], dd)
+        rhs_index = convert_index_mapping_dict_to_sympy(array_attr[1], dd)
+        acc_index = convert_index_mapping_dict_to_sympy(array_attr[2], dd)
+        result_index = convert_index_mapping_dict_to_sympy(array_attr[3], dd)
 
-    assert (
-        len(array_attr) == 4
-    ), f"Expected exactly four index mapping attributes for MMA op: {op}"
-    lhs_index = _convert_index_mapping_dict_to_sympy(array_attr[0])
-    rhs_index = _convert_index_mapping_dict_to_sympy(array_attr[1])
-    acc_index = _convert_index_mapping_dict_to_sympy(array_attr[2])
-    result_index = _convert_index_mapping_dict_to_sympy(array_attr[3])
     bmk_symbols = set(lhs_index.keys())
     bnk_symbols = set(rhs_index.keys())
     bnm_symbols = set(acc_index.keys())
@@ -376,7 +406,7 @@ def convert_index_mapping_array_to_sympy(
         assert lhs_index[b_symbol] == rhs_index[b_symbol]
         assert rhs_index[b_symbol] == acc_index[b_symbol]
         assert acc_index[b_symbol] == result_index[b_symbol]
-    return {b_symbol: lhs_index[b_symbol] for b_symbol in b_symbols} | {
+    combined = {b_symbol: lhs_index[b_symbol] for b_symbol in b_symbols} | {
         m_symbol: _make_piecewise_sequence(
             (lhs_index[m_symbol], ~index_symbol(MMA_ACC_SYMBOL_NAME)),
             (acc_index[m_symbol], index_symbol(MMA_ACC_SYMBOL_NAME)),
@@ -384,3 +414,14 @@ def convert_index_mapping_array_to_sympy(
         n_symbol: rhs_index[n_symbol],
         k_symbol: lhs_index[k_symbol],
     }
+    if has_scale_operands:
+        scale_shared = set(lhs_scale_index.keys()) & set(rhs_scale_index.keys())
+        for sym in scale_shared:
+            assert lhs_scale_index[sym] == rhs_scale_index[sym], (
+                f"lhs_scale and rhs_scale disagree on {sym}: "
+                f"{lhs_scale_index[sym]} vs {rhs_scale_index[sym]}"
+            )
+        scale_only = set(lhs_scale_index.keys()) - set(combined.keys())
+        for sym in scale_only:
+            combined[sym] = lhs_scale_index[sym]
+    return combined

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -1816,17 +1816,17 @@ def convert_mlir_to_trace(
         if (hyper_params := func_op.attributes.get("wave.hyperparameters")) is not None:
             subs: dict[IndexSymbol, int] = {}
             deferred: dict[str, tuple[IndexSymbol, IndexExpr]] = {}
-            for param in hyper_params.mapping:
-                sym = index_symbol(param.name)
-                if not isinstance(param.attr, WaveExprListAttr):
-                    subs[sym] = param.attr.value
+            for sym_attr, value_attr in hyper_params.mapping:
+                sym = index_symbol(sym_attr.name)
+                if not isinstance(value_attr, WaveExprListAttr):
+                    subs[sym] = value_attr.value
                     continue
-                exprs = expr_list_attr_to_exprs(param.attr)
+                exprs = expr_list_attr_to_exprs(value_attr)
                 assert len(exprs) == 1, (
                     f"Expected single expression for derived dim {sym}, "
                     f"got {len(exprs)}"
                 )
-                deferred[param.name] = (sym, exprs[0])
+                deferred[sym_attr.name] = (sym, exprs[0])
             for name, (sym, expr) in deferred.items():
                 derived_dims[name] = expr
                 evaluated = expr.subs(subs)

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -1636,8 +1636,15 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
     result_types = [
         _convert_wave_tensor_type(result.type, parse_ctx) for result in results
     ]
-    # Make sure the type on the iterate node gets populated.
-    iterate_op.infer_type()
+    # Set `Iterate.type` from MLIR result types, not `NestedRegionOp.infer_type()`.
+    # During import, `init_args` may not yet carry complete `Register`/`Memory`
+    # types for every operand (attention and other large graphs); `infer_type`
+    # would then produce wrong or partial `type` and break roundtrip comparison.
+    # Arity matches `infer_type`: one result -> scalar, several -> list.
+    if len(result_types) == 1:
+        iterate_op.fx_node.type = result_types[0]
+    else:
+        iterate_op.fx_node.type = result_types
 
     converted_attrs = _convert_supported_attrs(
         op,

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -1636,15 +1636,8 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
     result_types = [
         _convert_wave_tensor_type(result.type, parse_ctx) for result in results
     ]
-    # The source trace stores a single type on the Iterate node when all
-    # results share the same type (the common case). Per-result types are
-    # tracked independently on each GetResult node. Collapse here to match.
-    if len(result_types) == 1 or (
-        result_types and all(t == result_types[0] for t in result_types)
-    ):
-        iterate_op.fx_node.type = result_types[0]
-    else:
-        iterate_op.fx_node.type = result_types
+    # Make sure the type on the iterate node gets populated.
+    iterate_op.infer_type()
 
     converted_attrs = _convert_supported_attrs(
         op,

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -38,6 +38,7 @@ try:
         AddOp,
         AllocateOp,
         ApplyExprOp,
+        BitcastOp,
         BroadcastOp,
         CastOp,
         DivOp,
@@ -50,6 +51,7 @@ try:
         MinOp,
         MmaOp,
         MulOp,
+        ScaledMmaOp,
         PermuteOp,
         ReadOp,
         ReciprocalOp,
@@ -110,6 +112,7 @@ from wave_lang.kernel.ops.wave_ops import (
     Add,
     Allocate,
     ApplyExpr,
+    BitcastOp as Bitcast,
     Broadcast,
     CastOp as Cast,
     Exp2,
@@ -124,6 +127,7 @@ from wave_lang.kernel.ops.wave_ops import (
     MMA,
     MMABase,
     Mul,
+    ScaledMMA,
     NewRegister,
     Output,
     Permute,
@@ -144,7 +148,8 @@ from wave_lang.kernel.ops.wave_ops import (
 from wave_lang.kernel.wave.utils.classes import ShuffleMode
 from attr_type_converter import (
     OPERAND_SYMBOL_NAME_WAVE_PREFIX,
-    convert_index_mapping_array_to_sympy,
+    convert_index_mapping_dict_to_sympy,
+    convert_mma_index_to_sympy,
     expr_list_attr_to_exprs,
     mlir_element_type_to_dtype,
     symbol_attr_to_name,
@@ -229,7 +234,7 @@ def _convert_wave_tensor_type(
 ) -> type[Memory] | type[Register]:
     """Converts a WaveTensorType to Memory or Register, dispatching on address space."""
     dims: list[IndexExpr | int] = [
-        index_symbol(symbol_attr_to_name(attr)) for attr in type_.shape
+        _resolve_dim(symbol_attr_to_name(attr), parse_ctx) for attr in type_.shape
     ]
     dtype = mlir_element_type_to_dtype(type_.element_type)
     if type_.address_space.value == wave.WaveAddressSpace.Register:
@@ -276,6 +281,7 @@ def _convert_mapping_attr(
     mapping_attr: WaveExprListAttr,
     memory_type: WaveTensorType,
     value_type: WaveTensorType,
+    parse_ctx: _OpParseContext,
     *,
     is_read: bool,
 ) -> IndexMapping | None:
@@ -310,8 +316,12 @@ def _convert_mapping_attr(
     for i, j in enumerate(inverse_perm):
         perm[j] = i
 
-    memory_dims = [index_symbol(symbol_attr_to_name(s)) for s in memory_type.shape]
-    value_dims = [index_symbol(symbol_attr_to_name(s)) for s in value_type.shape]
+    memory_dims = [
+        _resolve_dim(symbol_attr_to_name(s), parse_ctx) for s in memory_type.shape
+    ]
+    value_dims = [
+        _resolve_dim(symbol_attr_to_name(s), parse_ctx) for s in value_type.shape
+    ]
 
     sym_to_iter = {memory_dims[i]: IndexMapping.iterator(perm[i]) for i in range(n)}
 
@@ -360,13 +370,16 @@ def _convert_vector_shapes(
 
 
 def _convert_supported_attrs(
-    op: ir.OpView, ignore_attrs: set[str] | None = None
+    op: ir.OpView,
+    ignore_attrs: set[str] | None = None,
+    parse_ctx: _OpParseContext | None = None,
 ) -> dict[str, AttrValue]:
     """Converts supported MLIR attributes of an operation into Python objects.
 
     Args:
         op: MLIR operation (OpView subclass)
         ignore_attrs: Set of attribute names to skip
+        parse_ctx: Parsing context with derived_dims for dimension remapping
 
     Returns:
         Dictionary mapping attribute names to converted Python values:
@@ -380,10 +393,18 @@ def _convert_supported_attrs(
     attrs = op.attributes
     ignore_attrs = ignore_attrs or set()
     # Only allow attributes we can faithfully convert.
+    derived_dims = parse_ctx.derived_dims if parse_ctx else None
+
+    def _convert_non_mma_index(array_attr: ir.ArrayAttr):
+        """Non-MMA ops have a single-element index array. MMA/ScaledMMA
+        exclude this attr via ignore_attrs and convert separately."""
+        assert (
+            len(array_attr) == 1
+        ), f"Expected single index mapping for {op.name}, got {len(array_attr)}"
+        return convert_index_mapping_dict_to_sympy(array_attr[0], derived_dims)
+
     converters = {
-        AttrNames.INDEX.mlir_name: lambda a: convert_index_mapping_array_to_sympy(
-            op, a
-        ),
+        AttrNames.INDEX.mlir_name: _convert_non_mma_index,
         AttrNames.BOUNDS.mlir_name: _convert_read_write_bounds,
         AttrNames.ELEMENTS_PER_THREAD.mlir_name: lambda a: int(a.value),
         AttrNames.KIND.mlir_name: _convert_mma_kind,
@@ -669,6 +690,7 @@ class _OpParseContext:
     default_mma_type: MMAType | ScaledMMAType | None = None
     value_map: dict[ir.Value, fx.Node | int | float] = field(default_factory=dict)
     unspecified_addr_counter: itertools.count = field(default_factory=itertools.count)
+    derived_dims: dict[str, IndexExpr] = field(default_factory=dict)
 
     def resolve_operand(self, value: ir.Value) -> fx.Node | int | float:
         """Resolve MLIR value to its corresponding FX node or scalar."""
@@ -684,6 +706,13 @@ class _OpParseContext:
         self.value_map[mlir_value] = fx_node
 
 
+def _resolve_dim(name: str, parse_ctx: _OpParseContext) -> IndexExpr:
+    """Resolve a dimension name to a sympy expression, using derived_dims if available."""
+    if name in parse_ctx.derived_dims:
+        return parse_ctx.derived_dims[name]
+    return index_symbol(name)
+
+
 def _handle_constant_op(op: arith.ConstantOp, parse_ctx: _OpParseContext) -> None:
     """Handle arith.constant operation."""
     value = op.attributes[AttrNames.VALUE.mlir_name].value
@@ -694,9 +723,11 @@ def _handle_register_op(op: RegisterOp, parse_ctx: _OpParseContext) -> None:
     """Handle wave.register operation."""
     init_value = parse_ctx.resolve_operand(op.init)
     result_type = op.result.type
-    dims = tuple(index_symbol(symbol_attr_to_name(attr)) for attr in result_type.shape)
+    dims = tuple(
+        _resolve_dim(symbol_attr_to_name(attr), parse_ctx) for attr in result_type.shape
+    )
     dtype = mlir_element_type_to_dtype(result_type.element_type)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     register_op = NewRegister.create(
         parse_ctx.graph,
@@ -714,10 +745,10 @@ def _handle_broadcast_op(op: BroadcastOp, parse_ctx: _OpParseContext) -> None:
     source_node = parse_ctx.resolve_operand(op.source)
     result_type = op.result.type
     target_shape = tuple(
-        index_symbol(symbol_attr_to_name(attr)) for attr in result_type.shape
+        _resolve_dim(symbol_attr_to_name(attr), parse_ctx) for attr in result_type.shape
     )
     dtype = mlir_element_type_to_dtype(result_type.element_type)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     broadcast_op = Broadcast.create(
         parse_ctx.graph,
@@ -744,7 +775,9 @@ def _handle_lds_barrier_op(op: amdgpu.LDSBarrierOp, parse_ctx: _OpParseContext) 
 def _handle_allocate_op(op: AllocateOp, parse_ctx: _OpParseContext) -> None:
     """Handle wave.allocate operation."""
     result_type = op.result.type
-    shape = tuple(index_symbol(symbol_attr_to_name(attr)) for attr in result_type.shape)
+    shape = tuple(
+        _resolve_dim(symbol_attr_to_name(attr), parse_ctx) for attr in result_type.shape
+    )
     dtype = mlir_element_type_to_dtype(result_type.element_type)
 
     if result_type.address_space.value == wave.WaveAddressSpace.Register:
@@ -772,6 +805,7 @@ def _handle_allocate_op(op: AllocateOp, parse_ctx: _OpParseContext) -> None:
     converted_attrs = _convert_supported_attrs(
         op,
         ignore_attrs={"distributed_shape", "offset", "padding", "tail_padding"},
+        parse_ctx=parse_ctx,
     )
 
     allocate_op = Allocate.create(
@@ -796,6 +830,7 @@ def _handle_read_op(op: ReadOp, parse_ctx: _OpParseContext) -> None:
     converted_attrs = _convert_supported_attrs(
         op,
         ignore_attrs={AttrNames.MAPPING.mlir_name},
+        parse_ctx=parse_ctx,
     )
 
     mapping = None
@@ -804,6 +839,7 @@ def _handle_read_op(op: ReadOp, parse_ctx: _OpParseContext) -> None:
             op.attributes[AttrNames.MAPPING.mlir_name],
             op.memory.type,
             op.result.type,
+            parse_ctx,
             is_read=True,
         )
 
@@ -828,6 +864,7 @@ def _handle_write_op(op: WriteOp, parse_ctx: _OpParseContext) -> None:
     converted_attrs = _convert_supported_attrs(
         op,
         ignore_attrs={AttrNames.MAPPING.mlir_name},
+        parse_ctx=parse_ctx,
     )
 
     mapping = None
@@ -836,6 +873,7 @@ def _handle_write_op(op: WriteOp, parse_ctx: _OpParseContext) -> None:
             op.attributes[AttrNames.MAPPING.mlir_name],
             op.memory.type,
             op.value_to_store.type,
+            parse_ctx,
             is_read=False,
         )
 
@@ -859,64 +897,112 @@ def _handle_write_op(op: WriteOp, parse_ctx: _OpParseContext) -> None:
     # No mapping added because write produces no SSA results.
 
 
-def _handle_mma_op(op: MmaOp, parse_ctx: _OpParseContext) -> None:
-    """Handle wave.mma operation."""
-    lhs_node = parse_ctx.resolve_operand(op.lhs)
-    rhs_node = parse_ctx.resolve_operand(op.rhs)
-    acc_node = parse_ctx.resolve_operand(op.accumulator)
-    converted_attrs = _convert_supported_attrs(op)
-    mma_type = converted_attrs.pop(AttrNames.KIND.mlir_name, None)
-
-    # Pop vector_shapes before _apply_mlir_attrs_to_fx_node (which
-    # expects single-entry lists).  MMA carries [lhs, rhs, acc, result].
-    vector_shape_entries = converted_attrs.pop(AttrNames.VECTOR_SHAPES.mlir_name, None)
-
-    mma_op = MMA.create(
-        parse_ctx.graph,
-        lhs=lhs_node,
-        rhs=rhs_node,
-        acc=acc_node,
-        mma_type=mma_type,
-        type=_convert_wave_tensor_type(op.result.type, parse_ctx),
-    )
-
-    _apply_mlir_attrs_to_fx_node(mma_op.fx_node, converted_attrs)
-
-    if vector_shape_entries is not None:
-        assert len(vector_shape_entries) == 4, (
-            f"MMA vector_shape must have 4 entries "
-            f"(lhs, rhs, acc, result), got {len(vector_shape_entries)}"
+def _check_operand_vector_shapes(
+    op_name: str,
+    label: str,
+    node: fx.Node,
+    expected: dict[IndexSymbol, int] | None,
+) -> None:
+    """Verify that an operand's vector_shapes match the MLIR attribute."""
+    actual = getattr(node, "vector_shapes", None)
+    if expected is not None and actual != expected:
+        raise ValueError(
+            f"{op_name} {label} vector_shapes mismatch: "
+            f"operand has {actual}, MLIR attr has {expected}"
         )
-        lhs_vs, rhs_vs, acc_vs, result_vs = vector_shape_entries
 
-        def _check_operand_vector_shapes(
-            label: str, node: fx.Node, expected: dict[IndexSymbol, int] | None
-        ):
-            actual = getattr(node, "vector_shapes", None)
-            if expected is not None and actual != expected:
-                raise ValueError(
-                    f"MMA {label} vector_shapes mismatch: "
-                    f"operand has {actual}, MLIR attr has {expected}"
-                )
 
-        _check_operand_vector_shapes("lhs", lhs_node, lhs_vs)
-        _check_operand_vector_shapes("rhs", rhs_node, rhs_vs)
-        _check_operand_vector_shapes("acc", acc_node, acc_vs)
-
-        if result_vs is not None:
-            mma_op.fx_node.vector_shapes = result_vs
-
-    # Derive reduction_dim: the dimension shared by lhs and rhs but absent from acc.
+def _set_reduction_dim(
+    fx_node: fx.Node,
+    lhs_node: fx.Node,
+    rhs_node: fx.Node,
+    acc_node: fx.Node,
+    op_name: str,
+) -> None:
+    """Derive and set reduction_dim from lhs/rhs/acc shapes."""
     lhs_shape = get_custom(lhs_node).type.symbolic_shape
     rhs_shape = get_custom(rhs_node).type.symbolic_shape
     acc_shape = get_custom(acc_node).type.symbolic_shape
     reduction_dim = (set(lhs_shape) & set(rhs_shape)) - set(acc_shape)
     assert (
         len(reduction_dim) == 1
-    ), f"Expected exactly one reduction dimension for MMA, got {reduction_dim}"
-    mma_op.fx_node.reduction_dim = reduction_dim.pop()
+    ), f"Expected exactly one reduction dimension for {op_name}, got {reduction_dim}"
+    fx_node.reduction_dim = reduction_dim.pop()
 
-    parse_ctx.add_mapping(op.result, mma_op.fx_node)
+
+def _handle_mma_like_op(op: MmaOp | ScaledMmaOp, parse_ctx: _OpParseContext) -> None:
+    """Handle wave.mma and wave.scaled_mma operations."""
+    is_scaled = isinstance(op, ScaledMmaOp)
+    lhs_node = parse_ctx.resolve_operand(op.lhs)
+    rhs_node = parse_ctx.resolve_operand(op.rhs)
+    acc_node = parse_ctx.resolve_operand(op.accumulator)
+
+    converted_attrs = _convert_supported_attrs(
+        op, ignore_attrs={AttrNames.INDEX.mlir_name}, parse_ctx=parse_ctx
+    )
+    if AttrNames.INDEX.mlir_name in op.attributes:
+        converted_attrs[AttrNames.INDEX.mlir_name] = convert_mma_index_to_sympy(
+            op.attributes[AttrNames.INDEX.mlir_name],
+            derived_dims=parse_ctx.derived_dims,
+            has_scale_operands=is_scaled,
+        )
+    mma_type = converted_attrs.pop(AttrNames.KIND.mlir_name, None)
+    # Pop vector_shapes before _apply_mlir_attrs_to_fx_node (which
+    # expects single-entry lists). MMA carries per-operand + result entries.
+    vector_shape_entries = converted_attrs.pop(AttrNames.VECTOR_SHAPES.mlir_name, None)
+
+    if is_scaled:
+        lhs_scale_node = parse_ctx.resolve_operand(op.lhs_scale)
+        rhs_scale_node = parse_ctx.resolve_operand(op.rhs_scale)
+        fx_op = ScaledMMA.create(
+            parse_ctx.graph,
+            lhs=lhs_node,
+            lhs_scale=lhs_scale_node,
+            rhs=rhs_node,
+            rhs_scale=rhs_scale_node,
+            acc=acc_node,
+            mma_type=mma_type,
+            type=_convert_wave_tensor_type(op.result.type, parse_ctx),
+        )
+        operand_pairs = [
+            ("lhs", lhs_node),
+            ("lhs_scale", lhs_scale_node),
+            ("rhs", rhs_node),
+            ("rhs_scale", rhs_scale_node),
+            ("acc", acc_node),
+        ]
+    else:
+        fx_op = MMA.create(
+            parse_ctx.graph,
+            lhs=lhs_node,
+            rhs=rhs_node,
+            acc=acc_node,
+            mma_type=mma_type,
+            type=_convert_wave_tensor_type(op.result.type, parse_ctx),
+        )
+        operand_pairs = [
+            ("lhs", lhs_node),
+            ("rhs", rhs_node),
+            ("acc", acc_node),
+        ]
+
+    _apply_mlir_attrs_to_fx_node(fx_op.fx_node, converted_attrs)
+
+    op_name = "ScaledMMA" if is_scaled else "MMA"
+    expected_vs_count = len(operand_pairs) + 1
+    if vector_shape_entries is not None:
+        assert len(vector_shape_entries) == expected_vs_count, (
+            f"{op_name} vector_shape must have {expected_vs_count} entries, "
+            f"got {len(vector_shape_entries)}"
+        )
+        for (name, node), vs in zip(operand_pairs, vector_shape_entries):
+            _check_operand_vector_shapes(op_name, name, node, vs)
+        result_vs = vector_shape_entries[-1]
+        if result_vs is not None:
+            fx_op.fx_node.vector_shapes = result_vs
+
+    _set_reduction_dim(fx_op.fx_node, lhs_node, rhs_node, acc_node, op_name)
+    parse_ctx.add_mapping(op.result, fx_op.fx_node)
 
 
 def _handle_reduction_op(
@@ -937,10 +1023,12 @@ def _handle_reduction_op(
         # input and result (the verifier guarantees fully-specified types
         # when axis is absent).
         input_shape = set(
-            index_symbol(symbol_attr_to_name(s)) for s in op.inputs[0].type.shape
+            _resolve_dim(symbol_attr_to_name(s), parse_ctx)
+            for s in op.inputs[0].type.shape
         )
         result_shape = set(
-            index_symbol(symbol_attr_to_name(s)) for s in op.result.type.shape
+            _resolve_dim(symbol_attr_to_name(s), parse_ctx)
+            for s in op.result.type.shape
         )
         reduced_dims = input_shape - result_shape
         assert (
@@ -948,7 +1036,9 @@ def _handle_reduction_op(
         ), f"Expected exactly one reduced dimension, got {reduced_dims}"
         dim = reduced_dims.pop()
 
-    converted_attrs = _convert_supported_attrs(op, ignore_attrs={"scope", "axis"})
+    converted_attrs = _convert_supported_attrs(
+        op, ignore_attrs={"scope", "axis"}, parse_ctx=parse_ctx
+    )
 
     # The MLIR op always has a variadic input list, but pre-expansion
     # the FX graph uses a single node. Unwrap to match.
@@ -978,7 +1068,7 @@ def _handle_binary_op(
     """
     lhs_node = parse_ctx.resolve_operand(op.lhs)
     rhs_node = parse_ctx.resolve_operand(op.rhs)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     fx_op = fx_cls.create(
         parse_ctx.graph,
@@ -998,7 +1088,7 @@ def _handle_select_op(
     cond_node = parse_ctx.resolve_operand(op.condition)
     lhs_node = parse_ctx.resolve_operand(op.lhs)
     rhs_node = parse_ctx.resolve_operand(op.rhs)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     fx_op = Select.create(
         parse_ctx.graph,
@@ -1018,7 +1108,7 @@ def _handle_unary_op(
 ) -> None:
     """Handle unary arithmetic operations (wave.exp2, wave.reciprocal)."""
     arg_node = parse_ctx.resolve_operand(op.argument)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     fx_op = fx_cls.create(
         parse_ctx.graph,
@@ -1036,9 +1126,28 @@ def _handle_cast_op(
     """Handle wave.cast operation."""
     arg_node = parse_ctx.resolve_operand(op.value_to_cast)
     target_dtype = mlir_element_type_to_dtype(op.result.type.element_type)
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     fx_op = Cast.create(
+        parse_ctx.graph,
+        arg=arg_node,
+        dtype=target_dtype,
+        type=_convert_wave_tensor_type(op.result.type, parse_ctx),
+    )
+    _apply_mlir_attrs_to_fx_node(fx_op.fx_node, converted_attrs)
+    parse_ctx.add_mapping(op.result, fx_op.fx_node)
+
+
+def _handle_bitcast_op(
+    op: BitcastOp,
+    parse_ctx: _OpParseContext,
+) -> None:
+    """Handle wave.bitcast operation."""
+    arg_node = parse_ctx.resolve_operand(op.value_to_cast)
+    target_dtype = mlir_element_type_to_dtype(op.result.type.element_type)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
+
+    fx_op = Bitcast.create(
         parse_ctx.graph,
         arg=arg_node,
         dtype=target_dtype,
@@ -1056,9 +1165,9 @@ def _handle_permute_op(
     value_node = parse_ctx.resolve_operand(op.value)
     result_type = op.result.type
     target_shape = tuple(
-        index_symbol(symbol_attr_to_name(attr)) for attr in result_type.shape
+        _resolve_dim(symbol_attr_to_name(attr), parse_ctx) for attr in result_type.shape
     )
-    converted_attrs = _convert_supported_attrs(op)
+    converted_attrs = _convert_supported_attrs(op, parse_ctx=parse_ctx)
 
     fx_op = Permute.create(
         parse_ctx.graph,
@@ -1089,7 +1198,7 @@ def _handle_shuffle_op(
     mode_attr = WaveShuffleModeAttr(op.mode)
     mode = _WAVE_SHUFFLE_MODE_TO_FX[mode_attr.value]
     converted_attrs = _convert_supported_attrs(
-        op, ignore_attrs={"offset", "width", "mode"}
+        op, ignore_attrs={"offset", "width", "mode"}, parse_ctx=parse_ctx
     )
 
     fx_op = Shuffle.create(
@@ -1120,6 +1229,7 @@ def _handle_self_index_op(
             AttrNames.DIM.mlir_name,
             AttrNames.ELEMENTS_PER_THREAD.mlir_name,
         },
+        parse_ctx=parse_ctx,
     )
 
     fx_op = SelfIndex.create(
@@ -1228,6 +1338,7 @@ def _handle_apply_expr_op(
             AttrNames.EXPR.mlir_name,
             AttrNames.COMBINATOR.mlir_name,
         },
+        parse_ctx=parse_ctx,
     )
 
     fx_op = ApplyExpr.create(
@@ -1253,6 +1364,7 @@ def _handle_extract_op(
     converted_attrs = _convert_supported_attrs(
         op,
         ignore_attrs={AttrNames.POSITION.mlir_name},
+        parse_ctx=parse_ctx,
     )
 
     fx_op = Extract.create(
@@ -1287,6 +1399,7 @@ def _handle_reshape_op(
             AttrNames.LOGICAL_SLICE.mlir_name,
             AttrNames.NUM_SLICES.mlir_name,
         },
+        parse_ctx=parse_ctx,
     )
 
     fx_op = Reshape.create(
@@ -1314,6 +1427,7 @@ def _handle_extract_slice_op(op: ExtractSliceOp, parse_ctx: _OpParseContext) -> 
             AttrNames.SIZE.mlir_name,
             AttrNames.STRIDE.mlir_name,
         },
+        parse_ctx=parse_ctx,
     )
 
     slice_op = ExtractSlice.create(
@@ -1480,6 +1594,7 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
             default_mma_type=parse_ctx.default_mma_type,
             value_map=local_map,
             unspecified_addr_counter=parse_ctx.unspecified_addr_counter,
+            derived_dims=parse_ctx.derived_dims,
         ),
     )
 
@@ -1502,8 +1617,9 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
     # Infer index for the iterate node
     iter_index = None
     if AttrNames.INDEX.mlir_name in op.attributes:
-        iter_index = convert_index_mapping_array_to_sympy(
-            op, op.attributes[AttrNames.INDEX.mlir_name]
+        index_array = op.attributes[AttrNames.INDEX.mlir_name]
+        iter_index = convert_index_mapping_dict_to_sympy(
+            index_array[0], parse_ctx.derived_dims
         )
     else:
         # Try to infer from output values
@@ -1520,7 +1636,12 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
     result_types = [
         _convert_wave_tensor_type(result.type, parse_ctx) for result in results
     ]
-    if len(result_types) == 1:
+    # The source trace stores a single type on the Iterate node when all
+    # results share the same type (the common case). Per-result types are
+    # tracked independently on each GetResult node. Collapse here to match.
+    if len(result_types) == 1 or (
+        result_types and all(t == result_types[0] for t in result_types)
+    ):
         iterate_op.fx_node.type = result_types[0]
     else:
         iterate_op.fx_node.type = result_types
@@ -1532,6 +1653,7 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
             "iterator",
             "operandSegmentSizes",
         },
+        parse_ctx=parse_ctx,
     )
 
     # Pop vector_shapes before the generic apply (which expects single-entry
@@ -1582,8 +1704,8 @@ def _convert_ops(ops: Sequence[ir.Operation], parse_ctx: _OpParseContext) -> Non
                 _handle_read_op(op, parse_ctx)
             case WriteOp():
                 _handle_write_op(op, parse_ctx)
-            case MmaOp():
-                _handle_mma_op(op, parse_ctx)
+            case MmaOp() | ScaledMmaOp():
+                _handle_mma_like_op(op, parse_ctx)
             case SumOp():
                 _handle_reduction_op(op, Sum, parse_ctx)
             case MaxElementOp():
@@ -1606,6 +1728,8 @@ def _convert_ops(ops: Sequence[ir.Operation], parse_ctx: _OpParseContext) -> Non
                 _handle_unary_op(op, Exp2, parse_ctx)
             case ReciprocalOp():
                 _handle_unary_op(op, Reciprocal, parse_ctx)
+            case BitcastOp():
+                _handle_bitcast_op(op, parse_ctx)
             case CastOp():
                 _handle_cast_op(op, parse_ctx)
             case PermuteOp():
@@ -1681,12 +1805,36 @@ def convert_mlir_to_trace(
         if func_op is None:
             raise ValueError("No func.func found in module")
 
-        # Convert hyperparameters into options.
+        # Convert hyperparameters into subs.
+        # Hyperparameters are either plain integers (e.g. K = 256) or
+        # derived expressions stored as WaveExprListAttr (e.g. K32 =
+        # ceiling(K/32)). Derived expressions reference base symbols, so
+        # we collect all base integers first, then evaluate derived ones
+        # in a second pass.
         options = WaveCompileOptions()
-        if (hyper := func_op.attributes.get("wave.hyperparameters")) is not None:
-            subs: dict = {}
-            for sym_attr, value_attr in hyper.mapping:
-                subs[index_symbol(sym_attr.name)] = value_attr.value
+        derived_dims: dict[str, IndexExpr] = {}
+        if (hyper_params := func_op.attributes.get("wave.hyperparameters")) is not None:
+            subs: dict[IndexSymbol, int] = {}
+            deferred: dict[str, tuple[IndexSymbol, IndexExpr]] = {}
+            for param in hyper_params.mapping:
+                sym = index_symbol(param.name)
+                if isinstance(param.attr, WaveExprListAttr):
+                    exprs = expr_list_attr_to_exprs(param.attr)
+                    assert len(exprs) == 1, (
+                        f"Expected single expression for derived dim {sym}, "
+                        f"got {len(exprs)}"
+                    )
+                    deferred[param.name] = (sym, exprs[0])
+                else:
+                    subs[sym] = param.attr.value
+            for name, (sym, expr) in deferred.items():
+                derived_dims[name] = expr
+                evaluated = expr.subs(subs)
+                assert evaluated.is_number, (
+                    f"Derived dim {name} = {expr} did not resolve to a "
+                    f"number (got {evaluated}); base hyperparameters may be missing"
+                )
+                subs[sym] = int(evaluated)
             options.subs = subs
         constraints = _convert_constraints(func_op)
 
@@ -1702,6 +1850,7 @@ def convert_mlir_to_trace(
             graph=root_graph,
             region_graph=region_graph,
             default_mma_type=default_mma_type,
+            derived_dims=derived_dims,
         )
 
         # Create placeholders for function arguments

--- a/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/fx_emitter.py
@@ -148,7 +148,7 @@ from wave_lang.kernel.ops.wave_ops import (
 from wave_lang.kernel.wave.utils.classes import ShuffleMode
 from attr_type_converter import (
     OPERAND_SYMBOL_NAME_WAVE_PREFIX,
-    convert_index_mapping_dict_to_sympy,
+    convert_symbol_mapping_attr_to_sympy,
     convert_mma_index_to_sympy,
     expr_list_attr_to_exprs,
     mlir_element_type_to_dtype,
@@ -401,7 +401,7 @@ def _convert_supported_attrs(
         assert (
             len(array_attr) == 1
         ), f"Expected single index mapping for {op.name}, got {len(array_attr)}"
-        return convert_index_mapping_dict_to_sympy(array_attr[0], derived_dims)
+        return convert_symbol_mapping_attr_to_sympy(array_attr[0], derived_dims)
 
     converters = {
         AttrNames.INDEX.mlir_name: _convert_non_mma_index,
@@ -912,14 +912,14 @@ def _check_operand_vector_shapes(
         )
 
 
-def _set_reduction_dim(
+def _set_mma_like_reduction_dim(
     fx_node: fx.Node,
     lhs_node: fx.Node,
     rhs_node: fx.Node,
     acc_node: fx.Node,
     op_name: str,
 ) -> None:
-    """Derive and set reduction_dim from lhs/rhs/acc shapes."""
+    """Derive and set reduction_dim for MMA / ScaledMMA from lhs/rhs/acc shapes."""
     lhs_shape = get_custom(lhs_node).type.symbolic_shape
     rhs_shape = get_custom(rhs_node).type.symbolic_shape
     acc_shape = get_custom(acc_node).type.symbolic_shape
@@ -1001,7 +1001,7 @@ def _handle_mma_like_op(op: MmaOp | ScaledMmaOp, parse_ctx: _OpParseContext) -> 
         if result_vs is not None:
             fx_op.fx_node.vector_shapes = result_vs
 
-    _set_reduction_dim(fx_op.fx_node, lhs_node, rhs_node, acc_node, op_name)
+    _set_mma_like_reduction_dim(fx_op.fx_node, lhs_node, rhs_node, acc_node, op_name)
     parse_ctx.add_mapping(op.result, fx_op.fx_node)
 
 
@@ -1618,7 +1618,7 @@ def _handle_iterate_op(op: IterateOp, parse_ctx: _OpParseContext) -> None:
     iter_index = None
     if AttrNames.INDEX.mlir_name in op.attributes:
         index_array = op.attributes[AttrNames.INDEX.mlir_name]
-        iter_index = convert_index_mapping_dict_to_sympy(
+        iter_index = convert_symbol_mapping_attr_to_sympy(
             index_array[0], parse_ctx.derived_dims
         )
     else:
@@ -1818,15 +1818,15 @@ def convert_mlir_to_trace(
             deferred: dict[str, tuple[IndexSymbol, IndexExpr]] = {}
             for param in hyper_params.mapping:
                 sym = index_symbol(param.name)
-                if isinstance(param.attr, WaveExprListAttr):
-                    exprs = expr_list_attr_to_exprs(param.attr)
-                    assert len(exprs) == 1, (
-                        f"Expected single expression for derived dim {sym}, "
-                        f"got {len(exprs)}"
-                    )
-                    deferred[param.name] = (sym, exprs[0])
-                else:
+                if not isinstance(param.attr, WaveExprListAttr):
                     subs[sym] = param.attr.value
+                    continue
+                exprs = expr_list_attr_to_exprs(param.attr)
+                assert len(exprs) == 1, (
+                    f"Expected single expression for derived dim {sym}, "
+                    f"got {len(exprs)}"
+                )
+                deferred[param.name] = (sym, exprs[0])
             for name, (sym, expr) in deferred.items():
                 derived_dims[name] = expr
                 evaluated = expr.subs(subs)

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -28,7 +28,8 @@ if __name__ == "__main__":
         sys.path.append(_current_dir)
 
 from attr_type_converter import (
-    convert_index_mapping_array_to_sympy,
+    convert_index_mapping_dict_to_sympy,
+    convert_mma_index_to_sympy,
     dtype_to_mlir_scalar_type,
     get_operand_symbol_placeholders,
     preprocess_symbols,
@@ -1738,13 +1739,22 @@ def _build_response(
                     ), f"Index already set for water id {attribute.value}."
                     assert "index" in op.attributes, f"Index not inferred for {op}."
 
-                    inferred_attributes[attribute.value].update(
-                        {
-                            "index": convert_index_mapping_array_to_sympy(
-                                op, op.attributes["index"], element
-                            )
-                        }
-                    )
+                    index_array = op.attributes["index"]
+                    if isinstance(op.opview, MmaOp):
+                        index = convert_mma_index_to_sympy(index_array)
+                    elif isinstance(op.opview, ScaledMmaOp):
+                        index = convert_mma_index_to_sympy(
+                            index_array, has_scale_operands=True
+                        )
+                    else:
+                        assert element < len(index_array), (
+                            f"index element {element} out of range for "
+                            f"{op.name} with {len(index_array)} entries"
+                        )
+                        index = convert_index_mapping_dict_to_sympy(
+                            index_array[element]
+                        )
+                    inferred_attributes[attribute.value].update({"index": index})
 
                 if attribute is not None:
                     record_index(attribute, inferred_attributes)

--- a/wave_lang/kernel/wave/mlir_converter/water_emitter.py
+++ b/wave_lang/kernel/wave/mlir_converter/water_emitter.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         sys.path.append(_current_dir)
 
 from attr_type_converter import (
-    convert_index_mapping_dict_to_sympy,
+    convert_symbol_mapping_attr_to_sympy,
     convert_mma_index_to_sympy,
     dtype_to_mlir_scalar_type,
     get_operand_symbol_placeholders,
@@ -1751,7 +1751,7 @@ def _build_response(
                             f"index element {element} out of range for "
                             f"{op.name} with {len(index_array)} entries"
                         )
-                        index = convert_index_mapping_dict_to_sympy(
+                        index = convert_symbol_mapping_attr_to_sympy(
                             index_array[element]
                         )
                     inferred_attributes[attribute.value].update({"index": index})

--- a/wave_lang/kernel/wave/utils/graph_utils.py
+++ b/wave_lang/kernel/wave/utils/graph_utils.py
@@ -31,6 +31,8 @@ from ...lang.wave_types import Memory, Register
 from ..constraints import HardwareConstraint, TilingConstraint, WaveConstraint
 from ...ops.wave_ops import (
     MMA,
+    MMABase,
+    ScaledMMA,
     Allocate,
     Broadcast,
     Conditional,
@@ -484,6 +486,46 @@ def _check_index_equivalent(
     raise ValueError(f"Unsupported index types: {type(lhs)} vs {type(rhs)}")
 
 
+def _check_mma_indices_equivalent(
+    lhs_custom: MMABase,
+    rhs_custom: MMABase,
+    subs: Optional[dict[IndexSymbol, int]],
+) -> Result:
+    """Compare MMA/ScaledMMA indices per-operand rather than on the combined dict.
+
+    The combined index dict carries Piecewise expressions whose conditions use
+    MMA_LHS, MMA_ACC, MMA_LHS_SCALE, MMA_RHS_SCALE, MMA_SCALE_FP4, etc.
+    Each per-operand property (lhs_index, rhs_index, ...) substitutes these
+    with concrete 0/1 values, resolving the Piecewise. Comparing per-operand
+    avoids mismatches from Piecewise branches that are dead for a given dtype
+    configuration and therefore lost during MLIR serialization.
+    """
+    # Result index == acc index (asserted in convert_mma_index_to_sympy),
+    # so comparing acc suffices.
+    operand_names = ["lhs", "rhs", "acc"]
+    if isinstance(lhs_custom, ScaledMMA):
+        operand_names = ["lhs", "lhs_scale", "rhs", "rhs_scale", "acc"]
+
+    for name in operand_names:
+        lhs_op_index = getattr(lhs_custom, f"{name}_index", None)
+        rhs_op_index = getattr(rhs_custom, f"{name}_index", None)
+        if lhs_op_index is None:
+            continue
+        if rhs_op_index is None:
+            return Failure(
+                f"{type(lhs_custom).__name__}.{name}_index: present in reference but absent in actual"
+            )
+        if not (
+            check_result := _check_index_mapping_equivalent(
+                lhs_op_index, rhs_op_index, subs
+            )
+        ):
+            return Failure(
+                f"{type(lhs_custom).__name__}.{name}_index: {check_result.error}"
+            )
+    return Success()
+
+
 def _check_nodes_equivalent(
     lhs_custom: CustomOp,
     rhs_custom: CustomOp,
@@ -598,7 +640,17 @@ def _check_nodes_equivalent(
                 return Failure(
                     f"index lost on {type(lhs_custom).__name__}: present in reference but absent in actual",
                 )
-            if not (
+            # MMA/ScaledMMA: compare per-operand indices rather than the
+            # combined dict, which carries Piecewise branches that may be
+            # dead for a given dtype and lost during MLIR serialization.
+            if isinstance(lhs_custom, MMABase):
+                if not (
+                    check_result := _check_mma_indices_equivalent(
+                        lhs_custom, rhs_custom, subs
+                    )
+                ):
+                    return check_result
+            elif not (
                 check_result := _check_index_equivalent(lhs_index, rhs_index, subs)
             ):
                 return check_result

--- a/wave_lang/kernel/wave/utils/graph_utils.py
+++ b/wave_lang/kernel/wave/utils/graph_utils.py
@@ -412,6 +412,41 @@ def _check_payloads_equivalent(
     return Success() if lhs == rhs else Failure(f"value mismatch: {lhs} vs {rhs}")
 
 
+def _pairs_for_nested_region_result_types(
+    lhs: ResultType,
+    rhs: ResultType,
+) -> Result[list[tuple[ResultType, ResultType]]]:
+    """Build (lhs, rhs) pairs for comparing NestedRegionOp `type` fields.
+
+    Same-length `zip` is the normal case. The arity-1-vs-N branch below should
+    not be needed if `Iterate.type` always matched `NestedRegionOp.infer_type`
+    (one type per carry, list when several). Some passes still collapse multiple
+    GetResult types onto a single `type` on the iterate node. MLIR import does
+    not.
+    """
+    lhs_types = list(lhs) if isinstance(lhs, (list, tuple)) else [lhs]
+    rhs_types = list(rhs) if isinstance(rhs, (list, tuple)) else [rhs]
+    if len(lhs_types) == len(rhs_types):
+        pairs = list(zip(lhs_types, rhs_types))
+    elif not lhs_types or not rhs_types:
+        return Failure(
+            f"result type arity mismatch: {len(lhs_types)} vs {len(rhs_types)}"
+        )
+    # Workaround until Iterate `type` is always arity-aligned with GetResults.
+    # TODO: fix those passes so roundtrip compares equal-arity `type` lists and
+    # this broadcast can be removed.
+    elif min(len(lhs_types), len(rhs_types)) == 1:
+        if len(lhs_types) == 1:
+            pairs = [(lhs_types[0], rhs_t) for rhs_t in rhs_types]
+        else:
+            pairs = [(lhs_t, rhs_types[0]) for lhs_t in lhs_types]
+    else:
+        return Failure(
+            f"result type arity mismatch: {len(lhs_types)} vs {len(rhs_types)}"
+        )
+    return Success(pairs)
+
+
 def _check_result_types_equivalent(
     lhs: ResultType,
     rhs: ResultType,
@@ -426,6 +461,15 @@ def _check_result_types_equivalent(
         return Success()
     if rhs is None:
         return Failure("type lost: present in reference but absent in actual")
+
+    if isinstance(lhs, (list, tuple)) or isinstance(rhs, (list, tuple)):
+        zipped_results = _pairs_for_nested_region_result_types(lhs, rhs)
+        if not zipped_results:
+            return zipped_results
+        for i, (a, b) in enumerate(zipped_results.value):
+            if not (check_result := _check_result_types_equivalent(a, b, subs)):
+                return Failure(f"result type[{i}]: {check_result.error}")
+        return Success()
 
     if (lhs_shape := getattr(lhs, "symbolic_shape", None)) != (
         rhs_shape := getattr(rhs, "symbolic_shape", None)

--- a/wave_lang/kernel/wave/utils/graph_utils.py
+++ b/wave_lang/kernel/wave/utils/graph_utils.py
@@ -9,11 +9,12 @@ from dataclasses import fields as dataclass_fields, is_dataclass
 
 import numpy as np
 from typing import (
+    Any,
     Callable,
+    Iterable,
     Optional,
     Sequence,
     TypeAlias,
-    Any,
 )
 
 import sympy
@@ -415,7 +416,7 @@ def _check_payloads_equivalent(
 def _pairs_for_nested_region_result_types(
     lhs: ResultType,
     rhs: ResultType,
-) -> Result[list[tuple[ResultType, ResultType]]]:
+) -> Result[Iterable[tuple[ResultType, ResultType]]]:
     """Build (lhs, rhs) pairs for comparing NestedRegionOp `type` fields.
 
     Same-length `zip` is the normal case. The arity-1-vs-N branch below should
@@ -427,19 +428,15 @@ def _pairs_for_nested_region_result_types(
     lhs_types = list(lhs) if isinstance(lhs, (list, tuple)) else [lhs]
     rhs_types = list(rhs) if isinstance(rhs, (list, tuple)) else [rhs]
     if len(lhs_types) == len(rhs_types):
-        pairs = list(zip(lhs_types, rhs_types))
-    elif not lhs_types or not rhs_types:
-        return Failure(
-            f"result type arity mismatch: {len(lhs_types)} vs {len(rhs_types)}"
-        )
+        pairs: Iterable[tuple[ResultType, ResultType]] = zip(lhs_types, rhs_types)
     # Workaround until Iterate `type` is always arity-aligned with GetResults.
     # TODO: fix those passes so roundtrip compares equal-arity `type` lists and
     # this broadcast can be removed.
     elif min(len(lhs_types), len(rhs_types)) == 1:
         if len(lhs_types) == 1:
-            pairs = [(lhs_types[0], rhs_t) for rhs_t in rhs_types]
+            pairs = ((lhs_types[0], rhs_t) for rhs_t in rhs_types)
         else:
-            pairs = [(lhs_t, rhs_types[0]) for lhs_t in lhs_types]
+            pairs = ((lhs_t, rhs_types[0]) for lhs_t in lhs_types)
     else:
         return Failure(
             f"result type arity mismatch: {len(lhs_types)} vs {len(rhs_types)}"


### PR DESCRIPTION
Teach the MLIR-to-FX importer to handle ops used by the MXFP4 GEMM kernel and fix the roundtrip comparison for MMA index expressions.

FX emitter:
- Add `_handle_mma_like_op` handling both `wave.mma` and `wave.scaled_mma`
- Add `_handle_bitcast_op` for `wave.bitcast`.
- Add derived dimension support: hyperparameter parsing separates base integers from WaveExprListAttr expressions (e.g. K32 = ceiling(K/32)), with `_resolve_dim` mapping MLIR dimension names back to symbolic expressions.
- Thread `parse_ctx` through all `_convert_supported_attrs` call sites.

Attribute converter:
- Replace `convert_index_mapping_array_to_sympy` (which dispatched on `op.name` strings) with `convert_index_mapping_dict_to_sympy` (single mapping) and `convert_mma_index_to_sympy` (MMA/ScaledMMA reconstruction with derived_dims support).
- Assert lhs_scale/rhs_scale index consistency for ScaledMMA.

Roundtrip comparison:
- Compare MMA/ScaledMMA indices per-operand (`lhs_index`, `rhs_index`, etc.)  rather than on the combined dict. The combined dict carries Piecewise expressions over operand-selector symbols that are dead for certain dtype configurations and lost during MLIR serialization.
- Add WaveConstraint comparator and thread `subs` into `assert_traces_equivalent`