### PR TITLE
Enable linearization for dynamic-stride and attention paths

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -175,9 +175,11 @@ def test_read_mapped_buffer():
     print(read_mapped_buffer.asm)
 
     # CHECK-LABEL:    func.func @read_mapped_buffer
-    # CHECK: %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast
-    # CHECK: %[[RES:.*]] = vector.load %[[BUF]][%{{.*}}] : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1xf16>
-    # CHECK: %[[EXTRACT:.*]] = vector.extract %[[RES]][0] : f16 from vector<1xf16>
+    # CHECK: %[[RC:.*]] = memref.reinterpret_cast %{{.*}} to offset: [{{.*}}], sizes: [16, 16], strides: [16, 1] : memref<f16> to memref<16x16xf16, strided<[16, 1], offset: ?>>
+    # CHECK: memref.extract_strided_metadata %[[RC]]
+    # CHECK: memref.reinterpret_cast %[[RC]] to offset:
+    # CHECK: vector.load %{{.*}}[%{{.*}}] : memref<?xf16, strided<[1], offset: ?>>, vector<1xf16>
+    # CHECK: %[[EXTRACT:.*]] = vector.extract %{{.*}}[0] : f16 from vector<1xf16>
     # CHECK: %[[FROM:.*]] = vector.from_elements %[[EXTRACT]]
 
 
@@ -223,8 +225,7 @@ def test_read_dynamic_3d_buffer():
     # CHECK:            %[[MEMREF_OFFSET:.+]] = arith.addi %{{.*}}, %[[BASE_TENSOR_OFFSET]] overflow<nsw> : index
 
     # CHECK:            %[[MEMREF_CAST:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [%[[MEMREF_OFFSET]]], {{.*}}: memref<?x?x16xf16, strided<[?, 16, 1], offset: ?>> to memref<?xf16, strided<[1], offset: ?>>
-    # CHECK:            %[[SWIZZLE_CAST:.*]] = arith.index_cast %c16{{.*}} : index to i14
-    # CHECK:            %[[BUF:.*]] = amdgpu.fat_raw_buffer_cast %[[MEMREF_CAST]] validBytes{{.*}} cacheSwizzleStride{{.*}} resetOffset : memref<?xf16, strided<[1], offset: ?>> to memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK:            vector.maskedload %[[MEMREF_CAST]][%{{.*}}], %{{.*}}, %{{.*}} : memref<?xf16, strided<[1], offset: ?>>, vector<16xi1>, vector<16xf16> into vector<16xf16>
 
 
 @run_test
@@ -2116,7 +2117,8 @@ def test_broadcast_scaled_add():
     # on the rhs before doing add.
 
     # CHECK-LABEL: func @broadcast_scaled_add
-    # CHECK: %[[RHS:.+]] = memref.load {{.*}} : memref<?xf16, #amdgpu.address_space<fat_raw_buffer>>
+    # 1073741822 = (2^31 - 1) / 2 - 1 : max f16 element count for a 32-bit SRD
+    # CHECK: %[[RHS:.+]] = memref.load %{{.*}}[%{{.*}}] : memref<1073741822xf16, strided<[1]>>
     # CHECK: %[[BROADCAST_RHS:.+]] = vector.broadcast %[[RHS]] : f16 to vector<2xf16>
     # CHECK: arith.addf %{{.*}}, %[[BROADCAST_RHS]] : vector<2xf16>
 

--- a/lit_tests/kernel/wave/dynamic_strides.py
+++ b/lit_tests/kernel/wave/dynamic_strides.py
@@ -32,22 +32,20 @@ def test_dynamic_strides_gemm():
     # Kernel func: 3 bindings + 3 index (stride) arguments (one leading stride per buffer).
     # CHECK: func.func @gemm(%{{.*}}: !stream.binding, %{{.*}}: !stream.binding, %{{.*}}: !stream.binding, %{{.*}}: index, %{{.*}}: index, %{{.*}}: index)
 
-    # All three buffers get 2-D views with dynamic leading strides (%arg3, %arg4, %arg5).
-    # CHECK: memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1024, 1024], strides: [%arg3, 1]
-    # CHECK-SAME: memref<f16> to memref<1024x1024xf16, strided<[?, 1]>>
-    # CHECK: memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1024, 1024], strides: [%arg4, 1]
-    # CHECK-SAME: memref<f16> to memref<1024x1024xf16, strided<[?, 1]>>
+    # Output buffer: 2-D view with dynamic leading stride for writes.
     # CHECK: memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1024, 1024], strides: [%arg5, 1]
     # CHECK-SAME: memref<f32> to memref<1024x1024xf32, strided<[?, 1]>>
 
-    # Input f16 loads use 2-D indexing on the strided views.
-    # CHECK: vector.load %reinterpret_cast[{{.*}}] : memref<1024x1024xf16, strided<[?, 1]>>, vector<8xf16>
-    # CHECK: vector.load %reinterpret_cast_0[{{.*}}] : memref<1024x1024xf16, strided<[?, 1]>>, vector<8xf16>
+    # Input f16 reads are linearized to 1-D (dense stride assumption;
+    # runtime contiguity assertion guards correctness).
+    # CHECK: %[[A:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1073741822], strides: [1] : memref<f16> to memref<1073741822xf16, strided<[1]>>
+    # CHECK: %[[B:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1073741822], strides: [1] : memref<f16> to memref<1073741822xf16, strided<[1]>>
+    # CHECK: vector.load %[[A]][%{{.*}}] : memref<1073741822xf16, strided<[1]>>, vector<8xf16>
+    # CHECK: vector.load %[[B]][%{{.*}}] : memref<1073741822xf16, strided<[1]>>, vector<8xf16>
 
     # Output is linearized using dynamic strides from extract_strided_metadata, then stored to 1D view.
-    # CHECK: memref.extract_strided_metadata %reinterpret_cast_1 : memref<1024x1024xf32, strided<[?, 1]>>
-    # CHECK: memref.reinterpret_cast %{{.*}} to offset: [%{{.*}}], sizes: [536870910], strides: [1]
-    # CHECK: vector.store {{.*}} %reinterpret_cast_3{{.*}} : memref<536870910xf32, strided<[1], offset: ?>>
+    # CHECK: memref.extract_strided_metadata %{{.*}} : memref<1024x1024xf32, strided<[?, 1]>>
+    # CHECK: vector.store {{.*}} : memref<536870910xf32, strided<[1], offset: ?>>, vector<1xf32>
 
     # Host dispatch passes three stride indices (ABI).
     # CHECK: flow.dispatch @gemm::@gemm[%arg3, %arg4, %arg5]

--- a/lit_tests/kernel/wave/scaled_gemm.py
+++ b/lit_tests/kernel/wave/scaled_gemm.py
@@ -798,23 +798,20 @@ def test_mxfp4_scaled_mma_unaligned_16x16x128():
     print(batched_gemm.asm)
 
     # This test checks the boundary condition for unaligned shapes (dynamic M with
-    # linearized global reads using OOB-index-redirect bounded by %arg6).
+    # global reads that stay masked (flatten skipped for globals under dynamic strides)).
 
     # CHECK-LABEL:  test_mxfp4_scaled_mma_unaligned_16x16x128
     # CHECK:        func.func @batched_gemm(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: !stream.binding, %arg3: !stream.binding, %arg4: !stream.binding, %arg5: index, %arg6: index) attributes {translation_info = #translation} {
     # CHECK-DAG:        %[[C0:.*]] = arith.constant 0 : index
-    # CHECK-DAG:        %[[C_NEG_8192_I14:.*]] = arith.constant -8192 : i14
-    # CHECK-DAG:        %[[C2147483647:.*]] = arith.constant 2147483647 : index
     # CHECK-DAG:        %[[BLOCK_ID_X:.*]] = gpu.block_id  x
     # CHECK-DAG:        %[[BLOCK_ID_Z:.*]] = gpu.block_id  z
     # CHECK-DAG:        %[[THREAD_ID_X:.*]] = gpu.thread_id  x upper_bound 256
     # CHECK-DAG:        %[[THREAD_ID_Y:.*]] = gpu.thread_id  y upper_bound 2
     # CHECK-DAG:        %{{.*}} = memref.alloc() : memref<{{.*}}xi8, #gpu.address_space<workgroup>>
-    # OOB-index-redirect: fat_raw_buffer_cast with validBytes and cacheSwizzleStride,
-    # then arith.select between computed index and sentinel (C2147483647).
-    # CHECK:            %[[BUFF_CAST:.*]] = amdgpu.fat_raw_buffer_cast %{{.*}} validBytes(%{{.*}}) cacheSwizzleStride(%[[C_NEG_8192_I14]]) resetOffset : memref<?xi8, strided<[1], offset: ?>> to memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>
-    # CHECK:            %[[SELECT:.*]] = arith.select %{{.*}}, %{{.*}}, %[[C2147483647]] : index
-    # CHECK:            vector.load %[[BUFF_CAST]][%[[SELECT]]] : memref<?xi8, #amdgpu.address_space<fat_raw_buffer>>, vector<16xi8>
+    # 2147483646 = (2^31 - 1) / 1 - 1 : max i8 element count for a 32-bit SRD
+    # CHECK-DAG:        %[[RC:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [2147483646], strides: [1] : memref<i8> to memref<2147483646xi8, strided<[1]>>
+    # CHECK-DAG:        arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+    # CHECK-DAG:        vector.maskedload %[[RC]][%{{.*}}], %{{.*}}, %{{.*}} : memref<2147483646xi8, strided<[1]>>, vector<16xi1>, vector<16xi8> into vector<16xi8>
 
 
 @run_test

--- a/tests/kernel/attention/extend_attention_test.py
+++ b/tests/kernel/attention/extend_attention_test.py
@@ -399,7 +399,6 @@ def testExtendAttention(
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
         wave_runtime=(True if use_wave_runtime else False),
-        linearize_reads=False,
     )
     options = set_default_run_config(options)
     extend_attention = wave_compile(options, extend_attention)
@@ -538,7 +537,6 @@ def testExtendRpeAttention(
         benchmark_batch_size=1000,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        linearize_reads=False,
     )
     options = set_default_run_config(options)
     extend_attention_rpe = wave_compile(options, extend_attention_rpe)

--- a/tests/kernel/attention/prefill_attention_test.py
+++ b/tests/kernel/attention/prefill_attention_test.py
@@ -150,7 +150,6 @@ def testPrefillAttention(
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=perf_filename_tk,
-        linearize_reads=False,
     )
     options = set_default_run_config(options)
     prefill = wave_compile(options, prefill)

--- a/tests/kernel/dynamic_strides_test.py
+++ b/tests/kernel/dynamic_strides_test.py
@@ -29,6 +29,7 @@ def _compile_gemm(shape, dynamic_dims=False, buffer_ops=False):
         dynamic_symbols=dynamic_symbols,
         wave_runtime=True,
         use_buffer_ops=buffer_ops,
+        allow_noncontiguous_runtime_buffers=True,
     )
     options = set_default_run_config(options)
     return wave_compile(options, gemm), options

--- a/wave_lang/kernel/compiler/utils.py
+++ b/wave_lang/kernel/compiler/utils.py
@@ -1,7 +1,31 @@
 from math import prod
-from typing import Optional
+from typing import Any, Optional
 
 from .._support.indexing import IndexingContext, IndexSymbol
+
+
+def symbolic_strides_match_physical_memory(memory: Any, symbolic_shape: tuple) -> bool:
+    """Return True when dense strides from *symbolic_shape* match the buffer layout.
+
+    Memories with an explicit ``physical_layout`` whose shape differs from the
+    symbolic shape have memref strides that do not match
+    :func:`strides_from_symbolic_shape`.  Linearizing read indices with the wrong
+    implied strides is incorrect; callers must skip flattening in that case.
+
+    ``MemoryLayout`` (physical_layout) stores only a shape; strides are always
+    derived as row-major from that shape.  Therefore shape equality implies
+    stride equality -- no explicit stride comparison is needed.
+    """
+    mem_type = getattr(memory, "type", None)
+    if mem_type is None:
+        return True
+    layout = getattr(mem_type, "physical_layout", None)
+    if layout is None:
+        return True
+    layout_shape = layout.shape
+    if len(layout_shape) != len(symbolic_shape):
+        return False
+    return all(l == s for l, s in zip(layout_shape, symbolic_shape))
 
 
 def strides_from_symbolic_shape(

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -46,7 +46,10 @@ from ..._support.indexing import (
 )
 from ..base import ValidationError
 from ..builder import IRProxyValue
-from ..utils import strides_from_symbolic_shape
+from ..utils import (
+    strides_from_symbolic_shape,
+    symbolic_strides_match_physical_memory as _symbolic_strides_match_physical,
+)
 from ...lang.global_symbols import *
 from ...lang.wave_types import IndexMapping
 from ...ops.wave_ops import (
@@ -260,27 +263,6 @@ def _get_strides_from_memref(mem: Value) -> list[Value]:
     metadata = memref_d.extract_strided_metadata(mem)
     # Strides start at index 2 + rank (after base, offset, sizes).
     return list(metadata[2 + rank : 2 + 2 * rank])
-
-
-def _symbolic_strides_match_physical(memory: CustomOp, symbolic_shape) -> bool:
-    """Return True when it is safe to linearize a write using symbolic strides.
-
-    Memories with an explicit physical_layout whose shape differs from the
-    symbolic shape will have memref strides that don't match the strides
-    computed by strides_from_symbolic_shape.  Linearizing with the wrong
-    strides produces incorrect offsets, so we must fall back to
-    multi-dimensional stores in that case.
-    """
-    mem_type = memory.type
-    if mem_type is None:
-        return True
-    layout = mem_type.physical_layout
-    if layout is None:
-        return True
-    layout_shape = layout.shape
-    if len(layout_shape) != len(symbolic_shape):
-        return False
-    return all(l == s for l, s in zip(layout_shape, symbolic_shape))
 
 
 def _linearize_memref(
@@ -1091,6 +1073,10 @@ def _handle_read_linear_index(
     ):
         subs_map = add_emitter_subs(emitter, dynamic_vals_map_start)
         sym_strides = _sym_strides_for_flat_memref(kb_src, input_shape)
+        # Invariant: LINEAR_INDEX global reads always use maskedload on a
+        # linearized memref, never buffer fat-pointer ops.  This ensures
+        # numerics match under both IREE (VMFB) and wave runtime launch.
+        linear_buffer_ops = False
         lin_src = _linear_read_linearize_memref_maybe_hoisted(
             emitter,
             kb_src,
@@ -1098,7 +1084,7 @@ def _handle_read_linear_index(
             subs_map,
             kb_ir_type.element_type,
             input_shape,
-            buffer_ops_enabled,
+            linear_buffer_ops,
         )
         total_offset = gen_sympy_index(subs_map, flat_offset)
         result = _linear_read_emit_global_vector_load(
@@ -1107,7 +1093,7 @@ def _handle_read_linear_index(
             total_offset,
             mask,
             elements_per_thread,
-            buffer_ops_enabled,
+            linear_buffer_ops,
         )
         emitter.bind_node_proxy(node, IRProxyValue(result))
         return

--- a/wave_lang/kernel/wave/analysis/flatten_read_indices.py
+++ b/wave_lang/kernel/wave/analysis/flatten_read_indices.py
@@ -32,10 +32,14 @@ import sympy
 
 from ..._support.indexing import IndexingContext, IndexSequence
 from ..._support.tracing import CapturedTrace
-from ...compiler.utils import strides_from_symbolic_shape
+from ...compiler.utils import (
+    strides_from_symbolic_shape,
+    symbolic_strides_match_physical_memory,
+)
 from ...lang.global_symbols import LINEAR_INDEX, SHARED_ADDRESS_SPACE
 from ...ops.wave_ops import MemoryAccessFlags, Read, get_custom
 from ..assumptions import get_divisibility_subs
+from ..compile_options import WaveCompileOptions
 from ..constraints import Constraint
 from ..utils.general_utils import (
     infer_dim,
@@ -202,8 +206,13 @@ def _linearize_to_flat(
 def flatten_read_indices(
     trace: CapturedTrace,
     constraints: Sequence[Constraint] = (),
+    options: WaveCompileOptions | None = None,
 ):
-    """Flatten N-D read indices to 1-D LINEAR_INDEX for eligible Reads."""
+    """Flatten N-D read indices to 1-D LINEAR_INDEX for eligible Reads.
+
+    *options* is required when invoked from ``compile.py``; a default of ``None``
+    keeps ad-hoc unit tests from constructing a full options object.
+    """
     idxc = IndexingContext.current()
     div_fwd, div_bwd = get_divisibility_subs(constraints)
 
@@ -221,14 +230,26 @@ def flatten_read_indices(
         if _is_shared_memory(mem_node):
             continue
 
-        if custom.flags != MemoryAccessFlags.NONE:
-            continue
-
         memory = get_custom(mem_node)
         symbolic_shape = memory.type.symbolic_shape
+        layout = getattr(memory.type, "physical_layout", None)
+
+        # Dynamic-strides-specific guards: under the LLVM + wave runtime
+        # ABI the only correct dense-stride assumption is when physical
+        # layout matches or is absent AND non-contiguous buffers are not
+        # expected.  The symbolic_strides_match_physical_memory check
+        # handles layout skew (e.g. attention's transposed layouts); the
+        # allow_noncontiguous_runtime_buffers opt-out handles slice views.
+        if options is not None and options.dynamic_strides:
+            if not symbolic_strides_match_physical_memory(memory, symbolic_shape):
+                continue
+            if options.allow_noncontiguous_runtime_buffers and layout is None:
+                continue
+
+        if custom.flags != MemoryAccessFlags.NONE:
+            continue
         symbolic_dims = [infer_dim(d) for d in symbolic_shape]
 
-        layout = getattr(memory.type, "physical_layout", None)
         stride_shape = layout.shape if layout is not None else symbolic_shape
 
         phys_starts = _get_physical_starts(

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -609,10 +609,15 @@ def build_graph_passes(
             launchable.reordering_constraints,
         ),
         *(
-            [partial(flatten_read_indices, trace, launchable.constraints)]
-            if options.linearize_reads
-            and not options.dynamic_strides
-            and not options.use_water_backend
+            [
+                partial(
+                    flatten_read_indices,
+                    trace,
+                    launchable.constraints,
+                    options,
+                )
+            ]
+            if options.linearize_reads and not options.use_water_backend
             else []
         ),
         partial(

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -111,6 +111,13 @@ class WaveCompileOptions:
     # 1 - one iteration apart, 2 - two, etc
     cluster_barrier_delay: Optional[int] = None
 
+    # When True with LLVM dynamic stride ABI (see ``dynamic_strides``), skip
+    # flatten_read_indices for globals without ``MemoryLayout``.  Use for tests
+    # that pass non-contiguous slice views where symbolic dense strides may not
+    # match runtime leading strides.  Default False: typical GEMM/MXFP4 paths
+    # keep read linearization without annotating every buffer.
+    allow_noncontiguous_runtime_buffers: bool = False
+
     # Enable dynamic strides through Wave runtime and LLVM backend
     @property
     def dynamic_strides(self) -> bool:

--- a/wave_lang/kernel/wave/utils/run_utils.py
+++ b/wave_lang/kernel/wave/utils/run_utils.py
@@ -104,9 +104,21 @@ def invoke_with_wave_runtime(
 
     # Force contiguous tensor layouts when dynamic strides are not enabled.
     kern_args = []
-    for arg_tensor in chain(kernel_inputs, kernel_outputs):
+    for i, arg_tensor in enumerate(chain(kernel_inputs, kernel_outputs)):
         if not arg_tensor.is_contiguous() and not options.dynamic_strides:
             arg_tensor = arg_tensor.contiguous()
+        if (
+            options.dynamic_strides
+            and options.linearize_reads
+            and not options.allow_noncontiguous_runtime_buffers
+            and not arg_tensor.is_contiguous()
+        ):
+            raise ValueError(
+                f"Buffer argument {i} is non-contiguous but kernel was compiled "
+                f"with linearized reads (dense stride assumption).  "
+                f"Pass a contiguous tensor, or set "
+                f"allow_noncontiguous_runtime_buffers=True and recompile."
+            )
         kern_args.append(arg_tensor.data_ptr())
 
     kernel_args = wave_runtime.Int64Vector(kern_args)


### PR DESCRIPTION
The major blocker for universal read linearization was non-contiguous tensors under the LLVM dynamic-stride ABI.  This PR enables flatten_read_indices for those paths by default and guards correctness with a runtime contiguity assertion at kernel launch.

What changes:

- flatten_read_indices now runs for dynamic-stride kernels.  It skips only when physical_layout disagrees with symbolic_shape (layout skew, e.g. attention transposed buffers) or when the caller explicitly opts out via allow_noncontiguous_runtime_buffers.

- invoke_with_wave_runtime rejects non-contiguous tensors when the kernel was compiled with linearized reads, unless allow_noncontiguous_runtime_buffers is set.  This closes the silent-corruption window for slice views passed to kernels that assume dense strides.

- LINEAR_INDEX global reads use maskedload on a linearized memref instead of the amdgpu buffer fat-pointer per-lane path, so results match under both VMFB and wave-runtime launch.

- Attention tests (extend, prefill) drop the explicit linearize_reads=False so the default linearization path is exercised.

- Add symbolic_strides_match_physical_memory to compiler utils and allow_noncontiguous_runtime_buffers to WaveCompileOptions.

- Lit test cleanup: FileCheck captures for SSA names, comments explaining magic SRD-limit constants, import ordering fix.

This does not yet remove the linearize_reads compilation option. We still need Water support and a few other minor things.