### PR TITLE
disable flaky rdna4 test

### DIFF
--- a/tests/kernel/wave_gemm_test.py
+++ b/tests/kernel/wave_gemm_test.py
@@ -759,7 +759,10 @@ def testNonTransposeGemm(
         pytest.param(MMAType.F32_16x16x16_F16, 64, False, marks=require_cdna_3_or_4),
         pytest.param(MMAType.F32_32x32x8_F16, 64, False, marks=require_cdna_3_or_4),
         pytest.param(
-            MMAType.RDNA4_WAVE32_F32_16x16x16_F16, 32, False, marks=require_rdna4
+            MMAType.RDNA4_WAVE32_F32_16x16x16_F16,
+            32,
+            False,
+            marks=(*require_rdna4, pytest.mark.skip(reason="flaky (race condition?)")),
         ),
     ],
 )


### PR DESCRIPTION
This has been failing intermittently on CI for over a month with no intention to fix, I'm tired of having to triage.