### PR TITLE
suggest uv instead of normal pip in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Before installing Wave, ensure you have the following prerequisites:
 
 2. **Install Wave**
 
-   You can then install Wave and its dependencies using pip:
+   You can then install Wave and its dependencies using pip or `uv pip`:
 
    ```bash
    pip install wave-lang
@@ -104,21 +104,22 @@ Before installing Wave, ensure you have the following prerequisites:
    ```
 
    Next, install the python dependencies. It is recommended to use a virtual environment.
+   We recommend using [uv](https://docs.astral.sh/uv/) for virtualenv creation and package installation.
+   The normal python pip works as well, but uv uses hard links to a shared cache, so large packages like PyTorch are only downloaded once, and setting up additional virtualenvs (e.g. for git worktrees) is fast.
 
    ```bash
-   python -m venv .venv
+   uv venv .venv
    source .venv/bin/activate
-   pip install --upgrade pip
-   pip install -r requirements-iree-pinned.txt
+   uv pip install -r requirements-iree-pinned.txt
    ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
-   pip install -r requirements-pytorch-rocm-generated.txt
-   pip install -e ".[dev]"
+   uv pip install -r requirements-pytorch-rocm-generated.txt
+   uv pip install -e ".[dev]"
    ```
 
    > **Note:** If you do not have access to Instinct GPUs, you can still install Wave as above but with the CPU version of PyTorch:
    >
    > ```bash
-   > pip install -r pytorch-cpu-requirements.txt
+   > uv pip install -r pytorch-cpu-requirements.txt
    > ```
    >
    > Currently, you can only run lit tests in this mode.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,14 +19,14 @@ a website build and publishes the latest content.
 From the project root directory:
 
 ```shell
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
 
 # Install PyTorch (CPU version for docs)
-python -m pip install -r pytorch-cpu-requirements.txt
+uv pip install -r pytorch-cpu-requirements.txt
 
 # Install wave with docs dependencies
-python -m pip install -e ".[docs]"
+uv pip install -e ".[docs]"
 ```
 
 ### Build docs

--- a/docs/wave/getting_started.rst
+++ b/docs/wave/getting_started.rst
@@ -36,7 +36,7 @@ For Users
 
 2. **Install Wave**
 
-   You can then install Wave and its dependencies using pip:
+   You can then install Wave and its dependencies using pip or `uv pip`:
 
    .. code-block:: bash
 
@@ -61,16 +61,17 @@ For Developers
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
    Next, install the python dependencies. It is recommended to use a virtual environment.
+   We recommend using `uv <https://docs.astral.sh/uv/>`_ for virtualenv creation and package installation.
+   uv uses hard links to a shared cache, so large packages like PyTorch are only downloaded once, and setting up additional virtualenvs (e.g. for git worktrees) is fast.
 
    .. code-block:: bash
 
-      python -m venv .venv
+      uv venv .venv
       source .venv/bin/activate
-      pip install --upgrade pip
-      pip install -r requirements-iree-pinned.txt
+      uv pip install -r requirements-iree-pinned.txt
       ./gen-pytorch-rocm-requirements.py -o requirements-pytorch-rocm-generated.txt
-      pip install -r requirements-pytorch-rocm-generated.txt
-      pip install -e ".[dev]"
+      uv pip install -r requirements-pytorch-rocm-generated.txt
+      uv pip install -e ".[dev]"
 
    *Note:*
 
@@ -78,7 +79,7 @@ For Developers
 
       .. code-block:: bash
 
-        pip install -r pytorch-cpu-requirements.txt
+        uv pip install -r pytorch-cpu-requirements.txt
 
       Currently, you can only run lit tests in this mode.
 

--- a/docs/wave/runtime.rst
+++ b/docs/wave/runtime.rst
@@ -20,11 +20,11 @@ In scenarios where the latencies associated with `torch.to_dlpack` are
 unacceptable, the Wave runtime can be used to launch kernels directly.
 The Wave runtime is a C++ extension that uses nanobind [3]_ to interface with
 inputs from Wave. In order to enable the wave runtime, first install
-the `wave-runtime` pip package.
+the ``wave-runtime`` pip package.
 
-.. code-block:: python
+.. code-block:: bash
 
-     pip install -r requirements-wave-runtime.txt
+     uv pip install -r requirements-wave-runtime.txt
 
 Then modify the `options` as shown below.
 

--- a/waveasm/README.md
+++ b/waveasm/README.md
@@ -88,7 +88,7 @@ ninja
 ### pip Build
 
 ```bash
-WAVE_BUILD_WAVEASM=1 WAVE_LLVM_DIR=/path/to/llvm-install pip install -e .
+WAVE_BUILD_WAVEASM=1 WAVE_LLVM_DIR=/path/to/llvm-install uv pip install -e .
 ```
 
 ### Verify Build


### PR DESCRIPTION
As mentioned in PR comments from https://github.com/iree-org/wave/pull/1266 using `uv` is nice for development generally, so let's just standardize on it in the setup instructions.