### PR TITLE
Reland [asm] Explicit SCC modeling (#1219)

### DIFF
--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -1365,6 +1365,8 @@ def _generate_asm_code(mb, options):
             else "--waveasm-insert-waitcnt=ticketed-waitcnt=false"
         )
         tail_passes = [
+            "--waveasm-scc-spill-reload",
+            "--waveasm-scc-verifier",
             "--waveasm-linear-scan=max-vgprs=256 max-agprs=256",
             waitcnt_flag,
             f"--waveasm-hazard-mitigation=target={options.target}",

--- a/waveasm/include/waveasm/Dialect/WaveASMControlFlowOps.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMControlFlowOps.td
@@ -75,7 +75,7 @@ def WaveASM_IfOp : WAVEASMOp<"if", [
     (simple if, if-then-else, multi-result if, if nested in loop).
   }];
 
-  let arguments = (ins WaveASM_AnySGPR:$condition);
+  let arguments = (ins WaveASM_AnySCCOrSGPR:$condition);
   let results = (outs Variadic<WaveASM_AnyReg>:$results);
   let regions = (region SizedRegion<1>:$thenRegion,
                         AnyRegion:$elseRegion);
@@ -123,7 +123,7 @@ def WaveASM_ConditionOp : WAVEASMOp<"condition", [
     See test/Dialect/region-control-flow.mlir for usage examples.
   }];
 
-  let arguments = (ins WaveASM_AnySGPR:$condition,
+  let arguments = (ins WaveASM_AnySCCOrSGPR:$condition,
                        Variadic<WaveASM_AnyReg>:$iterArgs);
 
   let assemblyFormat = [{

--- a/waveasm/include/waveasm/Dialect/WaveASMInterfaces.h
+++ b/waveasm/include/waveasm/Dialect/WaveASMInterfaces.h
@@ -53,6 +53,20 @@ class ControlFlowOp : public TraitBase<ConcreteType, ControlFlowOp> {};
 template <typename ConcreteType>
 class SpecialRegOp : public TraitBase<ConcreteType, SpecialRegOp> {};
 
+/// Trait for operations that implicitly write the SCC (Scalar Condition Code)
+/// flag as a hardware side effect.  Ops with this trait must not be placed
+/// between an SCC-producing op and its consumer (ConditionOp, s_cselect,
+/// s_addc_u32).  The SCC verifier pass checks this invariant.
+template <typename ConcreteType>
+class SCCDef : public TraitBase<ConcreteType, SCCDef> {};
+
+/// Trait for operations that implicitly read the SCC flag.
+/// The result depends on the current SCC value, so these ops are NOT
+/// eligible for CSE (two identical operands can produce different results
+/// if SCC differs).
+template <typename ConcreteType>
+class SCCUse : public TraitBase<ConcreteType, SCCUse> {};
+
 } // namespace OpTrait
 } // namespace mlir
 

--- a/waveasm/include/waveasm/Dialect/WaveASMInterfaces.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMInterfaces.td
@@ -269,4 +269,10 @@ def WaveASM_ControlFlowOp : NativeOpTrait<"ControlFlowOp">;
 // Trait for special register operations (M0, VCC, EXEC)
 def WaveASM_SpecialRegOp : NativeOpTrait<"SpecialRegOp">;
 
+// Trait for operations that implicitly write the SCC flag.
+def WaveASM_SCCDef : NativeOpTrait<"SCCDef">;
+
+// Trait for operations that implicitly read the SCC flag.
+def WaveASM_SCCUse : NativeOpTrait<"SCCUse">;
+
 #endif // WaveASM_DIALECT_WAVEASMINTERFACES

--- a/waveasm/include/waveasm/Dialect/WaveASMOps.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMOps.td
@@ -83,6 +83,8 @@ class VALUCmpOp<string mnemonic, list<Trait> traits = []>
 }
 
 // SALU Unary: dst = op(src)
+// Pure -- does NOT clobber SCC on hardware.
+// Used for: s_mov_b32, s_mov_b64, s_sext_i32_i8, s_sext_i32_i16.
 class SALUUnaryOp<string mnemonic, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_ArithmeticOp], traits)> {
   let arguments = (ins WaveASM_SRegOrImm:$src);
@@ -90,7 +92,20 @@ class SALUUnaryOp<string mnemonic, list<Trait> traits = []>
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($dst)";
 }
 
+// SALU Unary with SCC clobber: dst = op(src), SCC = f(result)
+// Writes SCC on hardware but result depends only on operands.
+class SALUUnaryWithSCCOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([
+        Pure, WaveASM_ArithmeticOp, WaveASM_SCCDef
+      ], traits)> {
+  let arguments = (ins WaveASM_SRegOrImm:$src);
+  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_SCC:$scc);
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($dst) `,` type($scc)";
+}
+
 // SALU Binary: dst = op(src0, src1)
+// Pure -- does NOT clobber SCC on hardware.
+// Used for: s_mul_i32, s_mul_hi_*, s_bfm_*, s_pack_*.
 class SALUBinaryOp<string mnemonic, list<Trait> traits = []>
     : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_ArithmeticOp], traits)> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
@@ -98,34 +113,48 @@ class SALUBinaryOp<string mnemonic, list<Trait> traits = []>
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($dst)";
 }
 
-// SALU Binary with carry/SCC: dst, scc = op(src0, src1)
-// s_add_u32 and s_addc_u32 set SCC (carry flag) as a side effect.
-// We model SCC as an explicit sreg result so the verifier can prevent
-// reordering ops that corrupt the carry chain.
-// TODO: The scc result should be fed as an explicit operand to s_addc_u32
-// when used in an add-with-carry chain (s_add_u32 → s_addc_u32), creating
-// a true SSA dependency. Currently the chain is only enforced by emission
-// ordering, not by the SSA graph.
-class SALUBinaryWithCarryOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, !listconcat([WaveASM_ArithmeticOp], traits)> {
+// SALU Binary with SCC clobber: dst = op(src0, src1), SCC = f(result)
+// Writes SCC on hardware but result depends only on operands.
+class SALUBinaryWithSCCOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([
+        Pure, WaveASM_ArithmeticOp, WaveASM_SCCDef
+      ], traits)> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
-  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_AnySGPR:$scc);
+  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_SCC:$scc);
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($dst) `,` type($scc)";
 }
 
-// SALU Compare: returns condition in SCC.
-// NOTE: On hardware, s_cmp sets the implicit SCC flag with no destination
-// register. We model SCC as an explicit sreg result so that ConditionOp
-// (the while-loop terminator) can reference it as an SSA Value. The
-// assembly emitter special-cases all S_CMP ops to emit only the two
-// source operands (no destination). The register allocator treats the
-// result as a regular sreg; this wastes one SGPR slot but is harmless
-// since the live range is very short (s_cmp -> condition terminator).
-// TODO: Consider a dedicated SCCType to avoid the wasted register slot.
-class SALUCmpOp<string mnemonic, list<Trait> traits = []>
-    : WAVEASMOp<mnemonic, traits> {
+// SALU Binary with carry-out: dst, scc = op(src0, src1)
+// Sets SCC as a side effect (carry-out). Used for S_ADD_U32, S_SUB_U32, etc.
+class SALUBinaryWithCarryOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_ArithmeticOp, WaveASM_SCCDef], traits)> {
   let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
-  let results = (outs WaveASM_AnySGPR:$result);  // SCC result (see note above)
+  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_SCC:$scc);
+  let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($dst) `,` type($scc)";
+}
+
+// SALU Binary with carry-in AND carry-out: dst, scc = op(scc_in, src0, src1)
+// Reads SCC (carry-in) and writes SCC (carry-out). Used for S_ADDC_U32.
+// The explicit $scc_in operand creates a true SSA dependency for the
+// carry chain (s_add_u32 -> s_addc_u32), enabling correct CSE behavior.
+class SALUBinaryWithCarryInOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([WaveASM_ArithmeticOp, WaveASM_SCCDef, WaveASM_SCCUse], traits)> {
+  let arguments = (ins WaveASM_SCC:$scc_in, WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
+  let results = (outs WaveASM_AnySGPR:$dst, WaveASM_SCC:$scc);
+  let assemblyFormat = "$scc_in `,` $src0 `,` $src1 attr-dict `:` type($scc_in) `,` type($src0) `,` type($src1) `->` type($dst) `,` type($scc)";
+}
+
+// SALU Compare: returns condition in SCC.
+// On hardware, s_cmp sets the implicit SCC flag with no destination register.
+// We model SCC as an explicit SCCType result so that ConditionOp / IfOp can
+// reference it as an SSA Value. The assembly emitter skips SCC results and
+// operands during emission. CSE-eligible; the SCC spill/reload pass handles
+// extended live ranges created by CSE.
+class SALUCmpOp<string mnemonic, list<Trait> traits = []>
+    : WAVEASMOp<mnemonic, !listconcat([Pure, WaveASM_ArithmeticOp,
+        WaveASM_SCCDef], traits)> {
+  let arguments = (ins WaveASM_AnySGPR:$src0, WaveASM_SRegOrImm:$src1);
+  let results = (outs WaveASM_SCC:$result);  // SCC flag (not a real SGPR)
   let assemblyFormat = "$src0 `,` $src1 attr-dict `:` type($src0) `,` type($src1) `->` type($result)";
 }
 
@@ -718,25 +747,28 @@ def WaveASM_V_CMP_GE_U64 : VALUCmpOp<"v_cmp_ge_u64">;
 // SALU Unary Instructions
 //===----------------------------------------------------------------------===//
 
+// No SCC clobber
 def WaveASM_S_MOV_B32 : SALUUnaryOp<"s_mov_b32">;
 def WaveASM_S_MOV_B64 : SALUUnaryOp<"s_mov_b64">;
-def WaveASM_S_NOT_B32 : SALUUnaryOp<"s_not_b32">;
-def WaveASM_S_NOT_B64 : SALUUnaryOp<"s_not_b64">;
-def WaveASM_S_BREV_B32 : SALUUnaryOp<"s_brev_b32">;
-def WaveASM_S_BREV_B64 : SALUUnaryOp<"s_brev_b64">;
-def WaveASM_S_BCNT0_I32_B32 : SALUUnaryOp<"s_bcnt0_i32_b32">;
-def WaveASM_S_BCNT0_I32_B64 : SALUUnaryOp<"s_bcnt0_i32_b64">;
-def WaveASM_S_BCNT1_I32_B32 : SALUUnaryOp<"s_bcnt1_i32_b32">;
-def WaveASM_S_BCNT1_I32_B64 : SALUUnaryOp<"s_bcnt1_i32_b64">;
-def WaveASM_S_FF0_I32_B32 : SALUUnaryOp<"s_ff0_i32_b32">;
-def WaveASM_S_FF0_I32_B64 : SALUUnaryOp<"s_ff0_i32_b64">;
-def WaveASM_S_FF1_I32_B32 : SALUUnaryOp<"s_ff1_i32_b32">;
-def WaveASM_S_FF1_I32_B64 : SALUUnaryOp<"s_ff1_i32_b64">;
-def WaveASM_S_FLBIT_I32_B32 : SALUUnaryOp<"s_flbit_i32_b32">;
-def WaveASM_S_FLBIT_I32_B64 : SALUUnaryOp<"s_flbit_i32_b64">;
-def WaveASM_S_ABS_I32 : SALUUnaryOp<"s_abs_i32">;
 def WaveASM_S_SEXT_I32_I8 : SALUUnaryOp<"s_sext_i32_i8">;
 def WaveASM_S_SEXT_I32_I16 : SALUUnaryOp<"s_sext_i32_i16">;
+
+// Clobber SCC (SCC = f(result))
+def WaveASM_S_NOT_B32 : SALUUnaryWithSCCOp<"s_not_b32">;
+def WaveASM_S_NOT_B64 : SALUUnaryWithSCCOp<"s_not_b64">;
+def WaveASM_S_BREV_B32 : SALUUnaryWithSCCOp<"s_brev_b32">;
+def WaveASM_S_BREV_B64 : SALUUnaryWithSCCOp<"s_brev_b64">;
+def WaveASM_S_BCNT0_I32_B32 : SALUUnaryWithSCCOp<"s_bcnt0_i32_b32">;
+def WaveASM_S_BCNT0_I32_B64 : SALUUnaryWithSCCOp<"s_bcnt0_i32_b64">;
+def WaveASM_S_BCNT1_I32_B32 : SALUUnaryWithSCCOp<"s_bcnt1_i32_b32">;
+def WaveASM_S_BCNT1_I32_B64 : SALUUnaryWithSCCOp<"s_bcnt1_i32_b64">;
+def WaveASM_S_FF0_I32_B32 : SALUUnaryWithSCCOp<"s_ff0_i32_b32">;
+def WaveASM_S_FF0_I32_B64 : SALUUnaryWithSCCOp<"s_ff0_i32_b64">;
+def WaveASM_S_FF1_I32_B32 : SALUUnaryWithSCCOp<"s_ff1_i32_b32">;
+def WaveASM_S_FF1_I32_B64 : SALUUnaryWithSCCOp<"s_ff1_i32_b64">;
+def WaveASM_S_FLBIT_I32_B32 : SALUUnaryWithSCCOp<"s_flbit_i32_b32">;
+def WaveASM_S_FLBIT_I32_B64 : SALUUnaryWithSCCOp<"s_flbit_i32_b64">;
+def WaveASM_S_ABS_I32 : SALUUnaryWithSCCOp<"s_abs_i32">;
 
 //===----------------------------------------------------------------------===//
 // SALU Binary Instructions
@@ -744,52 +776,61 @@ def WaveASM_S_SEXT_I32_I16 : SALUUnaryOp<"s_sext_i32_i16">;
 
 // Arithmetic with carry (sets SCC)
 def WaveASM_S_ADD_U32 : SALUBinaryWithCarryOp<"s_add_u32">;
-def WaveASM_S_ADDC_U32 : SALUBinaryWithCarryOp<"s_addc_u32">;
+def WaveASM_S_ADDC_U32 : SALUBinaryWithCarryInOp<"s_addc_u32">;
 def WaveASM_S_ADD_I32 : SALUBinaryWithCarryOp<"s_add_i32">;
 def WaveASM_S_SUB_U32 : SALUBinaryWithCarryOp<"s_sub_u32">;
 def WaveASM_S_SUB_I32 : SALUBinaryWithCarryOp<"s_sub_i32">;
+// Conditional select: dst = SCC ? src0 : src1 (reads SCC, no SCC write).
+// Takes an explicit SCC operand for SSA tracking of the SCC dependency.
+// NOT CSE-eligible: result depends on SCC state.  NoMemoryEffect allows DCE.
+def WaveASM_S_CSELECT_B32 : WAVEASMOp<"s_cselect_b32",
+    [WaveASM_SCCUse, NoMemoryEffect]> {
+  let arguments = (ins WaveASM_SCC:$scc_in, WaveASM_SRegOrImm:$src0, WaveASM_SRegOrImm:$src1);
+  let results = (outs WaveASM_AnySGPR:$dst);
+  let assemblyFormat = "$scc_in `,` $src0 `,` $src1 attr-dict `:` type($scc_in) `,` type($src0) `,` type($src1) `->` type($dst)";
+}
 // Multiplication does not set SCC
 def WaveASM_S_MUL_I32 : SALUBinaryOp<"s_mul_i32">;
 def WaveASM_S_MUL_HI_U32 : SALUBinaryOp<"s_mul_hi_u32">;
 def WaveASM_S_MUL_HI_I32 : SALUBinaryOp<"s_mul_hi_i32">;
 
-// Bitwise
-def WaveASM_S_AND_B32 : SALUBinaryOp<"s_and_b32">;
-def WaveASM_S_AND_B64 : SALUBinaryOp<"s_and_b64">;
-def WaveASM_S_OR_B32 : SALUBinaryOp<"s_or_b32">;
-def WaveASM_S_OR_B64 : SALUBinaryOp<"s_or_b64">;
-def WaveASM_S_XOR_B32 : SALUBinaryOp<"s_xor_b32">;
-def WaveASM_S_XOR_B64 : SALUBinaryOp<"s_xor_b64">;
-def WaveASM_S_ANDN2_B32 : SALUBinaryOp<"s_andn2_b32">;
-def WaveASM_S_ANDN2_B64 : SALUBinaryOp<"s_andn2_b64">;
-def WaveASM_S_ORN2_B32 : SALUBinaryOp<"s_orn2_b32">;
-def WaveASM_S_ORN2_B64 : SALUBinaryOp<"s_orn2_b64">;
-def WaveASM_S_NAND_B32 : SALUBinaryOp<"s_nand_b32">;
-def WaveASM_S_NAND_B64 : SALUBinaryOp<"s_nand_b64">;
-def WaveASM_S_NOR_B32 : SALUBinaryOp<"s_nor_b32">;
-def WaveASM_S_NOR_B64 : SALUBinaryOp<"s_nor_b64">;
-def WaveASM_S_XNOR_B32 : SALUBinaryOp<"s_xnor_b32">;
-def WaveASM_S_XNOR_B64 : SALUBinaryOp<"s_xnor_b64">;
+// Bitwise -- all clobber SCC (SCC = result != 0).
+def WaveASM_S_AND_B32 : SALUBinaryWithSCCOp<"s_and_b32">;
+def WaveASM_S_AND_B64 : SALUBinaryWithSCCOp<"s_and_b64">;
+def WaveASM_S_OR_B32 : SALUBinaryWithSCCOp<"s_or_b32">;
+def WaveASM_S_OR_B64 : SALUBinaryWithSCCOp<"s_or_b64">;
+def WaveASM_S_XOR_B32 : SALUBinaryWithSCCOp<"s_xor_b32">;
+def WaveASM_S_XOR_B64 : SALUBinaryWithSCCOp<"s_xor_b64">;
+def WaveASM_S_ANDN2_B32 : SALUBinaryWithSCCOp<"s_andn2_b32">;
+def WaveASM_S_ANDN2_B64 : SALUBinaryWithSCCOp<"s_andn2_b64">;
+def WaveASM_S_ORN2_B32 : SALUBinaryWithSCCOp<"s_orn2_b32">;
+def WaveASM_S_ORN2_B64 : SALUBinaryWithSCCOp<"s_orn2_b64">;
+def WaveASM_S_NAND_B32 : SALUBinaryWithSCCOp<"s_nand_b32">;
+def WaveASM_S_NAND_B64 : SALUBinaryWithSCCOp<"s_nand_b64">;
+def WaveASM_S_NOR_B32 : SALUBinaryWithSCCOp<"s_nor_b32">;
+def WaveASM_S_NOR_B64 : SALUBinaryWithSCCOp<"s_nor_b64">;
+def WaveASM_S_XNOR_B32 : SALUBinaryWithSCCOp<"s_xnor_b32">;
+def WaveASM_S_XNOR_B64 : SALUBinaryWithSCCOp<"s_xnor_b64">;
 
 // Shifts
-def WaveASM_S_LSHL_B32 : SALUBinaryOp<"s_lshl_b32">;
-def WaveASM_S_LSHL_B64 : SALUBinaryOp<"s_lshl_b64">;
-def WaveASM_S_LSHR_B32 : SALUBinaryOp<"s_lshr_b32">;
-def WaveASM_S_LSHR_B64 : SALUBinaryOp<"s_lshr_b64">;
-def WaveASM_S_ASHR_I32 : SALUBinaryOp<"s_ashr_i32">;
-def WaveASM_S_ASHR_I64 : SALUBinaryOp<"s_ashr_i64">;
+def WaveASM_S_LSHL_B32 : SALUBinaryWithSCCOp<"s_lshl_b32">;
+def WaveASM_S_LSHL_B64 : SALUBinaryWithSCCOp<"s_lshl_b64">;
+def WaveASM_S_LSHR_B32 : SALUBinaryWithSCCOp<"s_lshr_b32">;
+def WaveASM_S_LSHR_B64 : SALUBinaryWithSCCOp<"s_lshr_b64">;
+def WaveASM_S_ASHR_I32 : SALUBinaryWithSCCOp<"s_ashr_i32">;
+def WaveASM_S_ASHR_I64 : SALUBinaryWithSCCOp<"s_ashr_i64">;
 
 // Min/Max
-def WaveASM_S_MIN_I32 : SALUBinaryOp<"s_min_i32">;
-def WaveASM_S_MIN_U32 : SALUBinaryOp<"s_min_u32">;
-def WaveASM_S_MAX_I32 : SALUBinaryOp<"s_max_i32">;
-def WaveASM_S_MAX_U32 : SALUBinaryOp<"s_max_u32">;
+def WaveASM_S_MIN_I32 : SALUBinaryWithSCCOp<"s_min_i32">;
+def WaveASM_S_MIN_U32 : SALUBinaryWithSCCOp<"s_min_u32">;
+def WaveASM_S_MAX_I32 : SALUBinaryWithSCCOp<"s_max_i32">;
+def WaveASM_S_MAX_U32 : SALUBinaryWithSCCOp<"s_max_u32">;
 
 // Misc
-def WaveASM_S_BFE_U32 : SALUBinaryOp<"s_bfe_u32">;
-def WaveASM_S_BFE_I32 : SALUBinaryOp<"s_bfe_i32">;
-def WaveASM_S_BFE_U64 : SALUBinaryOp<"s_bfe_u64">;
-def WaveASM_S_BFE_I64 : SALUBinaryOp<"s_bfe_i64">;
+def WaveASM_S_BFE_U32 : SALUBinaryWithSCCOp<"s_bfe_u32">;
+def WaveASM_S_BFE_I32 : SALUBinaryWithSCCOp<"s_bfe_i32">;
+def WaveASM_S_BFE_U64 : SALUBinaryWithSCCOp<"s_bfe_u64">;
+def WaveASM_S_BFE_I64 : SALUBinaryWithSCCOp<"s_bfe_i64">;
 def WaveASM_S_BFM_B32 : SALUBinaryOp<"s_bfm_b32">;
 def WaveASM_S_BFM_B64 : SALUBinaryOp<"s_bfm_b64">;
 def WaveASM_S_PACK_LL_B32_B16 : SALUBinaryOp<"s_pack_ll_b32_b16">;
@@ -1162,6 +1203,10 @@ def WaveASM_S_NOP : WaveASM_CountedScalarOp<"s_nop"> {
 
 def WaveASM_S_SETPRIO : WaveASM_CountedScalarOp<"s_setprio"> {
   let summary = "Set wave priority level (0=default, 1-3=elevated)";
+}
+
+def WaveASM_S_SCHED_BARRIER : WaveASM_CountedScalarOp<"s_sched_barrier"> {
+  let summary = "Scheduling barrier (bitmask controls which instructions cross)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/waveasm/include/waveasm/Dialect/WaveASMTypes.h
+++ b/waveasm/include/waveasm/Dialect/WaveASMTypes.h
@@ -97,6 +97,9 @@ inline int64_t getRegAlignment(mlir::Type type) {
 /// Check if type is an immediate
 inline bool isImmType(mlir::Type type) { return mlir::isa<ImmType>(type); }
 
+/// Check if type is the SCC flag type
+inline bool isSCCType(mlir::Type type) { return mlir::isa<SCCType>(type); }
+
 /// Check if two types are structurally compatible for control flow.
 /// After register allocation, virtual types (vreg, sreg) become physical
 /// types (pvreg, psreg) which include a register index. For control flow
@@ -104,6 +107,11 @@ inline bool isImmType(mlir::Type type) { return mlir::isa<ImmType>(type); }
 /// not the specific physical register index.
 inline bool typesCompatible(mlir::Type a, mlir::Type b) {
   if (a == b)
+    return true;
+
+  // Both are SCC types (parameterless, so a == b already covers this,
+  // but be explicit for clarity).
+  if (mlir::isa<SCCType>(a) && mlir::isa<SCCType>(b))
     return true;
 
   // Both are VReg types (virtual)

--- a/waveasm/include/waveasm/Dialect/WaveASMTypes.td
+++ b/waveasm/include/waveasm/Dialect/WaveASMTypes.td
@@ -287,6 +287,29 @@ def WaveASM_ImmType : WAVEASMType<"Imm", "imm"> {
 }
 
 //===----------------------------------------------------------------------===//
+// SCC (Status Condition Code) Type
+//===----------------------------------------------------------------------===//
+
+def WaveASM_SCCType : WAVEASMType<"SCC", "scc"> {
+  let summary = "SCC flag (implicit 1-bit condition code)";
+  let description = [{
+    Represents the hardware SCC (Status Condition Code) flag, an implicit
+    1-bit condition code set by scalar ALU compare and carry instructions.
+    Unlike SRegType, SCC is not a general-purpose SGPR — no physical register
+    is allocated for it. The register allocator skips SCCType values because
+    they are excluded from isVirtualRegType().
+
+    Used as the result type for:
+    - SALUCmpOp (s_cmp_*): the compare sets SCC, no SGPR is written.
+    - SALUBinaryWithCarryOp (s_add_u32, s_addc_u32): the $scc carry result.
+
+    Consumed by ConditionOp and IfOp to model the SCC flag dependency.
+  }];
+
+  let parameters = (ins);
+}
+
+//===----------------------------------------------------------------------===//
 // Type Predicates for Op Definitions
 //===----------------------------------------------------------------------===//
 
@@ -320,6 +343,12 @@ def WaveASM_AnyReg : AnyTypeOf<[
 
 // Immediate
 def WaveASM_Imm : AnyTypeOf<[WaveASM_ImmType], "immediate">;
+
+// SCC flag
+def WaveASM_SCC : AnyTypeOf<[WaveASM_SCCType], "SCC flag">;
+
+// SCC or any SGPR (for condition consumers that accept either)
+def WaveASM_AnySCCOrSGPR : AnyTypeOf<[WaveASM_SCCType, WaveASM_SRegType, WaveASM_PSRegType], "SCC or SGPR">;
 
 // VGPR or immediate (common for src1)
 def WaveASM_VRegOrImm : AnyTypeOf<[WaveASM_VRegType, WaveASM_PVRegType, WaveASM_ImmType],

--- a/waveasm/include/waveasm/Transforms/Passes.td
+++ b/waveasm/include/waveasm/Transforms/Passes.td
@@ -249,6 +249,34 @@ def WAVEASMExtractScalarization
 }
 
 //===----------------------------------------------------------------------===//
+// SCC Spill/Reload Pass
+//===----------------------------------------------------------------------===//
+
+def WAVEASMSCCSpillReload : Pass<"waveasm-scc-spill-reload"> {
+  let summary = "Insert SCC spill/reload around SCC-clobbering ops";
+  let description = [{
+    When an SCC live range extends across SCC-clobbering ops (e.g. after
+    CSE merges identical SCC producers), this pass inserts s_cselect_b32
+    (spill: SCC -> SGPR) right after the producer and s_cmp_ne_u32
+    (reload: SGPR -> SCC) right before each affected consumer.
+  }];
+  let dependentDialects = ["::waveasm::WaveASMDialect"];
+}
+
+//===----------------------------------------------------------------------===//
+// SCC Verifier Pass
+//===----------------------------------------------------------------------===//
+
+def WAVEASMSCCVerifier : Pass<"waveasm-scc-verifier"> {
+  let summary = "Verify SCC (Scalar Condition Code) liveness invariants";
+  let description = [{
+    Checks that no SCC-clobbering SALU instruction sits between an
+    SCC-producing op (SCCDef trait) and its consumer.
+  }];
+  let dependentDialects = ["::waveasm::WaveASMDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // Memory Offset Optimization Pass
 //===----------------------------------------------------------------------===//
 

--- a/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
+++ b/waveasm/include/waveasm/Transforms/TranslateFromMLIR.h
@@ -258,6 +258,9 @@ public:
   /// Create a virtual AGPR type
   ARegType createARegType(int64_t size = 1, int64_t alignment = 1);
 
+  /// Create an SCC flag type
+  SCCType createSCCType();
+
   /// Create an immediate type with a value
   ImmType createImmType(int64_t value);
 

--- a/waveasm/lib/Dialect/WaveASMControlFlowOps.cpp
+++ b/waveasm/lib/Dialect/WaveASMControlFlowOps.cpp
@@ -326,7 +326,7 @@ ParseResult IfOp::parse(OpAsmParser &parser, OperationState &result) {
     }
   } else {
     // Default condition type
-    condType = SRegType::get(parser.getContext());
+    condType = SCCType::get(parser.getContext());
   }
 
   // Resolve condition

--- a/waveasm/lib/Transforms/ArithLegalization.cpp
+++ b/waveasm/lib/Transforms/ArithLegalization.cpp
@@ -132,7 +132,8 @@ static void legalizeAddI32(Value lhs, Value rhs, ArithAddOp op,
     result = V_ADD_U32::create(builder, loc, vregTy, lhs, rhs);
   } else {
     auto sregTy = SRegType::get(builder.getContext(), 1, 1);
-    result = S_ADD_U32::create(builder, loc, sregTy, sregTy, lhs, rhs).getDst();
+    auto sccTy = SCCType::get(builder.getContext());
+    result = S_ADD_U32::create(builder, loc, sregTy, sccTy, lhs, rhs).getDst();
   }
   op.replaceAllUsesWith(result);
 }
@@ -182,11 +183,13 @@ static void legalizeAddI64(Value lhs, Value rhs, ArithAddOp op,
     hiResult = addHi.getDst();
   } else {
     auto sregTy = SRegType::get(builder.getContext(), 1, 1);
+    auto sccTy = SCCType::get(builder.getContext());
     // s_add_u32: lo + lo, carry out to SCC.
-    auto addLo = S_ADD_U32::create(builder, loc, sregTy, sregTy, lhsLo, rhsLo);
+    auto addLo = S_ADD_U32::create(builder, loc, sregTy, sccTy, lhsLo, rhsLo);
     loResult = addLo.getDst();
     // s_addc_u32: hi + hi + carry in from SCC.
-    auto addHi = S_ADDC_U32::create(builder, loc, sregTy, sregTy, lhsHi, rhsHi);
+    auto addHi = S_ADDC_U32::create(builder, loc, sregTy, sccTy, addLo.getScc(),
+                                    lhsHi, rhsHi);
     hiResult = addHi.getDst();
   }
 
@@ -227,11 +230,12 @@ static void legalizeMulI64(Value lhs, Value rhs, ArithMulOp op,
     Value cross1 = S_MUL_I32::create(builder, loc, sregTy, aLo, bHi);
     Value cross2 = S_MUL_I32::create(builder, loc, sregTy, aHi, bLo);
     // Accumulate (carry discarded -- computing mod 2^64).
+    auto sccTy = SCCType::get(builder.getContext());
     Value hiTemp =
-        S_ADD_U32::create(builder, loc, sregTy, sregTy, hiPartial, cross1)
+        S_ADD_U32::create(builder, loc, sregTy, sccTy, hiPartial, cross1)
             .getDst();
-    hiResult = S_ADD_U32::create(builder, loc, sregTy, sregTy, hiTemp, cross2)
-                   .getDst();
+    hiResult =
+        S_ADD_U32::create(builder, loc, sregTy, sccTy, hiTemp, cross2).getDst();
   }
 
   Value result = mergeI64(loResult, hiResult, builder, loc);
@@ -280,7 +284,7 @@ static Value emitVCmp(CmpPredicate pred, Value lhs, Value rhs,
 /// Emit an SCC-setting compare and return the sreg result.
 static Value emitSCmp(CmpPredicate pred, Value lhs, Value rhs,
                       OpBuilder &builder, Location loc) {
-  auto sregTy = SRegType::get(builder.getContext(), 1, 1);
+  auto sregTy = SCCType::get(builder.getContext());
   switch (pred) {
   case CmpPredicate::eq:
     return S_CMP_EQ_I32::create(builder, loc, sregTy, lhs, rhs);
@@ -407,25 +411,50 @@ static LogicalResult legalizeCmpI64(Value lhs, Value rhs, CmpPredicate pred,
 
     if (isEqNe) {
       // eq/ne: XOR each half, OR, compare to zero.
-      Value xorLo = S_XOR_B32::create(builder, loc, sregTy, lhsLo, rhsLo);
-      Value xorHi = S_XOR_B32::create(builder, loc, sregTy, lhsHi, rhsHi);
-      Value combined = S_OR_B32::create(builder, loc, sregTy, xorLo, xorHi);
+      auto sccTy = SCCType::get(builder.getContext());
+      Value xorLo =
+          S_XOR_B32::create(builder, loc, sregTy, sccTy, lhsLo, rhsLo).getDst();
+      Value xorHi =
+          S_XOR_B32::create(builder, loc, sregTy, sccTy, lhsHi, rhsHi).getDst();
+      Value combined =
+          S_OR_B32::create(builder, loc, sregTy, sccTy, xorLo, xorHi).getDst();
       auto immTy = ImmType::get(builder.getContext(), 0);
       Value zero = ConstantOp::create(builder, loc, immTy, 0);
       Value result;
       if (pred == CmpPredicate::eq)
-        result = S_CMP_EQ_I32::create(builder, loc, sregTy, combined, zero);
+        result = S_CMP_EQ_I32::create(builder, loc, sccTy, combined, zero);
       else
-        result = S_CMP_NE_I32::create(builder, loc, sregTy, combined, zero);
+        result = S_CMP_NE_I32::create(builder, loc, sccTy, combined, zero);
       op.replaceAllUsesWith(result);
     } else {
       // Ordered: result = hiPred(hi) | (hiEq(hi) & loPred(lo)).
+      // Each S_CMP sets SCC (returns SCCType). Materialize each to a
+      // 0/1 SGPR via s_cselect_b32 before combining with AND/OR.
       auto [hiPred, loPred] = getOrderedI64Preds(pred);
-      Value hiCmp = emitSCmp(hiPred, lhsHi, rhsHi, builder, loc);
-      Value hiEq = emitSCmp(CmpPredicate::eq, lhsHi, rhsHi, builder, loc);
-      Value loCmp = emitSCmp(loPred, lhsLo, rhsLo, builder, loc);
-      Value eqAndLo = S_AND_B32::create(builder, loc, sregTy, hiEq, loCmp);
-      Value result = S_OR_B32::create(builder, loc, sregTy, hiCmp, eqAndLo);
+      auto immTy0 = ImmType::get(builder.getContext(), 0);
+      auto immTy1 = ImmType::get(builder.getContext(), 1);
+      Value zero = ConstantOp::create(builder, loc, immTy0, 0);
+      Value one = ConstantOp::create(builder, loc, immTy1, 1);
+      Value oneSgpr = S_MOV_B32::create(builder, loc, sregTy, one);
+
+      Value hiSCC = emitSCmp(hiPred, lhsHi, rhsHi, builder, loc);
+      Value hiCmp =
+          S_CSELECT_B32::create(builder, loc, sregTy, hiSCC, oneSgpr, zero);
+
+      Value eqSCC = emitSCmp(CmpPredicate::eq, lhsHi, rhsHi, builder, loc);
+      Value hiEq =
+          S_CSELECT_B32::create(builder, loc, sregTy, eqSCC, oneSgpr, zero);
+
+      Value loSCC = emitSCmp(loPred, lhsLo, rhsLo, builder, loc);
+      Value loCmp =
+          S_CSELECT_B32::create(builder, loc, sregTy, loSCC, oneSgpr, zero);
+
+      auto sccTy2 = SCCType::get(builder.getContext());
+      Value eqAndLo =
+          S_AND_B32::create(builder, loc, sregTy, sccTy2, hiEq, loCmp).getDst();
+      Value result =
+          S_OR_B32::create(builder, loc, sregTy, sccTy2, hiCmp, eqAndLo)
+              .getDst();
       op.replaceAllUsesWith(result);
     }
   }
@@ -521,7 +550,8 @@ static LogicalResult legalizeBitwiseOp(ArithOp op, OpBuilder &builder) {
       result = VALUOp64::create(builder, loc, vregTy, lhs, rhs);
     } else {
       auto sregTy = SRegType::get(builder.getContext(), 2, 2);
-      result = SALUOp64::create(builder, loc, sregTy, lhs, rhs);
+      auto sccTy = SCCType::get(builder.getContext());
+      result = SALUOp64::create(builder, loc, sregTy, sccTy, lhs, rhs).getDst();
     }
   } else {
     if (anyVGPR({lhs, rhs})) {
@@ -530,7 +560,8 @@ static LogicalResult legalizeBitwiseOp(ArithOp op, OpBuilder &builder) {
       result = VALUOp32::create(builder, loc, vregTy, lhs, rhs);
     } else {
       auto sregTy = SRegType::get(builder.getContext(), 1, 1);
-      result = SALUOp32::create(builder, loc, sregTy, lhs, rhs);
+      auto sccTy = SCCType::get(builder.getContext());
+      result = SALUOp32::create(builder, loc, sregTy, sccTy, lhs, rhs).getDst();
     }
   }
   op.replaceAllUsesWith(result);
@@ -595,38 +626,38 @@ static LogicalResult legalizeCmp(ArithCmpOp op, OpBuilder &builder) {
     auto placeholder = ConstantOp::create(builder, loc, immTy, 1);
     op.replaceAllUsesWith(placeholder.getResult());
   } else {
-    auto sregTy = SRegType::get(builder.getContext(), 1, 1);
+    auto sccTy = SCCType::get(builder.getContext());
     Value result;
     switch (pred) {
     case CmpPredicate::eq:
-      result = S_CMP_EQ_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_EQ_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::ne:
-      result = S_CMP_NE_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_NE_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::slt:
-      result = S_CMP_LT_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_LT_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::sle:
-      result = S_CMP_LE_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_LE_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::sgt:
-      result = S_CMP_GT_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_GT_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::sge:
-      result = S_CMP_GE_I32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_GE_I32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::ult:
-      result = S_CMP_LT_U32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_LT_U32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::ule:
-      result = S_CMP_LE_U32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_LE_U32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::ugt:
-      result = S_CMP_GT_U32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_GT_U32::create(builder, loc, sccTy, lhs, rhs);
       break;
     case CmpPredicate::uge:
-      result = S_CMP_GE_U32::create(builder, loc, sregTy, lhs, rhs);
+      result = S_CMP_GE_U32::create(builder, loc, sccTy, lhs, rhs);
       break;
     }
     op.replaceAllUsesWith(result);
@@ -743,7 +774,9 @@ static LogicalResult legalizeSExt(ArithSExtOp op, OpBuilder &builder) {
     auto sregTy = SRegType::get(builder.getContext(), 1, 1);
     auto immTy = ImmType::get(builder.getContext(), 31);
     Value shift = ConstantOp::create(builder, loc, immTy, 31);
-    Value hi = S_ASHR_I32::create(builder, loc, sregTy, src, shift);
+    auto sccTy = SCCType::get(builder.getContext());
+    Value hi =
+        S_ASHR_I32::create(builder, loc, sregTy, sccTy, src, shift).getDst();
     Value result = mergeI64(src, hi, builder, loc);
     op.replaceAllUsesWith(result);
   } else {

--- a/waveasm/lib/Transforms/AssemblyEmitter.cpp
+++ b/waveasm/lib/Transforms/AssemblyEmitter.cpp
@@ -78,6 +78,9 @@ std::string KernelGenerator::resolveValue(Value value) {
     return "0";
   }
 
+  if (isa<SCCType>(ty))
+    return "scc";
+
   return "<unknown>";
 }
 
@@ -287,9 +290,13 @@ std::string KernelGenerator::emitDefaultFormat(Operation *op,
   }
 
   for (Value result : op->getResults()) {
+    if (isa<SCCType>(result.getType()))
+      continue;
     operands.push_back(resolveValue(result));
   }
   for (Value operand : op->getOperands()) {
+    if (isa<SCCType>(operand.getType()))
+      continue;
     if (isScalarOp) {
       operands.push_back(resolveScalarValue(operand));
     } else {
@@ -841,13 +848,20 @@ std::optional<std::string> KernelGenerator::generateOp(Operation *op) {
       .Case<YieldOp>(
           [&](YieldOp) -> std::optional<std::string> { return std::nullopt; })
       .Case<S_CMP_LT_U32, S_CMP_EQ_U32, S_CMP_LE_U32, S_CMP_GT_U32,
-            S_CMP_GE_U32, S_CMP_LT_I32, S_CMP_EQ_I32, S_CMP_LE_I32,
-            S_CMP_GT_I32, S_CMP_GE_I32>(
+            S_CMP_GE_U32, S_CMP_NE_U32, S_CMP_LT_I32, S_CMP_EQ_I32,
+            S_CMP_LE_I32, S_CMP_GT_I32, S_CMP_GE_I32, S_CMP_NE_I32>(
           [&](auto cmpOp) -> std::optional<std::string> {
             llvm::StringRef opName = cmpOp->getName().getStringRef();
             llvm::StringRef mnemonic = opName;
             if (opName.starts_with("waveasm.")) {
               mnemonic = opName.drop_front(8);
+            }
+            std::string mnemStr;
+            if (mnemonic.contains("_ne_")) {
+              mnemStr = mnemonic.str();
+              size_t pos = mnemStr.find("_ne_");
+              mnemStr.replace(pos, 4, "_lg_");
+              mnemonic = mnemStr;
             }
             llvm::SmallVector<std::string> operands;
             for (Value operand : cmpOp->getOperands()) {
@@ -868,6 +882,8 @@ std::optional<std::string> KernelGenerator::generateOp(Operation *op) {
             // Only emit the first result (dst), not the second (scc)
             operands.push_back(resolveValue(addOp.getDst()));
             for (Value operand : addOp->getOperands()) {
+              if (isa<SCCType>(operand.getType()))
+                continue;
               operands.push_back(resolveValue(operand));
             }
             return formatter.format(mnemonic, operands);
@@ -976,6 +992,15 @@ std::optional<std::string> KernelGenerator::generateOp(Operation *op) {
               operands.push_back("vcc");
             return prefix + formatter.format(carryOp->getName().stripDialect(),
                                              operands);
+          })
+
+      .Case<S_CSELECT_B32>(
+          [&](S_CSELECT_B32 selOp) -> std::optional<std::string> {
+            llvm::SmallVector<std::string> operands;
+            operands.push_back(resolveValue(selOp.getDst()));
+            operands.push_back(resolveScalarValue(selOp.getSrc0()));
+            operands.push_back(resolveScalarValue(selOp.getSrc1()));
+            return formatter.format("s_cselect_b32", operands);
           })
 
       .Default([&](Operation *defaultOp) -> std::optional<std::string> {

--- a/waveasm/lib/Transforms/BufferLoadStrengthReduction.cpp
+++ b/waveasm/lib/Transforms/BufferLoadStrengthReduction.cpp
@@ -552,7 +552,8 @@ static void applyStrengthReduction(LoopOp loopOp) {
       Value strideConst =
           ConstantOp::create(preCondBuilder, loc, strideImm, group.stride);
       Value nextSoff = S_ADD_U32::create(preCondBuilder, loc, sregType,
-                                         sregType, currentSoff, strideConst)
+                                         SCCType::get(builder.getContext()),
+                                         currentSoff, strideConst)
                            .getDst();
       nextSoffs.push_back(nextSoff);
     }
@@ -574,7 +575,8 @@ static void applyStrengthReduction(LoopOp loopOp) {
       auto strideImm = bodyBuilder.getType<ImmType>(group.stride);
       Value strideConst =
           ConstantOp::create(bodyBuilder, loc, strideImm, group.stride);
-      Value nextSoff = S_ADD_U32::create(bodyBuilder, loc, sregType, sregType,
+      Value nextSoff = S_ADD_U32::create(bodyBuilder, loc, sregType,
+                                         SCCType::get(builder.getContext()),
                                          currentSoff, strideConst)
                            .getDst();
       newCondIterArgs.push_back(nextSoff);

--- a/waveasm/lib/Transforms/CMakeLists.txt
+++ b/waveasm/lib/Transforms/CMakeLists.txt
@@ -31,6 +31,8 @@ add_mlir_dialect_library(MLIRWaveASMTransforms
   Peephole.cpp
   RegionBuilder.cpp
   ScalePackElimination.cpp
+  SCCSpillReload.cpp
+  SCCVerifier.cpp
   ScopedCSE.cpp
   Ticketing.cpp
   TranslateFromLLVMDialect.cpp

--- a/waveasm/lib/Transforms/Peephole.cpp
+++ b/waveasm/lib/Transforms/Peephole.cpp
@@ -273,8 +273,9 @@ struct BufferLoadLDSSoffsetPattern : public OpRewritePattern<BufferLoadOp> {
     // Case 1: voffset = V_ADD_U32(row, V_LSHLREV_B32(const, sgpr)).
     if (auto found = findShiftInAdd(outerAdd)) {
       auto [base, shiftAmt, other] = *found;
-      auto sLshl =
-          S_LSHL_B32::create(rewriter, loc, base.getType(), base, shiftAmt);
+      auto sccTy = SCCType::get(rewriter.getContext());
+      auto sLshl = S_LSHL_B32::create(rewriter, loc, base.getType(), sccTy,
+                                      base, shiftAmt);
       rewriter.modifyOpInPlace(loadOp, [&]() {
         loadOp.getVoffsetMutable().assign(other);
         loadOp.getSoffsetMutable().assign(sLshl.getDst());
@@ -294,8 +295,9 @@ struct BufferLoadLDSSoffsetPattern : public OpRewritePattern<BufferLoadOp> {
         continue;
 
       auto [base, shiftAmt, threadBase] = *found;
-      auto sLshl =
-          S_LSHL_B32::create(rewriter, loc, base.getType(), base, shiftAmt);
+      auto sccTy = SCCType::get(rewriter.getContext());
+      auto sLshl = S_LSHL_B32::create(rewriter, loc, base.getType(), sccTy,
+                                      base, shiftAmt);
       // Rebuild voffset without the scalar shift: v_add_u32(threadBase, row).
       auto newAdd = V_ADD_U32::create(
           rewriter, loc, outerAdd.getResult().getType(), threadBase, row);
@@ -321,8 +323,9 @@ struct BufferLoadLDSSoffsetPattern : public OpRewritePattern<BufferLoadOp> {
         continue;
 
       auto [base, shiftAmt] = *shift;
-      auto sLshl =
-          S_LSHL_B32::create(rewriter, loc, base.getType(), base, shiftAmt);
+      auto sccTy = SCCType::get(rewriter.getContext());
+      auto sLshl = S_LSHL_B32::create(rewriter, loc, base.getType(), sccTy,
+                                      base, shiftAmt);
       // Create v_lshl_add_u32(src0, src1, 0) — drop the scalar shift.
       auto immType = rewriter.getType<ImmType>(0);
       auto zeroConst = ConstantOp::create(rewriter, loc, immType, 0);

--- a/waveasm/lib/Transforms/RegionBuilder.cpp
+++ b/waveasm/lib/Transforms/RegionBuilder.cpp
@@ -249,8 +249,9 @@ LoopOp RegionBuilder::buildLoopFromSCFFor(scf::ForOp forOp) {
   }
 
   auto sregType = ctx.createSRegType();
+  auto sccType = ctx.createSCCType();
   Value nextIV =
-      S_ADD_U32::create(builder, loc, sregType, sregType, inductionVar, *step)
+      S_ADD_U32::create(builder, loc, sregType, sccType, inductionVar, *step)
           .getDst();
   // S_CMP only accepts SGPR operands. If upper bound is a VGPR (e.g. from
   // v_min_i32 in split-K trip count computation), convert to SGPR first.
@@ -258,7 +259,7 @@ LoopOp RegionBuilder::buildLoopFromSCFFor(scf::ForOp forOp) {
   if (isVGPRType(ub.getType())) {
     ub = V_READFIRSTLANE_B32::create(builder, loc, sregType, ub);
   }
-  Value cond = S_CMP_LT_U32::create(builder, loc, sregType, nextIV, ub);
+  Value cond = S_CMP_LT_U32::create(builder, loc, sccType, nextIV, ub);
 
   // Collect iter args from yield
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());

--- a/waveasm/lib/Transforms/SCCSpillReload.cpp
+++ b/waveasm/lib/Transforms/SCCSpillReload.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// SCC Spill/Reload Pass
+//
+// After CSE merges identical s_cmp ops, the SCC live range may extend
+// across SCC-clobbering ops (s_and, s_or, s_add, etc.).  This pass
+// inserts s_cselect_b32 (spill: SCC -> SGPR) right after the s_cmp and
+// s_cmp_ne_u32 (reload: SGPR -> SCC) right before each consumer that
+// has an SCC clobber between it and the definition.
+//===----------------------------------------------------------------------===//
+
+#include "waveasm/Dialect/WaveASMDialect.h"
+#include "waveasm/Dialect/WaveASMInterfaces.h"
+#include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Dialect/WaveASMTypes.h"
+#include "waveasm/Transforms/Passes.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
+
+#define DEBUG_TYPE "waveasm-scc-spill-reload"
+
+using namespace mlir;
+using namespace waveasm;
+
+namespace waveasm {
+#define GEN_PASS_DEF_WAVEASMSCCSPILLRELOAD
+#include "waveasm/Transforms/Passes.h.inc"
+} // namespace waveasm
+
+namespace {
+
+/// Return true if the operation writes the SCC flag on hardware.
+static bool writesSCC(Operation *op) { return op->hasTrait<OpTrait::SCCDef>(); }
+
+/// Check if there is any SCC-clobbering op between \p producer and
+/// \p consumer in the same block.  Returns true if a clobber exists.
+static bool hasSCCClobberBetween(Operation *producer, Operation *consumer) {
+  if (!producer || !consumer)
+    return false;
+  // Different blocks: conservatively assume clobber.
+  if (producer->getBlock() != consumer->getBlock())
+    return true;
+  for (Operation *op = producer->getNextNode(); op && op != consumer;
+       op = op->getNextNode()) {
+    if (writesSCC(op))
+      return true;
+  }
+  return false;
+}
+
+struct SCCSpillReloadPass
+    : public waveasm::impl::WAVEASMSCCSpillReloadBase<SCCSpillReloadPass> {
+  using WAVEASMSCCSpillReloadBase::WAVEASMSCCSpillReloadBase;
+
+  void runOnOperation() override {
+    getOperation()->walk(
+        [&](ProgramOp program) { processBlock(program.getBodyBlock()); });
+  }
+
+private:
+  void processBlock(Block &block) {
+    // Collect SCC-typed results that need spill/reload.
+    // We process each SCC-typed value and check if any of its users
+    // have an SCC-clobbering op between the definition and the use.
+    //
+    // Key: the SCC-typed value (from s_cmp or carry result).
+    // Value: the spill SGPR (created lazily, shared across all users).
+    llvm::DenseMap<Value, Value> spillMap;
+
+    // First pass: identify values that need spilling.  Do not modify
+    // the IR during this pass to avoid iterator invalidation.
+    struct SpillInfo {
+      Value sccValue;
+      Operation *producer;
+      llvm::SmallVector<OpOperand *, 4> usesNeedingReload;
+    };
+    llvm::SmallVector<SpillInfo> spills;
+
+    for (Operation &op : block) {
+      // Recurse into nested regions first.
+      for (Region &region : op.getRegions())
+        for (Block &nestedBlock : region)
+          processBlock(nestedBlock);
+
+      for (Value result : op.getResults()) {
+        if (!isa<SCCType>(result.getType()))
+          continue;
+
+        // Check each use of this SCC value.
+        llvm::SmallVector<OpOperand *, 4> needsReload;
+        for (OpOperand &use : result.getUses()) {
+          Operation *consumer = use.getOwner();
+          if (hasSCCClobberBetween(&op, consumer))
+            needsReload.push_back(&use);
+        }
+
+        if (!needsReload.empty()) {
+          spills.push_back({result, &op, std::move(needsReload)});
+        }
+      }
+    }
+
+    if (spills.empty())
+      return;
+
+    // Second pass: insert spill/reload ops.
+    auto *ctx = block.getParent()->getParentOp()->getContext();
+    auto sregTy = SRegType::get(ctx, 1, 1);
+    auto sccTy = SCCType::get(ctx);
+    auto immTy1 = ImmType::get(ctx, 1);
+    auto immTy0 = ImmType::get(ctx, 0);
+
+    for (auto &info : spills) {
+      OpBuilder builder(ctx);
+
+      // Insert spill right after the producer: s_cselect_b32 sN, 1, 0.
+      builder.setInsertionPointAfter(info.producer);
+      Value oneConst =
+          ConstantOp::create(builder, info.producer->getLoc(), immTy1, 1);
+      Value zeroConst =
+          ConstantOp::create(builder, info.producer->getLoc(), immTy0, 0);
+      // s_cselect_b32 reads SCC explicitly: dst = SCC ? src0 : src1.
+      Value spillSgpr =
+          S_CSELECT_B32::create(builder, info.producer->getLoc(), sregTy,
+                                info.sccValue, oneConst, zeroConst);
+
+      LDBG() << "SCC spill: inserted s_cselect_b32 after "
+             << info.producer->getName();
+
+      // Insert reload before each consumer that needs it.
+      for (OpOperand *use : info.usesNeedingReload) {
+        Operation *consumer = use->getOwner();
+        builder.setInsertionPoint(consumer);
+
+        // s_cmp_ne_u32 sN, 0: reloads the spilled boolean back into SCC.
+        Value reloadZero =
+            ConstantOp::create(builder, consumer->getLoc(), immTy0, 0);
+        Value reloadSCC = S_CMP_NE_U32::create(builder, consumer->getLoc(),
+                                               sccTy, spillSgpr, reloadZero);
+
+        // Replace the consumer's SCC operand with the reload result.
+        use->set(reloadSCC);
+
+        LDBG() << "SCC reload: inserted s_cmp_ne_u32 before "
+               << consumer->getName();
+      }
+    }
+  }
+};
+
+} // namespace

--- a/waveasm/lib/Transforms/SCCVerifier.cpp
+++ b/waveasm/lib/Transforms/SCCVerifier.cpp
@@ -1,0 +1,107 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// SCC Verifier Pass
+//
+// Verifies that no SCC-clobbering SALU instruction is placed between an
+// SCC-producing op and its consumer.
+//===----------------------------------------------------------------------===//
+
+#include "waveasm/Dialect/WaveASMDialect.h"
+#include "waveasm/Dialect/WaveASMInterfaces.h"
+#include "waveasm/Dialect/WaveASMOps.h"
+#include "waveasm/Transforms/Passes.h"
+
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/DebugLog.h"
+
+#define DEBUG_TYPE "waveasm-scc-verifier"
+
+using namespace mlir;
+using namespace waveasm;
+
+namespace waveasm {
+#define GEN_PASS_DEF_WAVEASMSCCVERIFIER
+#include "waveasm/Transforms/Passes.h.inc"
+} // namespace waveasm
+
+namespace {
+
+/// Returns true if the operation writes the SCC flag on hardware.
+static bool writesSCC(Operation *op) { return op->hasTrait<OpTrait::SCCDef>(); }
+
+struct SCCVerifierPass
+    : public waveasm::impl::WAVEASMSCCVerifierBase<SCCVerifierPass> {
+  using WAVEASMSCCVerifierBase::WAVEASMSCCVerifierBase;
+
+  void runOnOperation() override {
+    Operation *module = getOperation();
+    unsigned errorCount = 0;
+    module->walk([&](ProgramOp program) {
+      for (Block &block : program.getBody())
+        errorCount += verifyBlock(block);
+    });
+    if (errorCount > 0) {
+      LDBG() << "SCC verifier: found " << errorCount << " SCC hazard(s)";
+      signalPassFailure();
+    }
+  }
+
+private:
+  static SmallVector<Operation *> findSCCClobbersBetween(Operation *producer,
+                                                         Operation *consumer) {
+    SmallVector<Operation *> clobbers;
+    if (!producer || !consumer || producer->getBlock() != consumer->getBlock())
+      return clobbers;
+    for (Operation *op = producer->getNextNode(); op && op != consumer;
+         op = op->getNextNode()) {
+      if (writesSCC(op))
+        clobbers.push_back(op);
+    }
+    return clobbers;
+  }
+
+  static void emitSCCClobberError(Operation *consumer, Operation *producer,
+                                  ArrayRef<Operation *> clobbers) {
+    auto diag = consumer->emitError()
+                << "SCC hazard: " << clobbers.size()
+                << " SCC-clobbering op(s) between SCC producer '"
+                << producer->getName() << "' and consumer '"
+                << consumer->getName() << "'";
+    for (Operation *c : clobbers)
+      diag.attachNote(c->getLoc())
+          << "SCC clobbered here by '" << c->getName() << "'";
+    diag.attachNote(producer->getLoc()) << "SCC defined here";
+  }
+
+  unsigned verifyBlock(Block &block) {
+    unsigned errors = 0;
+    for (Operation &op : block) {
+      // Check every SCC-typed operand: its producer must not be separated
+      // from this consumer by an SCC-clobbering op.
+      for (Value operand : op.getOperands()) {
+        if (!isa<SCCType>(operand.getType()))
+          continue;
+        Operation *producer = operand.getDefiningOp();
+        if (!producer)
+          continue;
+        auto clobbers = findSCCClobbersBetween(producer, &op);
+        if (!clobbers.empty()) {
+          emitSCCClobberError(&op, producer, clobbers);
+          ++errors;
+        }
+      }
+      for (Region &region : op.getRegions())
+        for (Block &nestedBlock : region)
+          errors += verifyBlock(nestedBlock);
+    }
+    return errors;
+  }
+};
+
+} // namespace

--- a/waveasm/lib/Transforms/ScopedCSE.cpp
+++ b/waveasm/lib/Transforms/ScopedCSE.cpp
@@ -155,6 +155,12 @@ bool isCSEEligible(Operation *op) {
   if (op->hasTrait<OpTrait::SpecialRegOp>())
     return false;
 
+  // SCC-reading ops are NOT CSE-eligible: their result depends on implicit
+  // SCC state, so two ops with identical operands can produce different
+  // results.
+  if (op->hasTrait<OpTrait::SCCUse>())
+    return false;
+
   // Precolored registers are not eligible (they're fixed)
   if (isa<PrecoloredSRegOp, PrecoloredVRegOp>(op))
     return false;

--- a/waveasm/lib/Transforms/TranslateFromLLVMDialect.cpp
+++ b/waveasm/lib/Transforms/TranslateFromLLVMDialect.cpp
@@ -435,7 +435,9 @@ static LogicalResult handleMakeBufferRsrc(ROCDL::MakeBufferRsrcOp op,
     // Clear stride/swizzle bits in SRD word 1 (keep only base_addr[47:32]).
     auto maskImm = ctx.createImmType(kSRDWord1BaseMask);
     auto maskVal = ConstantOp::create(builder, loc, maskImm, kSRDWord1BaseMask);
-    word1 = S_AND_B32::create(builder, loc, sregTy, word1, maskVal);
+    word1 = S_AND_B32::create(builder, loc, sregTy, ctx.createSCCType(), word1,
+                              maskVal)
+                .getDst();
 
     // Patch SRD[3] with the actual flags from make.buffer.rsrc.
     auto flags = getConstantIntValue(op.getFlags());
@@ -464,13 +466,11 @@ static LogicalResult handleMakeBufferRsrc(ROCDL::MakeBufferRsrcOp op,
         offHi = ConstantOp::create(builder, loc, ctx.createImmType(0), 0);
 
       // Adjust base: S_ADD_U32 sets SCC, S_ADDC_U32 reads it.
-      // TODO: thread the SCC result from S_ADD_U32 into S_ADDC_U32 as an
-      // explicit operand. Currently S_ADDC_U32 has no SCC input in TableGen,
-      // so the carry dependency is only enforced by emission ordering.
-      SRegType sccTy = ctx.createSRegType();
-      word0 =
-          S_ADD_U32::create(builder, loc, sregTy, sccTy, word0, offLo).getDst();
-      word1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy, word1, offHi)
+      SCCType sccTy = ctx.createSCCType();
+      auto addLo = S_ADD_U32::create(builder, loc, sregTy, sccTy, word0, offLo);
+      word0 = addLo.getDst();
+      word1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy, addLo.getScc(),
+                                 word1, offHi)
                   .getDst();
     }
 

--- a/waveasm/lib/Transforms/TranslateFromMLIR.cpp
+++ b/waveasm/lib/Transforms/TranslateFromMLIR.cpp
@@ -67,6 +67,10 @@ ARegType TranslationContext::createARegType(int64_t size, int64_t alignment) {
   return ARegType::get(builder.getContext(), size, alignment);
 }
 
+SCCType TranslationContext::createSCCType() {
+  return SCCType::get(builder.getContext());
+}
+
 ImmType TranslationContext::createImmType(int64_t value) {
   return ImmType::get(builder.getContext(), value);
 }
@@ -651,13 +655,13 @@ Value emitSRDBaseAdjustment(const TranslationContext::PendingSRDBaseAdjust &adj,
       S_MUL_I32::create(builder, loc, sregTy, offsetVal, elemSizeImm);
 
   // Adjust SRD base: s_add_u32 (sets SCC) + s_addc_u32 (reads SCC).
-  auto sccTy = ctx.createSRegType();
-  Value adjWord0 =
-      S_ADD_U32::create(builder, loc, sregTy, sccTy, srcWord0, byteOffLo)
-          .getDst();
-  Value adjWord1 =
-      S_ADDC_U32::create(builder, loc, sregTy, sccTy, srcWord1, byteOffHi)
-          .getDst();
+  SCCType sccTy = ctx.createSCCType();
+  auto addLo =
+      S_ADD_U32::create(builder, loc, sregTy, sccTy, srcWord0, byteOffLo);
+  Value adjWord0 = addLo.getDst();
+  Value adjWord1 = S_ADDC_U32::create(builder, loc, sregTy, sccTy,
+                                      addLo.getScc(), srcWord1, byteOffHi)
+                       .getDst();
 
   // Build word 2 (num_records).
   Value word2;

--- a/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/AMDGPUHandlers.cpp
@@ -646,11 +646,15 @@ LogicalResult handleFatRawBufferCast(Operation *op, TranslationContext &ctx) {
     int64_t srdWord1Bits = static_cast<int64_t>(swizzleStride | 0x4000) << 16;
     auto maskImm = ctx.createImmType(0xffff);
     auto maskVal = ConstantOp::create(builder, loc, maskImm, 0xffff);
-    Value cleared = S_AND_B32::create(builder, loc, sregTy, srcWord1, maskVal);
+    Value cleared = S_AND_B32::create(builder, loc, sregTy, ctx.createSCCType(),
+                                      srcWord1, maskVal)
+                        .getDst();
     auto swizzleImm = ctx.createImmType(srdWord1Bits);
     auto swizzleVal =
         ConstantOp::create(builder, loc, swizzleImm, srdWord1Bits);
-    word1 = S_OR_B32::create(builder, loc, sregTy, cleared, swizzleVal);
+    word1 = S_OR_B32::create(builder, loc, sregTy, ctx.createSCCType(), cleared,
+                             swizzleVal)
+                .getDst();
   } else {
     word1 = S_MOV_B32::create(builder, loc, sregTy, srcWord1);
   }
@@ -926,7 +930,9 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
               auto shiftConst =
                   ConstantOp::create(builder, loc, shiftImm, shiftAmt);
               rowContrib = S_LSHL_B32::create(builder, loc, sregType,
-                                              rowContrib, shiftConst);
+                                              ctx.createSCCType(), rowContrib,
+                                              shiftConst)
+                               .getDst();
             } else {
               auto strideImm = ctx.createImmType(ldsRowStride);
               auto strideConst =
@@ -983,8 +989,8 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
             bool m0IsSgpr = !isVGPRType(m0Val.getType());
             if (m0IsSgpr) {
               auto sregType = ctx.createSRegType();
-              m0Val = S_ADD_U32::create(builder, loc, sregType, sregType, m0Val,
-                                        totalConst)
+              m0Val = S_ADD_U32::create(builder, loc, sregType,
+                                        ctx.createSCCType(), m0Val, totalConst)
                           .getDst();
             } else {
               m0Val = V_ADD_U32::create(builder, loc, ctx.createVRegType(),
@@ -1007,9 +1013,10 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
               bool rowIsSgpr = !isVGPRType(rowContrib.getType());
               if (m0IsSgpr && rowIsSgpr) {
                 auto sregType = ctx.createSRegType();
-                m0Val = S_ADD_U32::create(builder, loc, sregType, sregType,
-                                          m0Val, rowContrib)
-                            .getDst();
+                m0Val =
+                    S_ADD_U32::create(builder, loc, sregType,
+                                      ctx.createSCCType(), m0Val, rowContrib)
+                        .getDst();
               } else {
                 m0Val = convertToVgpr(m0Val);
                 rowContrib = convertToVgpr(rowContrib);
@@ -1027,8 +1034,8 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
             bool m0IsSgpr = m0Val && !isVGPRType(m0Val.getType());
             if (m0IsSgpr) {
               auto sregType = ctx.createSRegType();
-              m0Val = S_ADD_U32::create(builder, loc, sregType, sregType, m0Val,
-                                        colConst)
+              m0Val = S_ADD_U32::create(builder, loc, sregType,
+                                        ctx.createSCCType(), m0Val, colConst)
                           .getDst();
             } else if (m0Val) {
               m0Val = V_ADD_U32::create(builder, loc, ctx.createVRegType(),
@@ -1048,8 +1055,10 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
                   auto shiftImm = ctx.createImmType(shiftAmt);
                   auto shiftConst =
                       ConstantOp::create(builder, loc, shiftImm, shiftAmt);
-                  colVal = S_LSHL_B32::create(builder, loc, sregType, colVal,
-                                              shiftConst);
+                  colVal = S_LSHL_B32::create(builder, loc, sregType,
+                                              ctx.createSCCType(), colVal,
+                                              shiftConst)
+                               .getDst();
                 } else {
                   auto scaleImm = ctx.createImmType(ldsElemBytes);
                   auto scaleConst =
@@ -1059,8 +1068,8 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
                 }
               }
               auto sregType = ctx.createSRegType();
-              m0Val = S_ADD_U32::create(builder, loc, sregType, sregType, m0Val,
-                                        colVal)
+              m0Val = S_ADD_U32::create(builder, loc, sregType,
+                                        ctx.createSCCType(), m0Val, colVal)
                           .getDst();
             } else {
               // At least one is VGPR: fall back to VALU
@@ -1089,8 +1098,8 @@ LogicalResult handleGatherToLds(Operation *op, TranslationContext &ctx) {
           bool m0IsSgpr = !isVGPRType(m0Val.getType());
           if (m0IsSgpr) {
             auto sregType = ctx.createSRegType();
-            m0Val = S_ADD_U32::create(builder, loc, sregType, sregType, m0Val,
-                                      baseConst)
+            m0Val = S_ADD_U32::create(builder, loc, sregType,
+                                      ctx.createSCCType(), m0Val, baseConst)
                         .getDst();
           } else {
             Value baseVgpr = V_MOV_B32::create(builder, loc,

--- a/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
+++ b/waveasm/lib/Transforms/handlers/ArithHandlers.cpp
@@ -342,13 +342,13 @@ LogicalResult handleArithCmpI(Operation *op, TranslationContext &ctx) {
   }
 
   // When both operands are scalar (SGPR or immediate), use S_CMP which
-  // produces an SGPR result directly.  This is required for scf.if/scf.for
-  // conditions that feed waveasm.if/waveasm.condition (which require SGPRs).
+  // produces an SCC result.  This feeds waveasm.if/waveasm.condition.
   bool lhsScalar = isSGPRType(lhs->getType()) || isImmType(lhs->getType());
   bool rhsScalar = isSGPRType(rhs->getType()) || isImmType(rhs->getType());
 
   if (lhsScalar && rhsScalar) {
-    auto sregType = ctx.createSRegType();
+    SRegType sregType = ctx.createSRegType();
+    SCCType sccType = ctx.createSCCType();
     // S_CMP requires SGPR operands; move immediates to SGPRs first.
     Value lhsOp = *lhs;
     Value rhsOp = *rhs;
@@ -359,34 +359,34 @@ LogicalResult handleArithCmpI(Operation *op, TranslationContext &ctx) {
     Value result;
     switch (cmpOp.getPredicate()) {
     case arith::CmpIPredicate::eq:
-      result = S_CMP_EQ_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_EQ_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::ne:
-      result = S_CMP_NE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_NE_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::slt:
-      result = S_CMP_LT_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_LT_I32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::sle:
-      result = S_CMP_LE_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_LE_I32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::sgt:
-      result = S_CMP_GT_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_GT_I32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::sge:
-      result = S_CMP_GE_I32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_GE_I32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::ult:
-      result = S_CMP_LT_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_LT_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::ule:
-      result = S_CMP_LE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_LE_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::ugt:
-      result = S_CMP_GT_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_GT_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     case arith::CmpIPredicate::uge:
-      result = S_CMP_GE_U32::create(builder, loc, sregType, lhsOp, rhsOp);
+      result = S_CMP_GE_U32::create(builder, loc, sccType, lhsOp, rhsOp);
       break;
     }
     ctx.getMapper().mapValue(cmpOp.getResult(), result);

--- a/waveasm/test/Dialect/basic.mlir
+++ b/waveasm/test/Dialect/basic.mlir
@@ -15,6 +15,9 @@ waveasm.program @simple_kernel
   // Comment
   waveasm.comment "Basic kernel body"
 
+  // Scheduling barrier.
+  waveasm.s_sched_barrier 0
+
   // End program
   waveasm.s_endpgm
 }

--- a/waveasm/test/Dialect/region-control-flow.mlir
+++ b/waveasm/test/Dialect/region-control-flow.mlir
@@ -25,12 +25,12 @@ waveasm.program @simple_loop
   // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
   // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
   %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
-    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next#0) : !waveasm.sreg
+    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
   // CHECK-NEXT: }
   }
 
@@ -61,12 +61,12 @@ waveasm.program @loop_with_accumulator
     // CHECK-NEXT:   %[[NEWACC:.*]] = waveasm.v_add_u32 %[[ACC]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
     %new_acc = waveasm.v_add_u32 %acc, %i
         : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
-    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.scc iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   // CHECK-NEXT: }
   }
 
@@ -99,12 +99,12 @@ waveasm.program @loop_mfma_accumulation
     %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a_tile, %b_tile, %acc
         : !waveasm.vreg<2>, !waveasm.vreg<2>, !waveasm.vreg<4> -> !waveasm.vreg<4>
 
-    %next_k:2 = waveasm.s_add_u32 %k, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %continue = waveasm.s_cmp_lt_u32 %next_k#0, %four : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %next_k:2 = waveasm.s_add_u32 %k, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %continue = waveasm.s_cmp_lt_u32 %next_k#0, %four : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
 
     // MFMA result fed back as accumulator iter_arg (vreg<4>)
-    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[MFMA]]) : !waveasm.sreg, !waveasm.vreg<4>
-    waveasm.condition %continue : !waveasm.sreg iter_args(%next_k#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4>
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[MFMA]]) : !waveasm.sreg, !waveasm.vreg<4>
+    waveasm.condition %continue : !waveasm.scc iter_args(%next_k#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4>
   }
 
   waveasm.s_endpgm
@@ -156,11 +156,11 @@ waveasm.program @if_then_else
   %b = waveasm.precolored.vreg 1 : !waveasm.vreg
   %limit = waveasm.constant 10 : !waveasm.imm<10>
 
-  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-  %cmp = waveasm.s_cmp_lt_u32 %tid, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
+  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+  %cmp = waveasm.s_cmp_lt_u32 %tid, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
 
-  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.sreg -> !waveasm.vreg {
-  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.scc -> !waveasm.vreg {
+  %result = waveasm.if %cmp : !waveasm.scc -> !waveasm.vreg {
     // CHECK-NEXT:   %{{.*}} = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
@@ -245,18 +245,18 @@ waveasm.program @nested_loops
       // CHECK:      %{{.*}} = waveasm.v_add_u32 %[[IACC]], %{{.*}} : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
       %val = waveasm.v_add_u32 %inner_acc, %j
           : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
-      %next_j:2 = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      %cond_j = waveasm.s_cmp_lt_u32 %next_j#0, %inner_limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
-      waveasm.condition %cond_j : !waveasm.sreg iter_args(%next_j#0, %val) : !waveasm.sreg, !waveasm.vreg
+      %next_j:2 = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      %cond_j = waveasm.s_cmp_lt_u32 %next_j#0, %inner_limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
+      waveasm.condition %cond_j : !waveasm.scc iter_args(%next_j#0, %val) : !waveasm.sreg, !waveasm.vreg
     }
 
-    %next_i:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond_i = waveasm.s_cmp_lt_u32 %next_i#0, %outer_limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %next_i:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond_i = waveasm.s_cmp_lt_u32 %next_i#0, %outer_limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
 
     // Outer condition: accumulator comes from inner loop's result #1
-    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
-    waveasm.condition %cond_i : !waveasm.sreg iter_args(%next_i#0, %inner_result) : !waveasm.sreg, !waveasm.vreg
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond_i : !waveasm.scc iter_args(%next_i#0, %inner_result) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -279,14 +279,14 @@ waveasm.program @loop_with_if
   // CHECK:      %{{.*}} = waveasm.loop (%[[IV:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
   %result = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
     // Block arg used by s_and to check parity
-    // CHECK:      %[[REM:.*]] = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
-    %rem = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
-    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
-    %is_even = waveasm.s_cmp_eq_u32 %rem, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+    // CHECK:      %[[REM:.*]], %{{.*}} = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %rem:2 = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.scc
+    %is_even = waveasm.s_cmp_eq_u32 %rem#0, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.scc
 
-    // If branches on the comparison result, producing an sreg step value
-    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.sreg -> !waveasm.sreg {
-    %step = waveasm.if %is_even : !waveasm.sreg -> !waveasm.sreg {
+    // If branches on the comparison result, producing an sreg step value.
+    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.scc -> !waveasm.sreg {
+    %step = waveasm.if %is_even : !waveasm.scc -> !waveasm.sreg {
       // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
       %step_val = waveasm.s_mov_b32 %two : !waveasm.imm<2> -> !waveasm.sreg
       waveasm.yield %step_val : !waveasm.sreg
@@ -298,12 +298,12 @@ waveasm.program @loop_with_if
     }
 
     // If result (%STEP) used to update counter, which feeds condition
-    // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    %continue = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
-    waveasm.condition %continue : !waveasm.sreg iter_args(%next#0) : !waveasm.sreg
+    // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    %continue = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %continue : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Dialect/scc-ops.mlir
+++ b/waveasm/test/Dialect/scc-ops.mlir
@@ -1,0 +1,103 @@
+// RUN: waveasm-translate %s | FileCheck %s
+//
+// Roundtrip tests for SCC-producing and SCC-consuming ops.
+
+// CHECK-LABEL: waveasm.program @scc_binary_with_carry
+waveasm.program @scc_binary_with_carry
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %s1 = waveasm.precolored.sreg 1 : !waveasm.psreg<1>
+  %s2 = waveasm.precolored.sreg 2 : !waveasm.psreg<2>
+  %s3 = waveasm.precolored.sreg 3 : !waveasm.psreg<3>
+
+  // SALUBinaryWithCarryOp: produces dst + SCC carry-out.
+  // CHECK: [[LO:%.*]], [[SCC1:%.*]] = waveasm.s_add_u32
+  // CHECK-SAME: -> !waveasm.sreg, !waveasm.scc
+  %lo:2 = waveasm.s_add_u32 %s0, %s2
+      : !waveasm.psreg<0>, !waveasm.psreg<2> -> !waveasm.sreg, !waveasm.scc
+
+  // SALUBinaryWithCarryInOp: reads SCC carry-in, produces dst + SCC carry-out.
+  // CHECK: [[HI:%.*]], [[SCC2:%.*]] = waveasm.s_addc_u32 [[SCC1]]
+  // CHECK-SAME: -> !waveasm.sreg, !waveasm.scc
+  %hi:2 = waveasm.s_addc_u32 %lo#1, %s1, %s3
+      : !waveasm.scc, !waveasm.psreg<1>, !waveasm.psreg<3>
+      -> !waveasm.sreg, !waveasm.scc
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: waveasm.program @scc_binary_with_scc_clobber
+waveasm.program @scc_binary_with_scc_clobber
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %s1 = waveasm.precolored.sreg 1 : !waveasm.psreg<1>
+
+  // SALUBinaryWithSCCOp: bitwise ops clobber SCC.
+  // CHECK: [[AND:%.*]], %{{.*}} = waveasm.s_and_b32
+  // CHECK-SAME: -> !waveasm.sreg, !waveasm.scc
+  %and:2 = waveasm.s_and_b32 %s0, %s1
+      : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.scc
+
+  // CHECK: [[OR:%.*]], %{{.*}} = waveasm.s_or_b32
+  %or:2 = waveasm.s_or_b32 %s0, %s1
+      : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.scc
+
+  // CHECK: [[LSHL:%.*]], %{{.*}} = waveasm.s_lshl_b32
+  %c4 = waveasm.constant 4 : !waveasm.imm<4>
+  %lshl:2 = waveasm.s_lshl_b32 %s0, %c4
+      : !waveasm.psreg<0>, !waveasm.imm<4> -> !waveasm.sreg, !waveasm.scc
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: waveasm.program @scc_cmp_and_cselect
+waveasm.program @scc_cmp_and_cselect
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  // SALUCmpOp: produces SCC.
+  // CHECK: [[CMP:%.*]] = waveasm.s_cmp_lt_u32
+  // CHECK-SAME: -> !waveasm.scc
+  %cmp = waveasm.s_cmp_lt_u32 %s0, %c10
+      : !waveasm.psreg<0>, !waveasm.imm<10> -> !waveasm.scc
+
+  // S_CSELECT_B32: consumes SCC.
+  // CHECK: waveasm.s_cselect_b32 [[CMP]]
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %sel = waveasm.s_cselect_b32 %cmp, %one, %zero
+      : !waveasm.scc, !waveasm.imm<1>, !waveasm.imm<0> -> !waveasm.sreg
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: waveasm.program @scc_unary_with_scc
+waveasm.program @scc_unary_with_scc
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+
+  // SALUUnaryWithSCCOp: clobbers SCC.
+  // CHECK: [[NOT:%.*]], %{{.*}} = waveasm.s_not_b32
+  // CHECK-SAME: -> !waveasm.sreg, !waveasm.scc
+  %not:2 = waveasm.s_not_b32 %s0
+      : !waveasm.psreg<0> -> !waveasm.sreg, !waveasm.scc
+
+  // CHECK: [[BREV:%.*]], %{{.*}} = waveasm.s_brev_b32
+  %brev:2 = waveasm.s_brev_b32 %s0
+      : !waveasm.psreg<0> -> !waveasm.sreg, !waveasm.scc
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/arith-legalization.mlir
+++ b/waveasm/test/Transforms/arith-legalization.mlir
@@ -17,7 +17,7 @@ waveasm.program @test_add
   %add_vv = waveasm.arith.add %v0, %v0 : (!waveasm.vreg, !waveasm.vreg) -> !waveasm.vreg
 
   // SGPR + SGPR -> s_add_u32.
-  // CHECK: waveasm.s_add_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.sreg
+  // CHECK: waveasm.s_add_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.scc
   %add_ss = waveasm.arith.add %s0, %s1 : (!waveasm.sreg, !waveasm.sreg) -> !waveasm.sreg
 
   // SGPR + VGPR -> v_add_u32 (SGPR broadcast via v_mov_b32).
@@ -26,7 +26,7 @@ waveasm.program @test_add
   %add_sv = waveasm.arith.add %s0, %v0 : (!waveasm.sreg, !waveasm.vreg) -> !waveasm.vreg
 
   // SGPR + imm -> s_add_u32.
-  // CHECK: waveasm.s_add_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<42>
+  // CHECK: waveasm.s_add_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<42> -> !waveasm.sreg, !waveasm.scc
   %add_si = waveasm.arith.add %s0, %c42 : (!waveasm.sreg, !waveasm.imm<42>) -> !waveasm.sreg
 
   // CHECK-NOT: waveasm.arith.
@@ -157,9 +157,9 @@ waveasm.program @test_add_i64_salu
   // CHECK-DAG: [[A_HI:%.*]] = waveasm.precolored.sreg 1 : !waveasm.sreg
   // CHECK-DAG: [[B_LO:%.*]] = waveasm.precolored.sreg 2 : !waveasm.sreg
   // CHECK-DAG: [[B_HI:%.*]] = waveasm.precolored.sreg 3 : !waveasm.sreg
-  // Carry chain: s_add_u32 (lo) then s_addc_u32 (hi).
-  // CHECK: [[LO:%.*]], %{{.*}} = waveasm.s_add_u32 [[A_LO]], [[B_LO]]
-  // CHECK-NEXT: [[HI:%.*]], %{{.*}} = waveasm.s_addc_u32 [[A_HI]], [[B_HI]]
+  // Carry chain: s_add_u32 (lo) then s_addc_u32 (hi, with explicit SCC-in).
+  // CHECK: [[LO:%.*]], [[SCC:%.*]] = waveasm.s_add_u32 [[A_LO]], [[B_LO]]
+  // CHECK-NEXT: [[HI:%.*]], %{{.*}} = waveasm.s_addc_u32 [[SCC]], [[A_HI]], [[B_HI]]
   // CHECK: waveasm.pack [[LO]], [[HI]]
   %add = waveasm.arith.add %a, %b : (!waveasm.sreg<2, 2>, !waveasm.sreg<2, 2>) -> !waveasm.sreg<2, 2>
 
@@ -256,7 +256,7 @@ waveasm.program @test_sext
   %v0 = waveasm.precolored.vreg 0 : !waveasm.vreg
 
   // SGPR sext: hi = s_ashr_i32(lo, 31), then merge.
-  // CHECK: waveasm.s_ashr_i32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<31>
+  // CHECK: waveasm.s_ashr_i32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<31> -> !waveasm.sreg, !waveasm.scc
   // CHECK: waveasm.pack
   %sext_s = waveasm.arith.sext %s0 : (!waveasm.sreg) -> !waveasm.sreg<2, 2>
 
@@ -306,9 +306,9 @@ waveasm.program @test_cmp_i64_eq
   // CHECK-DAG: [[A_HI:%.*]] = waveasm.precolored.sreg 1 : !waveasm.sreg
   // CHECK-DAG: [[B_LO:%.*]] = waveasm.precolored.sreg 2 : !waveasm.sreg
   // CHECK-DAG: [[B_HI:%.*]] = waveasm.precolored.sreg 3 : !waveasm.sreg
-  // CHECK: [[XOR_LO:%.*]] = waveasm.s_xor_b32 [[A_LO]], [[B_LO]]
-  // CHECK: [[XOR_HI:%.*]] = waveasm.s_xor_b32 [[A_HI]], [[B_HI]]
-  // CHECK: [[COMBINED:%.*]] = waveasm.s_or_b32 [[XOR_LO]], [[XOR_HI]]
+  // CHECK: [[XOR_LO:%.*]], %{{.*}} = waveasm.s_xor_b32 [[A_LO]], [[B_LO]]
+  // CHECK: [[XOR_HI:%.*]], %{{.*}} = waveasm.s_xor_b32 [[A_HI]], [[B_HI]]
+  // CHECK: [[COMBINED:%.*]], %{{.*}} = waveasm.s_or_b32 [[XOR_LO]], [[XOR_HI]]
   // CHECK: waveasm.s_cmp_eq_i32 [[COMBINED]], %{{.*}}
   %cmp = waveasm.arith.cmp eq, %a, %b : (!waveasm.sreg<2, 2>, !waveasm.sreg<2, 2>) -> !waveasm.sreg
 
@@ -352,15 +352,19 @@ waveasm.program @test_cmp_i64_slt_salu
   %b = waveasm.precolored.sreg 2, 2 : !waveasm.sreg<2, 2>
 
   // Ordered i64 slt (SALU): hiLt | (hiEq & loLt).
+  // Each s_cmp sets SCC, then s_cselect_b32 materializes the boolean to SGPR.
   // CHECK-DAG: [[A_LO:%.*]] = waveasm.precolored.sreg 0 : !waveasm.sreg
   // CHECK-DAG: [[A_HI:%.*]] = waveasm.precolored.sreg 1 : !waveasm.sreg
   // CHECK-DAG: [[B_LO:%.*]] = waveasm.precolored.sreg 2 : !waveasm.sreg
   // CHECK-DAG: [[B_HI:%.*]] = waveasm.precolored.sreg 3 : !waveasm.sreg
-  // CHECK: [[HI_LT:%.*]] = waveasm.s_cmp_lt_i32 [[A_HI]], [[B_HI]]
-  // CHECK: [[HI_EQ:%.*]] = waveasm.s_cmp_eq_i32 [[A_HI]], [[B_HI]]
-  // CHECK: [[LO_LT:%.*]] = waveasm.s_cmp_lt_u32 [[A_LO]], [[B_LO]]
-  // CHECK: [[EQ_AND_LO:%.*]] = waveasm.s_and_b32 [[HI_EQ]], [[LO_LT]]
-  // CHECK: waveasm.s_or_b32 [[HI_LT]], [[EQ_AND_LO]]
+  // CHECK: [[SCC1:%.*]] = waveasm.s_cmp_lt_i32 [[A_HI]], [[B_HI]]
+  // CHECK: [[HI_LT:%.*]] = waveasm.s_cselect_b32 [[SCC1]],
+  // CHECK: [[SCC2:%.*]] = waveasm.s_cmp_eq_i32 [[A_HI]], [[B_HI]]
+  // CHECK: [[HI_EQ:%.*]] = waveasm.s_cselect_b32 [[SCC2]],
+  // CHECK: [[SCC3:%.*]] = waveasm.s_cmp_lt_u32 [[A_LO]], [[B_LO]]
+  // CHECK: [[LO_LT:%.*]] = waveasm.s_cselect_b32 [[SCC3]],
+  // CHECK: [[EQ_AND_LO:%.*]], %{{.*}} = waveasm.s_and_b32 [[HI_EQ]], [[LO_LT]]
+  // CHECK: %{{.*}}, %{{.*}} = waveasm.s_or_b32 [[HI_LT]], [[EQ_AND_LO]]
   %cmp = waveasm.arith.cmp slt, %a, %b : (!waveasm.sreg<2, 2>, !waveasm.sreg<2, 2>) -> !waveasm.sreg
 
   // CHECK-NOT: waveasm.arith.

--- a/waveasm/test/Transforms/buffer-load-strength-reduction.mlir
+++ b/waveasm/test/Transforms/buffer-load-strength-reduction.mlir
@@ -49,9 +49,9 @@ waveasm.program @basic_strength_reduction
 
     %new_acc = waveasm.v_add_u32 %acc, %val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -90,9 +90,9 @@ waveasm.program @no_transform_loop_invariant_voffset
 
     %new_acc = waveasm.v_add_u32 %acc, %val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -141,9 +141,9 @@ waveasm.program @two_srd_groups
     %sum = waveasm.v_add_u32 %val_a, %val_b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     %new_acc = waveasm.v_add_u32 %acc, %sum : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -197,9 +197,9 @@ waveasm.program @shared_srd_group
     %sum = waveasm.v_add_u32 %val_a, %val_b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     %new_acc = waveasm.v_add_u32 %acc, %sum : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -241,9 +241,9 @@ waveasm.program @soffset_increment
     // CHECK: waveasm.buffer_load_dword {{.*}}, {{.*}}, [[SOFF:%[a-z0-9]+]] : !waveasm.psreg<0, 4>, !waveasm.vreg, !waveasm.sreg ->
     // CHECK: [[NEXT_SOFF:%[a-z0-9_]+]], %{{.*}} = waveasm.s_add_u32 [[SOFF]], {{.*}} ->
     // CHECK: waveasm.condition {{.*}} iter_args({{.*}}, {{.*}}, [[NEXT_SOFF]]) :
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -283,9 +283,9 @@ waveasm.program @stride_precompute
     %val = waveasm.buffer_load_dword %srd, %voff, %soff0
         : !waveasm.psreg<0, 4>, !waveasm.vreg, !waveasm.imm<0> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -345,9 +345,9 @@ waveasm.program @non_uniform_stride
 
     %new_acc = waveasm.v_add_u32 %acc, %val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -390,9 +390,9 @@ waveasm.program @multi_dword_load
 
     %new_acc = waveasm.v_add_u32 %acc, %v0 : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -431,9 +431,9 @@ waveasm.program @nonzero_inst_offset
     %val = waveasm.buffer_load_dword %srd, %voff, %soff0 offset : 2048
         : !waveasm.psreg<0, 4>, !waveasm.vreg, !waveasm.imm<0> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -487,9 +487,9 @@ waveasm.program @different_strides_same_srd
     %sum = waveasm.v_add_u32 %val_a, %val_b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     %new_acc = waveasm.v_add_u32 %acc, %sum : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -534,9 +534,9 @@ waveasm.program @lds_load_strength_reduction
     waveasm.buffer_load_dwordx4_lds %voff, %srd, %soff0
         : !waveasm.vreg, !waveasm.psreg<0, 4>, !waveasm.imm<0>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -571,9 +571,9 @@ waveasm.program @lds_load_no_transform
     waveasm.buffer_load_dword_lds %tid, %srd, %soff0
         : !waveasm.pvreg<0>, !waveasm.psreg<0, 4>, !waveasm.imm<0>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -621,9 +621,9 @@ waveasm.program @lshrrev_in_address_chain
         : !waveasm.psreg<0, 4>, !waveasm.vreg, !waveasm.imm<0>
         -> !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %two : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<32> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %two : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<32> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -667,9 +667,9 @@ waveasm.program @lshrrev_non_divisible
 
     %new_acc = waveasm.v_add_u32 %acc, %val : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/expr-cse.mlir
+++ b/waveasm/test/Transforms/expr-cse.mlir
@@ -88,9 +88,9 @@ waveasm.program @cse_sgpr_arith target = #waveasm.target<#waveasm.gfx942, 5> abi
 
   // First SALU add
   // CHECK: waveasm.s_add_u32
-  %r0:2 = waveasm.s_add_u32 %s0, %s1 : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.sreg
+  %r0:2 = waveasm.s_add_u32 %s0, %s1 : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.scc
   // Same operation - should be CSE'd
-  %r1:2 = waveasm.s_add_u32 %s0, %s1 : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.sreg
+  %r1:2 = waveasm.s_add_u32 %s0, %s1 : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.scc
   // Different operation
   // CHECK: waveasm.s_mul_i32
   %r2 = waveasm.s_mul_i32 %s0, %s1 : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg

--- a/waveasm/test/Transforms/hazard-mitigation.mlir
+++ b/waveasm/test/Transforms/hazard-mitigation.mlir
@@ -412,8 +412,8 @@ waveasm.program @loop_exit_no_hazard target = #waveasm.target<#waveasm.gfx942, 5
   %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
     // VALU writes pvreg<0>.
     %sum = waveasm.v_add_u32 %v0, %v1 : !waveasm.pvreg<0>, !waveasm.pvreg<1> -> !waveasm.pvreg<0>
-    %cond = waveasm.s_cmp_lt_u32 %i, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%i) : !waveasm.sreg
+    %cond = waveasm.s_cmp_lt_u32 %i, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%i) : !waveasm.sreg
   }
 
   // condition (s_cbranch) is the last emitting op -- not a VALU.

--- a/waveasm/test/Transforms/licm.mlir
+++ b/waveasm/test/Transforms/licm.mlir
@@ -46,9 +46,9 @@ waveasm.program @test_licm_chain
 
     waveasm.buffer_store_dword %addr, %srd, %v0 : !waveasm.vreg, !waveasm.psreg<0, 4>, !waveasm.pvreg<0>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -84,9 +84,9 @@ waveasm.program @test_licm_no_hoist
     %addr = waveasm.v_add_u32 %v0, %acc : !waveasm.pvreg<0>, !waveasm.vreg -> !waveasm.vreg
     waveasm.buffer_store_dword %addr, %srd, %v0 : !waveasm.vreg, !waveasm.psreg<0, 4>, !waveasm.pvreg<0>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %addr) : !waveasm.sreg, !waveasm.vreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %addr) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -135,14 +135,14 @@ waveasm.program @test_licm_nested
 
       waveasm.buffer_store_dword %sum, %srd, %v0 : !waveasm.vreg, !waveasm.psreg<0, 4>, !waveasm.pvreg<0>
 
-      %next_iiv:2 = waveasm.s_add_u32 %iiv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      %icond = waveasm.s_cmp_lt_u32 %next_iiv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-      waveasm.condition %icond : !waveasm.sreg iter_args(%next_iiv#0, %sum) : !waveasm.sreg, !waveasm.vreg
+      %next_iiv:2 = waveasm.s_add_u32 %iiv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      %icond = waveasm.s_cmp_lt_u32 %next_iiv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+      waveasm.condition %icond : !waveasm.scc iter_args(%next_iiv#0, %sum) : !waveasm.sreg, !waveasm.vreg
     }
 
-    %next_oiv:2 = waveasm.s_add_u32 %oiv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %ocond = waveasm.s_cmp_lt_u32 %next_oiv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %ocond : !waveasm.sreg iter_args(%next_oiv#0) : !waveasm.sreg
+    %next_oiv:2 = waveasm.s_add_u32 %oiv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %ocond = waveasm.s_cmp_lt_u32 %next_oiv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %ocond : !waveasm.scc iter_args(%next_oiv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/linear-scan-bidirectional.mlir
+++ b/waveasm/test/Transforms/linear-scan-bidirectional.mlir
@@ -145,10 +145,10 @@ waveasm.program @bidirectional_loop_double_buffer
         -> !waveasm.vreg<4, 4>
 
     %next_i:2 = waveasm.s_add_u32 %i, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
     %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c16
-        : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_i#0, %buf0_use, %buf1_use)
         : !waveasm.sreg, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
   }
@@ -227,19 +227,19 @@ waveasm.program @sgpr_not_bidirectional
 
   %s1 = waveasm.s_mov_b32 %c1 : !waveasm.imm<1> -> !waveasm.sreg
   %s2:2 = waveasm.s_add_u32 %s1, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s3:2 = waveasm.s_add_u32 %s2#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s4:2 = waveasm.s_add_u32 %s3#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s5:2 = waveasm.s_add_u32 %s4#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s6:2 = waveasm.s_add_u32 %s5#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s7:2 = waveasm.s_add_u32 %s6#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
   %s8:2 = waveasm.s_add_u32 %s7#0, %c1
-      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+      : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
   // Late use of %ptr — long-lived SGPR quad
   %v0 = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>

--- a/waveasm/test/Transforms/linear-scan-if-feeds-loop.mlir
+++ b/waveasm/test/Transforms/linear-scan-if-feeds-loop.mlir
@@ -39,9 +39,9 @@ waveasm.program @if_result_feeds_loop
   %vs = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
 
   %s_zero = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
-  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.scc
 
-  %if_result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.areg<4, 4> {
+  %if_result = waveasm.if %cmp : !waveasm.scc -> !waveasm.areg<4, 4> {
     %acc_init = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.areg<4, 4>
     %mfma = waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 %v0, %v4, %acc_init, %vs, %vs
         : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.areg<4, 4>, !waveasm.pvreg<8>, !waveasm.pvreg<8> -> !waveasm.areg<4, 4>
@@ -59,9 +59,9 @@ waveasm.program @if_result_feeds_loop
     %new_mfma = waveasm.v_mfma_scale_f32_16x16x128_f8f6f4 %v0, %v4, %acc, %vs, %vs
         : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.areg<4, 4>, !waveasm.pvreg<8>, !waveasm.pvreg<8> -> !waveasm.areg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i#0, %new_mfma) : !waveasm.sreg, !waveasm.areg<4, 4>
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %loop_cond : !waveasm.scc iter_args(%next_i#0, %new_mfma) : !waveasm.sreg, !waveasm.areg<4, 4>
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/linear-scan-ifop-bug.mlir
+++ b/waveasm/test/Transforms/linear-scan-ifop-bug.mlir
@@ -26,9 +26,9 @@ waveasm.program @if_yield_type_mismatch
 
   %val = waveasm.v_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.vreg
   %s_zero = waveasm.s_mov_b32 %c0 : !waveasm.imm<0> -> !waveasm.sreg
-  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+  %cmp = waveasm.s_cmp_lt_u32 %s_zero, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.scc
 
-  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+  %result = waveasm.if %cmp : !waveasm.scc -> !waveasm.vreg {
     %added = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
     waveasm.yield %added : !waveasm.vreg
   } else {
@@ -65,9 +65,9 @@ waveasm.program @if_in_loop_type_mismatch
   %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
       : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
 
-    %cmp = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
+    %cmp = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.scc
 
-    %new_val = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+    %new_val = waveasm.if %cmp : !waveasm.scc -> !waveasm.vreg {
       %added = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
       waveasm.yield %added : !waveasm.vreg
     } else {
@@ -76,9 +76,9 @@ waveasm.program @if_in_loop_type_mismatch
 
     %new_sum = waveasm.v_add_u32 %new_val, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %loop_cond : !waveasm.scc iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -110,25 +110,25 @@ waveasm.program @multiple_ifs_compound
   %i_out, %val_out = waveasm.loop(%i = %init_i, %val = %init_val)
       : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
 
-    %cmp1 = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
-    %if1_result = waveasm.if %cmp1 : !waveasm.sreg -> !waveasm.vreg {
+    %cmp1 = waveasm.s_cmp_lt_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.scc
+    %if1_result = waveasm.if %cmp1 : !waveasm.scc -> !waveasm.vreg {
       %a1 = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
       waveasm.yield %a1 : !waveasm.vreg
     } else {
       waveasm.yield %val : !waveasm.vreg
     }
 
-    %cmp2 = waveasm.s_cmp_lt_u32 %i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    %if2_result = waveasm.if %cmp2 : !waveasm.sreg -> !waveasm.vreg {
+    %cmp2 = waveasm.s_cmp_lt_u32 %i, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    %if2_result = waveasm.if %cmp2 : !waveasm.scc -> !waveasm.vreg {
       %b1 = waveasm.v_add_u32 %if1_result, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
       waveasm.yield %b1 : !waveasm.vreg
     } else {
       waveasm.yield %if1_result : !waveasm.vreg
     }
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %loop_cond : !waveasm.sreg iter_args(%next_i#0, %if2_result) : !waveasm.sreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %loop_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %loop_cond : !waveasm.scc iter_args(%next_i#0, %if2_result) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/linear-scan-stress.mlir
+++ b/waveasm/test/Transforms/linear-scan-stress.mlir
@@ -117,9 +117,9 @@ waveasm.program @loop_dsread_acc_competition
     %n3 = waveasm.v_mfma_f32_16x16x16_f16 %lds_data0, %lds_data1, %acc3
         : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %n0, %n1, %n2, %n3)
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %n0, %n1, %n2, %n3)
         : !waveasm.sreg,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
@@ -161,9 +161,9 @@ waveasm.program @value_live_across_loop
     %tmp2 = waveasm.v_add_u32 %tmp, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
     %tmp3 = waveasm.v_add_u32 %tmp2, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %tmp3) : !waveasm.sreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %tmp3) : !waveasm.sreg, !waveasm.vreg
   }
 
   // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[OUTSIDE]]>
@@ -203,16 +203,16 @@ waveasm.program @nested_loops
         : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
       %inner_tmp = waveasm.v_add_u32 %inner_acc, %v0
           : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
-      %next_j:2 = waveasm.s_add_u32 %ij, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      %inner_cond = waveasm.s_cmp_lt_u32 %next_j#0, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-      waveasm.condition %inner_cond : !waveasm.sreg iter_args(%next_j#0, %inner_tmp) : !waveasm.sreg, !waveasm.vreg
+      %next_j:2 = waveasm.s_add_u32 %ij, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      %inner_cond = waveasm.s_cmp_lt_u32 %next_j#0, %c4 : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+      waveasm.condition %inner_cond : !waveasm.scc iter_args(%next_j#0, %inner_tmp) : !waveasm.sreg, !waveasm.vreg
     }
 
     %outer_new_sum = waveasm.v_add_u32 %inner_result, %c1
         : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
-    %next_i:2 = waveasm.s_add_u32 %oi, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %outer_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %outer_cond : !waveasm.sreg iter_args(%next_i#0, %outer_new_sum) : !waveasm.sreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %oi, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %outer_cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %outer_cond : !waveasm.scc iter_args(%next_i#0, %outer_new_sum) : !waveasm.sreg, !waveasm.vreg
   }
 
   // CHECK: waveasm.s_endpgm
@@ -268,9 +268,9 @@ waveasm.program @multi_mfma_chain_loop
     %n6 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc6 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
     %n7 = waveasm.v_mfma_f32_16x16x16_f16 %lds_a, %lds_b, %acc7 : !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7)
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7)
         : !waveasm.sreg,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>
@@ -351,9 +351,9 @@ waveasm.program @blockarg_only_mfma_use
     %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
         : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   %v8 = waveasm.precolored.vreg 8 : !waveasm.pvreg<8>
@@ -389,9 +389,9 @@ waveasm.program @sequential_loops
       : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
     %n1 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %loop1_acc
         : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
-    %next_i1:2 = waveasm.s_add_u32 %i1, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond1 = waveasm.s_cmp_lt_u32 %next_i1#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond1 : !waveasm.sreg iter_args(%next_i1#0, %n1) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i1:2 = waveasm.s_add_u32 %i1, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond1 = waveasm.s_cmp_lt_u32 %next_i1#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond1 : !waveasm.scc iter_args(%next_i1#0, %n1) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   %use1 = waveasm.v_add_u32 %acc1_out, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
@@ -404,9 +404,9 @@ waveasm.program @sequential_loops
       : (!waveasm.sreg, !waveasm.vreg<4, 4>) -> (!waveasm.sreg, !waveasm.vreg<4, 4>) {
     %n2 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %loop2_acc
         : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
-    %next_i2:2 = waveasm.s_add_u32 %i2, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond2 = waveasm.s_cmp_lt_u32 %next_i2#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond2 : !waveasm.sreg iter_args(%next_i2#0, %n2) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i2:2 = waveasm.s_add_u32 %i2, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond2 = waveasm.s_cmp_lt_u32 %next_i2#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond2 : !waveasm.scc iter_args(%next_i2#0, %n2) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   %use2 = waveasm.v_add_u32 %acc2_out, %v0 : !waveasm.vreg<4, 4>, !waveasm.pvreg<0> -> !waveasm.vreg
@@ -440,9 +440,9 @@ waveasm.program @blockarg_cond_only
 
     %new_val = waveasm.v_add_u32 %val, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_val, %sum) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_val, %sum) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
   }
 
   // CHECK: waveasm.v_add_u32 {{.*}}!waveasm.pvreg<[[FWD]]>
@@ -477,9 +477,9 @@ waveasm.program @long_epilogue
     %lb = waveasm.precolored.vreg 8, 4 : !waveasm.pvreg<8, 4>
     %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %la, %lb, %acc
         : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   // Long epilogue chain

--- a/waveasm/test/Transforms/linear-scan.mlir
+++ b/waveasm/test/Transforms/linear-scan.mlir
@@ -97,9 +97,9 @@ waveasm.program @loop_result_alloc target = #waveasm.target<#waveasm.gfx942, 5> 
       : (!waveasm.sreg, !waveasm.vreg) -> (!waveasm.sreg, !waveasm.vreg) {
     // CHECK: waveasm.v_add_u32 {{.*}} -> !waveasm.pvreg<[[LR]]>
     %new_sum = waveasm.v_add_u32 %sum, %v0 : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
   }
 
   // Post-loop use: loop result should have same physical register as init/body.
@@ -133,8 +133,8 @@ waveasm.program @init_arg_post_loop_use target = #waveasm.target<#waveasm.gfx942
     %next_iv = waveasm.v_mul_lo_u32 %iv, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
     %cond_s = waveasm.v_readfirstlane_b32 %next_iv : !waveasm.vreg -> !waveasm.sreg
     %ub_s = waveasm.v_readfirstlane_b32 %init_i : !waveasm.vreg -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub_s : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv) : !waveasm.vreg
+    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub_s : !waveasm.sreg, !waveasm.sreg -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv) : !waveasm.vreg
   }
 
   // Post-loop use of %init_val. It must still hold 0, not the loop's final IV.

--- a/waveasm/test/Transforms/lit-waitcnt.mlir
+++ b/waveasm/test/Transforms/lit-waitcnt.mlir
@@ -33,7 +33,7 @@ waveasm.program @smem_waitcnt target = #waveasm.target<#waveasm.gfx942, 5> abi =
   // CHECK: waveasm.s_load_dword
   // CHECK: waveasm.s_waitcnt
   %s1 = waveasm.precolored.sreg 4 : !waveasm.psreg<4>
-  %result:2 = waveasm.s_add_u32 %loaded, %s1 : !waveasm.sreg, !waveasm.psreg<4> -> !waveasm.sreg, !waveasm.sreg
+  %result:2 = waveasm.s_add_u32 %loaded, %s1 : !waveasm.sreg, !waveasm.psreg<4> -> !waveasm.sreg, !waveasm.scc
   waveasm.s_endpgm
 }
 

--- a/waveasm/test/Transforms/liveness-cfg.mlir
+++ b/waveasm/test/Transforms/liveness-cfg.mlir
@@ -21,9 +21,9 @@ module {
         %sum = arith.addi %i, %c1 : index
       }
       // Increment, compare, condition with iter_arg
-      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/waveasm/test/Transforms/loop-address-promotion.mlir
+++ b/waveasm/test/Transforms/loop-address-promotion.mlir
@@ -48,10 +48,10 @@ waveasm.program @basic_double_buffer
     %val = waveasm.ds_read_b128 %addr : !waveasm.vreg -> !waveasm.vreg<4, 4>
 
     // IV bump + condition.
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
     // Rotation: s0->s1, s1->s0.
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -88,9 +88,9 @@ waveasm.program @no_transform_not_lds
     %addr = waveasm.v_add_u32 %tid, %s0 : !waveasm.pvreg<0>, !waveasm.sreg -> !waveasm.vreg
     %dummy = waveasm.v_add_u32 %addr, %tid : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -126,10 +126,10 @@ waveasm.program @no_transform_no_rotation
     %addr = waveasm.v_add_u32 %tid, %s0 : !waveasm.pvreg<0>, !waveasm.sreg -> !waveasm.vreg
     %val = waveasm.ds_read_b128 %addr : !waveasm.vreg -> !waveasm.vreg<4, 4>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
     // Identity: s0->s0, no rotation.
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s0) : !waveasm.sreg, !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s0) : !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -169,10 +169,10 @@ waveasm.program @triple_buffer
     // CHECK: waveasm.ds_read_b128
     %val = waveasm.ds_read_b128 %addr : !waveasm.vreg -> !waveasm.vreg<4, 4>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
     // Rotation: s0->s1->s2->s0.
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s1, %s2, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s1, %s2, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -217,9 +217,9 @@ waveasm.program @two_reads_same_group
     // CHECK: waveasm.ds_read_b32
     %val1 = waveasm.ds_read_b32 %addr1 : !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -257,9 +257,9 @@ waveasm.program @operand_order_reversed
     // CHECK: waveasm.ds_read_b64
     %val = waveasm.ds_read_b64 %addr : !waveasm.vreg -> !waveasm.vreg<2>
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %s1, %s0) : !waveasm.sreg, !waveasm.sreg, !waveasm.sreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/loop-entry-copy-emit.mlir
+++ b/waveasm/test/Transforms/loop-entry-copy-emit.mlir
@@ -29,8 +29,8 @@ waveasm.program @loop_entry_copy
     %next_iv = waveasm.v_mul_lo_u32 %iv, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
     %cond_s = waveasm.v_readfirstlane_b32 %next_iv : !waveasm.vreg -> !waveasm.sreg
     %ub_s = waveasm.v_readfirstlane_b32 %init_i : !waveasm.vreg -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub_s : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv) : !waveasm.vreg
+    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub_s : !waveasm.sreg, !waveasm.sreg -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv) : !waveasm.vreg
   }
 
   // Post-loop use still reads the original register.

--- a/waveasm/test/Transforms/loop-pressure-regression.mlir
+++ b/waveasm/test/Transforms/loop-pressure-regression.mlir
@@ -123,9 +123,9 @@ waveasm.program @double_buffer_pressure
     %n29 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc29 : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
     // Loop counter
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0,
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c16 : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0,
         %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7,
         %n8, %n9, %n10, %n11, %n12, %n13, %n14, %n15,
         %n16, %n17, %n18, %n19, %n20, %n21, %n22, %n23,

--- a/waveasm/test/Transforms/loop-result-liveness.mlir
+++ b/waveasm/test/Transforms/loop-result-liveness.mlir
@@ -47,9 +47,9 @@ waveasm.program @loop_result_no_body_pressure
         : !waveasm.pvreg<4, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
     // Loop bookkeeping
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10 : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   // Use the loop result after the loop -- should get same phys reg as accumulator
@@ -92,9 +92,9 @@ waveasm.program @loop_result_tied_to_block_arg
     %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
         : !waveasm.pvreg<0, 4>, !waveasm.pvreg<4, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
   // Post-loop use of accumulator result -- same physical register

--- a/waveasm/test/Transforms/regalloc-overflow-error.mlir
+++ b/waveasm/test/Transforms/regalloc-overflow-error.mlir
@@ -61,9 +61,9 @@ waveasm.program @overflow_test
     %n8 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc8 : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
     %n9 = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc9 : !waveasm.pvreg<4, 4>, !waveasm.pvreg<8, 4>, !waveasm.vreg<4, 4> -> !waveasm.vreg<4, 4>
 
-    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_i#0, %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7, %n8, %n9)
+    %next_i:2 = waveasm.s_add_u32 %i, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c8 : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_i#0, %n0, %n1, %n2, %n3, %n4, %n5, %n6, %n7, %n8, %n9)
         : !waveasm.sreg,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,
           !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>, !waveasm.vreg<4, 4>,

--- a/waveasm/test/Transforms/region-based-translation.mlir
+++ b/waveasm/test/Transforms/region-based-translation.mlir
@@ -22,9 +22,9 @@ module {
         %i_i32 = arith.index_cast %i : index to i32
       }
       // Induction variable incremented, compared, condition terminates
-      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
@@ -51,9 +51,9 @@ module {
       // Body accumulates: vreg + sreg
       // CHECK:      %[[NEWACC:.*]] = waveasm.v_add_u32 %[[ACC]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
       // Induction variable incremented, compared, condition with both iter_args
-      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
+      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.scc iter_args(%[[NEXT]], %[[NEWACC]]) : !waveasm.sreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
@@ -68,7 +68,7 @@ module {
       %cond_i32 = arith.cmpi slt, %arg0, %c10 : i32
       %cond_ext = arith.extui %cond_i32 : i1 to i32
 
-      // CHECK:      %{{.*}} = waveasm.if %{{.*}} : !waveasm.sreg -> !waveasm.vreg {
+      // CHECK:      %{{.*}} = waveasm.if %{{.*}} : !waveasm.scc -> !waveasm.vreg {
       %result = scf.if %cond_i32 -> i32 {
         // CHECK:      waveasm.v_add_u32
         %sum = arith.addi %arg0, %arg1 : i32
@@ -104,10 +104,10 @@ module {
           %sum = arith.addi %i, %j : index
         }
         // Inner condition
-        // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}) : !waveasm.sreg
+        // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}) : !waveasm.sreg
       }
       // Outer condition
-      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}) : !waveasm.sreg
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/waveasm/test/Transforms/region-cf-integration.mlir
+++ b/waveasm/test/Transforms/region-cf-integration.mlir
@@ -23,12 +23,12 @@ waveasm.program @test_loop_structure
   // CHECK:      %[[INIT:.*]] = waveasm.s_mov_b32 %{{.*}} : !waveasm.imm<0> -> !waveasm.sreg
   // CHECK-NEXT: %{{.*}} = waveasm.loop (%[[IV:.*]] = %[[INIT]]) : (!waveasm.sreg) -> !waveasm.sreg {
   %counter = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
-    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next#0, %ten : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next#0) : !waveasm.sreg
+    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next#0, %ten : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
   // CHECK-NEXT: }
   }
 
@@ -56,12 +56,12 @@ waveasm.program @test_loop_accumulator
     // CHECK-NEXT:   %[[NEWSUM:.*]] = waveasm.v_add_u32 %[[SUM]], %[[IV]] : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
     %new_sum = waveasm.v_add_u32 %sum, %i
         : !waveasm.vreg, !waveasm.sreg -> !waveasm.vreg
-    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.sreg
-    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
+    // CHECK-NEXT:   %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT:   %[[COND:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<16> -> !waveasm.scc
+    // CHECK-NEXT:   waveasm.condition %[[COND]] : !waveasm.scc iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
   // CHECK-NEXT: }
   }
 
@@ -84,11 +84,11 @@ waveasm.program @test_if_then_else
   %b = waveasm.precolored.vreg 1 : !waveasm.vreg
   %threshold = waveasm.constant 100 : !waveasm.imm<100>
 
-  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
-  %cmp = waveasm.s_cmp_lt_u32 %tid, %threshold : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
+  // CHECK:      %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %{{.*}}, %{{.*}} : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.scc
+  %cmp = waveasm.s_cmp_lt_u32 %tid, %threshold : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.scc
 
-  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.sreg -> !waveasm.vreg {
-  %result = waveasm.if %cmp : !waveasm.sreg -> !waveasm.vreg {
+  // CHECK-NEXT: %{{.*}} = waveasm.if %[[CMP]] : !waveasm.scc -> !waveasm.vreg {
+  %result = waveasm.if %cmp : !waveasm.scc -> !waveasm.vreg {
     // CHECK-NEXT:   %{{.*}} = waveasm.v_add_u32 %{{.*}}, %{{.*}} : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     %add = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
     // CHECK-NEXT:   waveasm.yield %{{.*}} : !waveasm.vreg
@@ -139,17 +139,17 @@ waveasm.program @test_nested_loops
           : !waveasm.sreg, !waveasm.sreg -> !waveasm.vreg
       %new_acc = waveasm.v_add_u32 %acc_inner, %product
           : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
-      %next_j:2 = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      %cond_j = waveasm.s_cmp_lt_u32 %next_j#0, %inner_lim : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
-      waveasm.condition %cond_j : !waveasm.sreg iter_args(%next_j#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
+      %next_j:2 = waveasm.s_add_u32 %j, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      %cond_j = waveasm.s_cmp_lt_u32 %next_j#0, %inner_lim : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
+      waveasm.condition %cond_j : !waveasm.scc iter_args(%next_j#0, %new_acc) : !waveasm.sreg, !waveasm.vreg
     }
 
-    %next_i:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond_i = waveasm.s_cmp_lt_u32 %next_i#0, %outer_lim : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %next_i:2 = waveasm.s_add_u32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond_i = waveasm.s_cmp_lt_u32 %next_i#0, %outer_lim : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
 
     // Outer condition: inner loop's vreg result (#1) becomes outer accumulator
-    // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
-    waveasm.condition %cond_i : !waveasm.sreg iter_args(%next_i#0, %inner_result) : !waveasm.sreg, !waveasm.vreg
+    // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
+    waveasm.condition %cond_i : !waveasm.scc iter_args(%next_i#0, %inner_result) : !waveasm.sreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm
@@ -170,13 +170,13 @@ waveasm.program @test_if_in_loop
 
   // CHECK:      %{{.*}} = waveasm.loop (%[[IV:.*]] = %{{.*}}) : (!waveasm.sreg) -> !waveasm.sreg {
   %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
-    // CHECK:      %[[REM:.*]] = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
-    %rem = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg
-    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
-    %is_even = waveasm.s_cmp_eq_u32 %rem, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.sreg
+    // CHECK:      %[[REM:.*]], %{{.*}} = waveasm.s_and_b32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %rem:2 = waveasm.s_and_b32 %i, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT: %[[EVEN:.*]] = waveasm.s_cmp_eq_u32 %[[REM]], %{{.*}} : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.scc
+    %is_even = waveasm.s_cmp_eq_u32 %rem#0, %zero : !waveasm.sreg, !waveasm.imm<0> -> !waveasm.scc
 
-    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.sreg -> !waveasm.sreg {
-    %step = waveasm.if %is_even : !waveasm.sreg -> !waveasm.sreg {
+    // CHECK-NEXT: %[[STEP:.*]] = waveasm.if %[[EVEN]] : !waveasm.scc -> !waveasm.sreg {
+    %step = waveasm.if %is_even : !waveasm.scc -> !waveasm.sreg {
       // CHECK:      waveasm.yield %{{.*}} : !waveasm.sreg
       %step_val = waveasm.s_mov_b32 %two : !waveasm.imm<2> -> !waveasm.sreg
       waveasm.yield %step_val : !waveasm.sreg
@@ -188,12 +188,12 @@ waveasm.program @test_if_in_loop
     }
 
     // If result feeds loop counter update
-    // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.sreg
-    %next:2 = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.sreg
-    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    %cont = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
-    waveasm.condition %cont : !waveasm.sreg iter_args(%next#0) : !waveasm.sreg
+    // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %[[STEP]] : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.scc
+    %next:2 = waveasm.s_add_u32 %i, %step : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg, !waveasm.scc
+    // CHECK-NEXT: %[[CONT:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    %cont = waveasm.s_cmp_lt_u32 %next#0, %limit : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // CHECK-NEXT: waveasm.condition %[[CONT]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
+    waveasm.condition %cont : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/salu-vop2-literals.mlir
+++ b/waveasm/test/Transforms/salu-vop2-literals.mlir
@@ -18,12 +18,12 @@ waveasm.program @salu_literal_test target = #waveasm.target<#waveasm.gfx942, 5> 
   // CHECK-NOT: v_mov_b32
   // CHECK: s_add_u32 s{{[0-9]+}}, s0, 4096
   %c4096 = waveasm.constant 4096 : !waveasm.imm<4096>
-  %r1:2 = waveasm.s_add_u32 %s0, %c4096 : !waveasm.psreg<0>, !waveasm.imm<4096> -> !waveasm.sreg, !waveasm.sreg
+  %r1:2 = waveasm.s_add_u32 %s0, %c4096 : !waveasm.psreg<0>, !waveasm.imm<4096> -> !waveasm.sreg, !waveasm.scc
   // Another SALU with literal -- should also be direct
   // CHECK-NOT: v_mov_b32
   // CHECK: s_lshl_b32 s{{[0-9]+}}, s{{[0-9]+}}, 7
   %c7 = waveasm.constant 7 : !waveasm.imm<7>
-  %r2 = waveasm.s_lshl_b32 %r1#0, %c7 : !waveasm.sreg, !waveasm.imm<7> -> !waveasm.sreg
+  %r2:2 = waveasm.s_lshl_b32 %r1#0, %c7 : !waveasm.sreg, !waveasm.imm<7> -> !waveasm.sreg, !waveasm.scc
 
   waveasm.s_endpgm
 }

--- a/waveasm/test/Transforms/scalar-war-hazard.mlir
+++ b/waveasm/test/Transforms/scalar-war-hazard.mlir
@@ -42,17 +42,17 @@ waveasm.program @scalar_war_hazard
     // Iter_arg defined EARLY : WAR hazard source.
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[INIT_IV]]>{{.*}}!waveasm.imm<2>
     %next_iv:2 = waveasm.s_add_u32 %iv, %c2
-        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
 
     // Block_arg %iv used AFTER %next_iv is defined : WAR victim.
     // If tied, this reads iv+2 instead of iv.
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[INIT_IV]]>{{.*}}!waveasm.imm<1>
     %offset:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -97,10 +97,10 @@ waveasm.program @vgpr_war_hazard
         : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
 
     %next_i:2 = waveasm.s_add_u32 %i, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
     %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_i#0, %new_val) : !waveasm.sreg, !waveasm.vreg
   }
 
@@ -142,12 +142,12 @@ waveasm.program @no_hazard_same_point
     // Same program point as the def of %next_iv → no hazard with >.
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}} -> !waveasm.psreg<[[IV]]>
     %next_iv:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     // Work that does NOT use %iv : only uses %next_iv.
     %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -189,7 +189,7 @@ waveasm.program @mixed_mfma_and_scalar_war
     // --- Scalar IV: WAR hazard ---
     // Define iter_arg for %iv EARLY.
     %next_iv:2 = waveasm.s_add_u32 %iv, %c2
-        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
 
     // --- MFMA accumulator: no hazard ---
     // %acc used as operand and %new_acc defined at the SAME program point.
@@ -202,11 +202,11 @@ waveasm.program @mixed_mfma_and_scalar_war
     // --- Scalar IV: WAR victim ---
     // Uses %iv AFTER %next_iv defined → triggers WAR.
     %offset:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 
@@ -242,22 +242,22 @@ waveasm.program @multiple_post_def_uses
 
     // Iter_arg defined first.
     %next_iv:2 = waveasm.s_add_u32 %iv, %c4
-        : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg, !waveasm.scc
 
     // Three subsequent uses of %iv : all read wrong value if tied.
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<1>
     %off1:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<2>
     %off2:2 = waveasm.s_add_u32 %iv, %c2
-        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
     // CHECK: waveasm.s_add_u32 {{.*}}!waveasm.psreg<[[IV]]>{{.*}}!waveasm.imm<3>
     %off3:2 = waveasm.s_add_u32 %iv, %c3
-        : !waveasm.sreg, !waveasm.imm<3> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<3> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %off3#0, %c100
-        : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<100> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   waveasm.s_endpgm
@@ -300,10 +300,10 @@ waveasm.program @no_war_def_after_all_uses
         : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
 
     %next_i:2 = waveasm.s_add_u32 %i, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
     %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_i#0, %new_sum) : !waveasm.sreg, !waveasm.vreg
   }
 

--- a/waveasm/test/Transforms/scale-pack-elimination.mlir
+++ b/waveasm/test/Transforms/scale-pack-elimination.mlir
@@ -66,13 +66,13 @@ waveasm.program @basic_scale_pack
     %nb2 = waveasm.v_bfe_u32 %next_dword, %sixteen, %eight : !waveasm.vreg, !waveasm.imm<16>, !waveasm.imm<8> -> !waveasm.vreg
     %nb3 = waveasm.v_bfe_u32 %next_dword, %twentyfour, %eight : !waveasm.vreg, !waveasm.imm<24>, !waveasm.imm<8> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
 
     // Yield should carry (next_iv, next_dword) instead of (next_iv, nb0..nb3).
     // CHECK: waveasm.condition
     // CHECK-SAME: iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
-    waveasm.condition %cond : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %nb0, %nb1, %nb2, %nb3)
         : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg
   }
@@ -135,9 +135,9 @@ waveasm.program @no_transform_extra_use
     %nb2 = waveasm.v_bfe_u32 %next_dword, %sixteen, %eight : !waveasm.vreg, !waveasm.imm<16>, !waveasm.imm<8> -> !waveasm.vreg
     %nb3 = waveasm.v_bfe_u32 %next_dword, %twentyfour, %eight : !waveasm.vreg, !waveasm.imm<24>, !waveasm.imm<8> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %nb0, %nb1, %nb2, %nb3)
         : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg
   }
@@ -199,9 +199,9 @@ waveasm.program @no_transform_different_yield_source
     %nb2 = waveasm.v_bfe_u32 %dword_b, %sixteen, %eight : !waveasm.vreg, !waveasm.imm<16>, !waveasm.imm<8> -> !waveasm.vreg
     %nb3 = waveasm.v_bfe_u32 %dword_b, %twentyfour, %eight : !waveasm.vreg, !waveasm.imm<24>, !waveasm.imm<8> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %nb0, %nb1, %nb2, %nb3)
         : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg
   }
@@ -299,13 +299,13 @@ waveasm.program @two_chains
     %nb2 = waveasm.v_bfe_u32 %next_dword_b, %sixteen, %eight : !waveasm.vreg, !waveasm.imm<16>, !waveasm.imm<8> -> !waveasm.vreg
     %nb3 = waveasm.v_bfe_u32 %next_dword_b, %twentyfour, %eight : !waveasm.vreg, !waveasm.imm<24>, !waveasm.imm<8> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
 
     // Yield should carry (next_iv, next_dword_a, next_dword_b).
     // CHECK: waveasm.condition
     // CHECK-SAME: iter_args(%{{.*}}, %{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
-    waveasm.condition %cond : !waveasm.sreg
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %na0, %na1, %na2, %na3, %nb0, %nb1, %nb2, %nb3)
         : !waveasm.sreg,
           !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg,
@@ -369,9 +369,9 @@ waveasm.program @post_loop_multi_byte_use
     %nb2 = waveasm.v_bfe_u32 %next_dword, %sixteen, %eight : !waveasm.vreg, !waveasm.imm<16>, !waveasm.imm<8> -> !waveasm.vreg
     %nb3 = waveasm.v_bfe_u32 %next_dword, %twentyfour, %eight : !waveasm.vreg, !waveasm.imm<24>, !waveasm.imm<8> -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %one : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %nb0, %nb1, %nb2, %nb3)
         : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg, !waveasm.vreg
   }

--- a/waveasm/test/Transforms/scc-assembly-emit.mlir
+++ b/waveasm/test/Transforms/scc-assembly-emit.mlir
@@ -1,0 +1,72 @@
+// RUN: waveasm-translate --waveasm-linear-scan --emit-assembly %s | FileCheck %s
+//
+// Verify assembly emission for SCC-related ops:
+// - s_cselect_b32 emits dst, src0, src1 (no SCC operand).
+// - s_cmp_ne_u32 emits as s_cmp_lg_u32 (hardware mnemonic).
+// - s_add_u32 / s_addc_u32 skip SCC operands in emission.
+
+// CHECK-LABEL: scc_cselect_and_cmp_ne:
+waveasm.program @scc_cselect_and_cmp_ne
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+  %c1 = waveasm.constant 1 : !waveasm.imm<1>
+  %c10 = waveasm.constant 10 : !waveasm.imm<10>
+
+  // s_cmp_ne_u32 -> s_cmp_lg_u32 in assembly.
+  // CHECK: s_cmp_lg_u32 s0, 0
+  %cmp = waveasm.s_cmp_ne_u32 %s0, %c0
+      : !waveasm.psreg<0>, !waveasm.imm<0> -> !waveasm.scc
+
+  // s_cselect_b32: SCC operand not emitted.
+  // CHECK: s_cselect_b32 s{{[0-9]+}}, 1, 0
+  %sel = waveasm.s_cselect_b32 %cmp, %c1, %c0
+      : !waveasm.scc, !waveasm.imm<1>, !waveasm.imm<0> -> !waveasm.sreg
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: scc_carry_chain:
+waveasm.program @scc_carry_chain
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %s1 = waveasm.precolored.sreg 1 : !waveasm.psreg<1>
+  %s2 = waveasm.precolored.sreg 2 : !waveasm.psreg<2>
+  %s3 = waveasm.precolored.sreg 3 : !waveasm.psreg<3>
+
+  // s_add_u32: SCC result not emitted.
+  // CHECK: s_add_u32 s{{[0-9]+}}, s0, s2
+  %lo:2 = waveasm.s_add_u32 %s0, %s2
+      : !waveasm.psreg<0>, !waveasm.psreg<2> -> !waveasm.sreg, !waveasm.scc
+
+  // s_addc_u32: SCC operand and SCC result not emitted.
+  // CHECK: s_addc_u32 s{{[0-9]+}}, s1, s3
+  %hi:2 = waveasm.s_addc_u32 %lo#1, %s1, %s3
+      : !waveasm.scc, !waveasm.psreg<1>, !waveasm.psreg<3>
+      -> !waveasm.sreg, !waveasm.scc
+
+  waveasm.s_endpgm
+}
+
+// CHECK-LABEL: scc_bitwise_skip:
+waveasm.program @scc_bitwise_skip
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %s1 = waveasm.precolored.sreg 1 : !waveasm.psreg<1>
+
+  // SALUBinaryWithSCCOp: SCC result not emitted.
+  // CHECK: s_and_b32 s{{[0-9]+}}, s0, s1
+  %and:2 = waveasm.s_and_b32 %s0, %s1
+      : !waveasm.psreg<0>, !waveasm.psreg<1> -> !waveasm.sreg, !waveasm.scc
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/scc-spill-reload.mlir
+++ b/waveasm/test/Transforms/scc-spill-reload.mlir
@@ -1,0 +1,67 @@
+// RUN: waveasm-translate --waveasm-scc-spill-reload %s | FileCheck %s
+//
+// Verify that SCC spill/reload inserts s_cselect_b32 (spill) after the SCC
+// producer and s_cmp_ne_u32 (reload) before each consumer when an
+// SCC-clobbering op intervenes.
+
+// CHECK-LABEL: waveasm.program @spill_reload_condition
+waveasm.program @spill_reload_condition
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // SCC producer.
+    %cond = waveasm.s_cmp_lt_u32 %i, %limit
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // Spill: s_cselect_b32 saves SCC to SGPR right after the producer.
+    // CHECK: waveasm.s_cmp_lt_u32
+    // CHECK-NEXT: waveasm.constant 1
+    // CHECK-NEXT: waveasm.constant 0
+    // CHECK-NEXT: waveasm.s_cselect_b32
+    // SCC-clobbering op.
+    %next:2 = waveasm.s_add_u32 %i, %one
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // Reload: s_cmp_ne_u32 restores SCC from SGPR before the consumer.
+    // CHECK: waveasm.s_add_u32
+    // CHECK: waveasm.s_cmp_ne_u32
+    // CHECK: waveasm.condition
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}
+
+// Verify no spill/reload when there is no intervening clobber.
+// CHECK-LABEL: waveasm.program @no_spill_when_adjacent
+waveasm.program @no_spill_when_adjacent
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // Increment first, then compare.  No clobber between cmp and condition.
+    %next:2 = waveasm.s_add_u32 %i, %one
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next#0, %limit
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // No spill/reload should be inserted.
+    // CHECK: waveasm.s_cmp_lt_u32
+    // CHECK-NOT: waveasm.s_cselect_b32
+    // CHECK-NOT: waveasm.s_cmp_ne_u32
+    // CHECK: waveasm.condition
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/scc-verifier.mlir
+++ b/waveasm/test/Transforms/scc-verifier.mlir
@@ -1,0 +1,62 @@
+// RUN: not waveasm-translate --waveasm-scc-verifier %s 2>&1 | FileCheck %s
+//
+// Verify that the SCC verifier detects hazards:
+// 1. SCC-clobbering op between SCC producer and condition consumer.
+// 2. SCC-clobbering op between SCC producer and if consumer.
+
+// CHECK: error: SCC hazard: 1 SCC-clobbering op(s) between SCC producer 'waveasm.s_cmp_lt_u32' and consumer 'waveasm.condition'
+waveasm.program @clobber_before_condition
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %zero = waveasm.constant 0 : !waveasm.imm<0>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %init = waveasm.s_mov_b32 %zero : !waveasm.imm<0> -> !waveasm.sreg
+
+  %final = waveasm.loop(%i = %init) : (!waveasm.sreg) -> (!waveasm.sreg) {
+    // SCC producer.
+    %cond = waveasm.s_cmp_lt_u32 %i, %limit
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    // SCC clobber between producer and consumer.
+    %next:2 = waveasm.s_add_u32 %i, %one
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    // Consumer reads stale SCC.
+    waveasm.condition %cond : !waveasm.scc iter_args(%next#0) : !waveasm.sreg
+  }
+
+  waveasm.s_endpgm
+}
+
+// CHECK: error: SCC hazard: 1 SCC-clobbering op(s) between SCC producer 'waveasm.s_cmp_lt_u32' and consumer 'waveasm.if'
+waveasm.program @clobber_before_if
+  target = #waveasm.target<#waveasm.gfx942, 5>
+  abi = #waveasm.abi<tid = 0, kernarg = 0>
+  attributes {vgprs = 32 : i64, sgprs = 16 : i64} {
+
+  %tid = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %limit = waveasm.constant 10 : !waveasm.imm<10>
+  %one = waveasm.constant 1 : !waveasm.imm<1>
+  %a = waveasm.precolored.vreg 0 : !waveasm.pvreg<0>
+  %b = waveasm.precolored.vreg 1 : !waveasm.pvreg<1>
+
+  // SCC producer.
+  %cmp = waveasm.s_cmp_lt_u32 %tid, %limit
+      : !waveasm.psreg<0>, !waveasm.imm<10> -> !waveasm.scc
+  // Clobber.
+  %dummy:2 = waveasm.s_add_u32 %tid, %one
+      : !waveasm.psreg<0>, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+  // Consumer reads stale SCC.
+  %result = waveasm.if %cmp : !waveasm.scc -> !waveasm.vreg {
+    %sum = waveasm.v_add_u32 %a, %b
+        : !waveasm.pvreg<0>, !waveasm.pvreg<1> -> !waveasm.vreg
+    waveasm.yield %sum : !waveasm.vreg
+  } else {
+    %diff = waveasm.v_sub_u32 %a, %b
+        : !waveasm.pvreg<0>, !waveasm.pvreg<1> -> !waveasm.vreg
+    waveasm.yield %diff : !waveasm.vreg
+  }
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/scoped-cse.mlir
+++ b/waveasm/test/Transforms/scoped-cse.mlir
@@ -79,3 +79,20 @@ waveasm.program @no_precolored_cse target = #waveasm.target<#waveasm.gfx942, 5> 
 
   waveasm.s_endpgm
 }
+
+// Test 6: s_cmp_ne_u32 IS now CSE-eligible (SALUCmpOp has ArithmeticOp trait).
+// SALUBinaryWithSCCOp (S_AND_B32, S_OR_B32, etc.) now produce explicit SCC
+// results, so SCC data flow is fully tracked and CSE on SALUCmpOp is safe.
+// CHECK-LABEL: waveasm.program @cse_s_cmp
+waveasm.program @cse_s_cmp target = #waveasm.target<#waveasm.gfx942, 5> abi = #waveasm.abi<> {
+  %s0 = waveasm.precolored.sreg 0 : !waveasm.psreg<0>
+  %c0 = waveasm.constant 0 : !waveasm.imm<0>
+
+  // Two identical s_cmp_ne_u32 - second should be eliminated by CSE.
+  // CHECK: waveasm.s_cmp_ne_u32
+  // CHECK-NOT: waveasm.s_cmp_ne_u32
+  %cmp1 = waveasm.s_cmp_ne_u32 %s0, %c0 : !waveasm.psreg<0>, !waveasm.imm<0> -> !waveasm.scc
+  %cmp2 = waveasm.s_cmp_ne_u32 %s0, %c0 : !waveasm.psreg<0>, !waveasm.imm<0> -> !waveasm.scc
+
+  waveasm.s_endpgm
+}

--- a/waveasm/test/Transforms/scratch-vgpr-cache.mlir
+++ b/waveasm/test/Transforms/scratch-vgpr-cache.mlir
@@ -104,8 +104,8 @@ waveasm.program @loop_invalidates_cache
     %next = waveasm.v_add_u32 %iv, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
     %cond_s = waveasm.v_readfirstlane_b32 %next : !waveasm.vreg -> !waveasm.sreg
     %ub = waveasm.v_readfirstlane_b32 %v0 : !waveasm.pvreg<0> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next) : !waveasm.vreg
+    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub : !waveasm.sreg, !waveasm.sreg -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next) : !waveasm.vreg
   }
 
   // CHECK: s_endpgm
@@ -144,8 +144,8 @@ waveasm.program @loop_body_cache_reuse
     %next = waveasm.v_add_u32 %iv, %c1 : !waveasm.vreg, !waveasm.imm<1> -> !waveasm.vreg
     %cond_s = waveasm.v_readfirstlane_b32 %next : !waveasm.vreg -> !waveasm.sreg
     %ub = waveasm.v_readfirstlane_b32 %v0 : !waveasm.pvreg<0> -> !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub : !waveasm.sreg, !waveasm.sreg -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next) : !waveasm.vreg
+    %cond = waveasm.s_cmp_lt_u32 %cond_s, %ub : !waveasm.sreg, !waveasm.sreg -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next) : !waveasm.vreg
   }
 
   // CHECK: s_endpgm

--- a/waveasm/test/Transforms/vgpr-swap-emit.mlir
+++ b/waveasm/test/Transforms/vgpr-swap-emit.mlir
@@ -32,10 +32,10 @@ waveasm.program @vgpr_swap_iter_args
     // Use both so they're not dead.
     %sum = waveasm.v_add_u32 %a, %b : !waveasm.vreg, !waveasm.vreg -> !waveasm.vreg
 
-    %next_iv:2 = waveasm.s_add_u32 %iv, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.sreg
+    %next_iv:2 = waveasm.s_add_u32 %iv, %c1 : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+    %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %limit : !waveasm.sreg, !waveasm.imm<8> -> !waveasm.scc
     // Swap: pass %b as new %a, %a as new %b.
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0, %b, %a) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0, %b, %a) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
   }
 
   waveasm.s_endpgm

--- a/waveasm/test/Transforms/war-hazard-emit.mlir
+++ b/waveasm/test/Transforms/war-hazard-emit.mlir
@@ -37,15 +37,15 @@ waveasm.program @emit_scalar_war_copy
 
     // Iter_arg defined EARLY : WAR hazard source.
     %next_iv:2 = waveasm.s_add_u32 %iv, %c2
-        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
 
     // Block_arg %iv used AFTER %next_iv defined.
     %offset:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   // CHECK:      s_cmp_lt_u32
@@ -91,10 +91,10 @@ waveasm.program @emit_vgpr_war_copy
         : !waveasm.vreg, !waveasm.pvreg<0> -> !waveasm.vreg
 
     %next_i:2 = waveasm.s_add_u32 %i, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
     %cond = waveasm.s_cmp_lt_u32 %next_i#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_i#0, %new_val) : !waveasm.sreg, !waveasm.vreg
   }
 
@@ -135,11 +135,11 @@ waveasm.program @emit_no_copy_same_point
     // %iv's ONLY use is as the operand of this instruction.
     // Same point as the def of %next_iv -> says no hazard - tied.
     %next_iv:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %next_iv#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg iter_args(%next_iv#0) : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc iter_args(%next_iv#0) : !waveasm.sreg
   }
 
   // No back-edge copy: iter_arg and block_arg share the same register.
@@ -186,7 +186,7 @@ waveasm.program @emit_mixed_selective
 
     // Scalar IV iter_arg defined EARLY : WAR hazard source.
     %next_iv:2 = waveasm.s_add_u32 %iv, %c2
-        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<2> -> !waveasm.sreg, !waveasm.scc
 
     // MFMA: %acc used and %new_acc defined at SAME point -> no hazard.
     %new_acc = waveasm.v_mfma_f32_16x16x16_f16 %a, %b, %acc
@@ -195,11 +195,11 @@ waveasm.program @emit_mixed_selective
 
     // Block_arg %iv used AFTER %next_iv defined : WAR victim.
     %offset:2 = waveasm.s_add_u32 %iv, %c1
-        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
 
     %cond = waveasm.s_cmp_lt_u32 %offset#0, %c10
-        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.sreg
-    waveasm.condition %cond : !waveasm.sreg
+        : !waveasm.sreg, !waveasm.imm<10> -> !waveasm.scc
+    waveasm.condition %cond : !waveasm.scc
         iter_args(%next_iv#0, %new_acc) : !waveasm.sreg, !waveasm.vreg<4, 4>
   }
 

--- a/waveasm/test/Translate/scf-for-iter-args.mlir
+++ b/waveasm/test/Translate/scf-for-iter-args.mlir
@@ -26,9 +26,9 @@ module {
         scf.yield %new_sum : i32
       }
       // Increment, compare, condition with both iter_args
-      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
+      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.scc iter_args(%[[NEXT]], %[[NEWSUM]]) : !waveasm.sreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
@@ -57,7 +57,7 @@ module {
         scf.yield %new_a, %new_b : i32, i32
       }
       // Condition feeds back all three iter_args
-      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[NEWA]], %[[NEWB]]) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[NEWA]], %[[NEWB]]) : !waveasm.sreg, !waveasm.vreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return
@@ -82,11 +82,11 @@ module {
           scf.yield %next : i32
         }
         // Inner condition
-        // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
+        // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %{{.*}}) : !waveasm.sreg, !waveasm.vreg
         scf.yield %inner_result : i32
       }
       // Outer condition uses inner loop result (#1) for accumulator
-      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[INNER]]#1) : !waveasm.sreg, !waveasm.vreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/waveasm/test/Translate/scf-for-loop.mlir
+++ b/waveasm/test/Translate/scf-for-loop.mlir
@@ -20,9 +20,9 @@ module {
         %sum = arith.addi %i, %c1 : index
       }
       // Increment, compare, condition
-      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.sreg
-      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.sreg
-      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.sreg iter_args(%[[NEXT]]) : !waveasm.sreg
+      // CHECK:      %[[NEXT:.*]], %{{.*}} = waveasm.s_add_u32 %[[IV]], %{{.*}} : !waveasm.sreg, !waveasm.imm<1> -> !waveasm.sreg, !waveasm.scc
+      // CHECK-NEXT: %[[CMP:.*]] = waveasm.s_cmp_lt_u32 %[[NEXT]], %{{.*}} : !waveasm.sreg, !waveasm.imm<4> -> !waveasm.scc
+      // CHECK-NEXT: waveasm.condition %[[CMP]] : !waveasm.scc iter_args(%[[NEXT]]) : !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return

--- a/waveasm/test/Translate/scf-for-memref-iter-args.mlir
+++ b/waveasm/test/Translate/scf-for-memref-iter-args.mlir
@@ -57,7 +57,7 @@ module {
       }
 
       // Condition should carry: [nextIV, acc, offsetB, offsetA] (swapped!)
-      // CHECK:      waveasm.condition %{{.*}} : !waveasm.sreg iter_args(%{{.*}}, %[[ACC]], %[[OB]], %[[OA]]) : !waveasm.sreg, !waveasm.vreg<4, 4>, !waveasm.sreg, !waveasm.sreg
+      // CHECK:      waveasm.condition %{{.*}} : !waveasm.scc iter_args(%{{.*}}, %[[ACC]], %[[OB]], %[[OA]]) : !waveasm.sreg, !waveasm.vreg<4, 4>, !waveasm.sreg, !waveasm.sreg
 
       // CHECK: waveasm.s_endpgm
       gpu.return


### PR DESCRIPTION
Model the AMDGCN Scalar Condition Code (SCC) flag as a first-class MLIR type in WaveASM instead of treating it as an implicit side effect.

### Problem

Many SALU instructions (bitwise, shifts, adds, compares) clobber the hardware SCC flag, but WaveASM previously had no way to represent this in the IR. This caused:

- **Silent correctness bugs**: CSE could merge two `s_cmp` ops, extending the SCC live range across an SCC-clobbering op (e.g. `s_and_b32`), producing wrong branch conditions.
- **Fragile carry chains**: `s_add_u32` -> `s_addc_u32` carry dependency was only enforced by emission order, not the SSA graph. Any pass reordering ops could break 64-bit adds.

### Solution

**New type and traits:**
- `SCCType` (`!waveasm.scc`) -- 1-bit type representing the hardware SCC flag.
- `SCCDef` / `SCCUse` op traits -- mark ops that write/read SCC.

**New op classes:**
- `SALUUnaryWithSCCOp` / `SALUBinaryWithSCCOp` -- produce explicit `(dst, scc)` results. All SCC-clobbering ops (bitwise, shifts, min/max, bfe, etc.) migrated from `Pure` base classes.
- `SALUBinaryWithCarryInOp` -- `s_addc_u32` takes an explicit `scc_in` operand, creating a true SSA dependency for carry chains.
- `S_CSELECT_B32` -- conditional select reading SCC.
- `S_SCHED_BARRIER` -- scheduling barrier (unrelated but included in the migration).

**New passes:**
- `waveasm-scc-verifier` -- detects SCC-clobbering hazards between producer and consumer. Wired into the pipeline.
- `waveasm-scc-spill-reload` -- inserts `s_cselect_b32` (spill SCC to SGPR) and `s_cmp_ne_u32` (reload) when CSE extends SCC live ranges across clobbers.

**Updated call sites:**
- All SALU op creation sites across TranslateFromMLIR, TranslateFromLLVMDialect, ArithLegalization, ArithHandlers, Peephole, BufferLoadStrengthReduction, RegionBuilder, and AMDGPUHandlers updated for explicit SCC types.
- Assembly emitter skips SCC results/operands during emission.
- ScopedCSE excludes `SCCUse` ops from CSE eligibility.

**Bugfix:** `S_CSELECT_B32` src0 constraint relaxed from `AnySGPR` to `SRegOrImm` to match hardware and allow the spill/reload pass to use immediate operands.

---------

Previous version was reverted due to in-flight collision with another PR