### PR TITLE
[water] improve error message for source vector shape conflict

### DIFF
--- a/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
+++ b/water/lib/Dialect/Wave/IR/WaveInterfaces.cpp
@@ -1609,7 +1609,8 @@ wave::IndexExprsLatticeStorage::getJoinedSourceVectorShape(
   int32_t rhsPri = rhs.getSourceVectorShapePriority();
 
   if (!lhsSVS && !rhsSVS)
-    return std::make_pair(DictionaryAttr(), wave::IndexExprsLatticeStorage::kLowestPriority);
+    return std::make_pair(DictionaryAttr(),
+                          wave::IndexExprsLatticeStorage::kLowestPriority);
   if (!lhsSVS)
     return std::make_pair(rhsSVS, rhsPri);
   if (!rhsSVS)


### PR DESCRIPTION
This is a separate field of the index expression lattice so it is helpful to highlight which field is causing conflicts.