### PR TITLE
Add wide_stores support for MXFP4 (4wave) GEMM (llvm backend)

### DIFF
--- a/examples/python/7.1_schedule.py
+++ b/examples/python/7.1_schedule.py
@@ -32,6 +32,7 @@ from wave_lang.kernel.wave.schedules import (
 from wave_lang.kernel.wave.templates import (
     get_tagged_mxfp4_gemm,
     get_tagged_mxfp4_gemm_preshuffle_b,
+    get_tagged_mxfp4_gemm_preshuffle_b_wide_store,
     get_tagged_mxfp4_gemm_preshuffle_scales,
     get_tagged_mxfp4_gemm_preshuffle_scales_and_B,
 )
@@ -432,18 +433,16 @@ def test_dbuf_4wave_mxfp_dynamic_preshuffle_b_gemm_wide_stores(
 ):
     """Preshuffle-B MXFP4 GEMM with dynamic M, N, K and wide epilogue stores.
 
-    Uses wide_stores=True to swap MFMA operands (B as LHS, A as RHS),
+    Uses the wide_store variant to swap MFMA operands (B as LHS, A as RHS),
     aligning the accumulator's contiguous values with the output's stride-1
     dimension. The coalesce_wide_stores pass emits v_permlane16_swap_b32
     + buffer_store_dwordx4 (8 bf16 per store) instead of buffer_store_short.
     """
-    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(
+    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b_wide_store(
         shape,
         block,
         wave_shape=(2, 2),
         reorder_workgroups=True,
-        output_dtype=tkl.bf16,
-        wide_stores=True,
     )
     dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]
     for sym in dynamic_symbols:

--- a/examples/python/7.1_schedule.py
+++ b/examples/python/7.1_schedule.py
@@ -434,7 +434,7 @@ def test_dbuf_4wave_mxfp_dynamic_preshuffle_b_gemm_wide_stores(
 
     Uses wide_stores=True to swap MFMA operands (B as LHS, A as RHS),
     aligning the accumulator's contiguous values with the output's stride-1
-    dimension. The coalesce_epilogue_stores pass emits v_permlane16_swap_b32
+    dimension. The coalesce_wide_stores pass emits v_permlane16_swap_b32
     + buffer_store_dwordx4 (8 bf16 per store) instead of buffer_store_short.
     """
     gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(

--- a/examples/python/7.1_schedule.py
+++ b/examples/python/7.1_schedule.py
@@ -12,36 +12,36 @@ Usage:
 """
 
 import torch
-import wave_lang.kernel.lang as tkl
+from utils import list_tests, parse_args, run_test
 
+import wave_lang.kernel.lang as tkl
+from wave_lang.kernel.lang.global_symbols import (
+    GLOBAL_ADDRESS_SPACE,
+    SHARED_ADDRESS_SPACE,
+)
 from wave_lang.kernel.wave.compile import wave_compile
-from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
+from wave_lang.kernel.wave.schedules import (
+    get_mxfp4_asymmetric_schedule,
+    get_mxfp4_dbuf_mixed_pingpong_schedule,
+    get_mxfp4_dbuf_mixed_pingpong_shuffle_schedule,
+    get_mxfp4_dbuf_pingpong_schedule,
+    get_mxfp4_dbuf_pingpong_schedule_Bshuffled,
+    get_mxfp4_dbuf_pingpong_schedule_Bshuffled_lds,
+    get_mxfp4_dbuf_schedule,
+)
 from wave_lang.kernel.wave.templates import (
     get_tagged_mxfp4_gemm,
     get_tagged_mxfp4_gemm_preshuffle_b,
     get_tagged_mxfp4_gemm_preshuffle_scales,
     get_tagged_mxfp4_gemm_preshuffle_scales_and_B,
 )
-from wave_lang.kernel.wave.schedules import (
-    get_mxfp4_dbuf_schedule,
-    get_mxfp4_dbuf_pingpong_schedule,
-    get_mxfp4_dbuf_mixed_pingpong_schedule,
-    get_mxfp4_asymmetric_schedule,
-    get_mxfp4_dbuf_mixed_pingpong_shuffle_schedule,
-    get_mxfp4_dbuf_pingpong_schedule_Bshuffled,
-    get_mxfp4_dbuf_pingpong_schedule_Bshuffled_lds,
-)
 from wave_lang.kernel.wave.utils.mxfp_utils import (
-    generate_gemm_afp4wfp4_inputs,
-    torchScaledGemmMXFP4,
     b_preshuffle,
     e8m0_shuffle,
+    generate_gemm_afp4wfp4_inputs,
+    torchScaledGemmMXFP4,
 )
-from wave_lang.kernel.lang.global_symbols import (
-    GLOBAL_ADDRESS_SPACE,
-    SHARED_ADDRESS_SPACE,
-)
-from utils import parse_args, list_tests, run_test
+from wave_lang.kernel.wave.utils.run_utils import set_default_run_config
 
 
 def _run_mxfp_gemm(gemm, shape):
@@ -422,6 +422,46 @@ def test_dbuf_4wave_mxfp_dynamic_preshuffle_b_gemm(
 
     _run_mxfp_gemm_preshuffle(gemm, shape, all=True)
     print("MXFP GEMM preshuffle-B 4-wave dynamic M, N, K (LLVM backend) test passed!")
+
+
+def test_dbuf_4wave_mxfp_dynamic_preshuffle_b_gemm_wide_stores(
+    is_debug=False,
+    shape=(1024, 3072, 8192),
+    block=(256, 192, 256),
+    eliminate_epilogue=False,
+):
+    """Preshuffle-B MXFP4 GEMM with dynamic M, N, K and wide epilogue stores.
+
+    Uses wide_stores=True to swap MFMA operands (B as LHS, A as RHS),
+    aligning the accumulator's contiguous values with the output's stride-1
+    dimension. The coalesce_epilogue_stores pass emits v_permlane16_swap_b32
+    + buffer_store_dwordx4 (8 bf16 per store) instead of buffer_store_short.
+    """
+    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(
+        shape,
+        block,
+        wave_shape=(2, 2),
+        reorder_workgroups=True,
+        output_dtype=tkl.bf16,
+        wide_stores=True,
+    )
+    dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]
+    for sym in dynamic_symbols:
+        del options.subs[sym]
+    options.dynamic_symbols = dynamic_symbols
+    options.use_buffer_ops = True
+    options.backend = "llvm"
+    options.wave_runtime = True
+    options.eliminate_epilogue = eliminate_epilogue
+    schedule = get_mxfp4_asymmetric_schedule(
+        eliminate_epilogue=eliminate_epilogue, is_bscale_shuffled=True
+    )
+    options.print_ir_after = "all" if is_debug else []
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm, schedule)
+
+    _run_mxfp_gemm_preshuffle(gemm, shape, all=True, output_dtype=torch.bfloat16)
+    print("MXFP GEMM preshuffle-B 4-wave dynamic M, N, K (wide stores) test passed!")
 
 
 def test_dbuf_4wave_mxfp_dynamic_preshuffle_b_gemm_asm(

--- a/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
+++ b/lit_tests/kernel/wave/mlir_roundtrip_pipeline.py
@@ -304,6 +304,7 @@ def mxfp4_gemm_progressive_roundtrip():
             "guard_g2s_with_bounds_check",
             "schedule_reordering",
             "minimize_shared_allocs",
+            "coalesce_wide_stores",
             "add_shared_memory_barriers",
             "add_cluster_barriers",
             "compute_shared_memory_usage",

--- a/lit_tests/kernel/wave/wide_stores_mxfp4.py
+++ b/lit_tests/kernel/wave/wide_stores_mxfp4.py
@@ -3,7 +3,7 @@
 """
 Test wide store coalescing for preshuffle-B MXFP4 GEMM with bf16 output.
 
-When wide_stores=True, the kernel swaps MFMA operands (B as LHS, A as RHS)
+The wide_store variant kernel swaps MFMA operands (B as LHS, A as RHS)
 so the accumulator's 4-contiguous values align with the output's stride-1
 dimension. The coalesce_wide_stores pass tags eligible bf16 global
 writes, and the codegen emits v_permlane16_swap_b32 to exchange data
@@ -23,7 +23,9 @@ import wave_lang.kernel.lang as tkl
 from wave_lang.kernel.wave.compile import wave_compile
 from wave_lang.kernel.wave.constraints import ScaledMMAType
 from wave_lang.kernel.wave.schedules import get_mxfp4_asymmetric_schedule
-from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm_preshuffle_b
+from wave_lang.kernel.wave.templates import (
+    get_tagged_mxfp4_gemm_preshuffle_b_wide_store,
+)
 from wave_lang.kernel.wave.utils.general_utils import run_test
 
 
@@ -31,13 +33,11 @@ from wave_lang.kernel.wave.utils.general_utils import run_test
 def test_wide_stores_preshuffle_b_mxfp4():
     shape = (1024, 3072, 8192)
     block = (256, 192, 256)
-    kernel, options = get_tagged_mxfp4_gemm_preshuffle_b(
+    kernel, options = get_tagged_mxfp4_gemm_preshuffle_b_wide_store(
         shape,
         block,
         wave_shape=(2, 2),
         reorder_workgroups=True,
-        output_dtype=tkl.bf16,
-        wide_stores=True,
         mfma_variant=ScaledMMAType.F32_16x16x128_F8F6F4,
     )
     dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]

--- a/lit_tests/kernel/wave/wide_stores_mxfp4.py
+++ b/lit_tests/kernel/wave/wide_stores_mxfp4.py
@@ -5,7 +5,7 @@ Test wide store coalescing for preshuffle-B MXFP4 GEMM with bf16 output.
 
 When wide_stores=True, the kernel swaps MFMA operands (B as LHS, A as RHS)
 so the accumulator's 4-contiguous values align with the output's stride-1
-dimension. The coalesce_epilogue_stores pass tags eligible bf16 global
+dimension. The coalesce_wide_stores pass tags eligible bf16 global
 writes, and the codegen emits v_permlane16_swap_b32 to exchange data
 between lane pairs 16 apart, producing 8 consecutive bf16 values written
 as a single buffer_store_dwordx4.

--- a/lit_tests/kernel/wave/wide_stores_mxfp4.py
+++ b/lit_tests/kernel/wave/wide_stores_mxfp4.py
@@ -1,0 +1,82 @@
+# RUN: python %s | FileCheck %s
+
+"""
+Test wide store coalescing for preshuffle-B MXFP4 GEMM with bf16 output.
+
+When wide_stores=True, the kernel swaps MFMA operands (B as LHS, A as RHS)
+so the accumulator's 4-contiguous values align with the output's stride-1
+dimension. The coalesce_epilogue_stores pass tags eligible bf16 global
+writes, and the codegen emits v_permlane16_swap_b32 to exchange data
+between lane pairs 16 apart, producing 8 consecutive bf16 values written
+as a single buffer_store_dwordx4.
+
+Key structural invariants verified:
+  1. Function signature accepts dynamic index arguments for M, N, K.
+  2. Register type is [N, M] (swapped from standard [M, N]).
+  3. scaled_mfma has B as LHS and A as RHS (swapped operands).
+  4. rocdl.permlane16.swap used for lane exchange.
+  5. vector.store of vector<8xbf16> for wide stores.
+  6. arith.truncf for f32 -> bf16 conversion.
+"""
+
+import wave_lang.kernel.lang as tkl
+from wave_lang.kernel.wave.compile import wave_compile
+from wave_lang.kernel.wave.constraints import ScaledMMAType
+from wave_lang.kernel.wave.schedules import get_mxfp4_asymmetric_schedule
+from wave_lang.kernel.wave.templates import get_tagged_mxfp4_gemm_preshuffle_b
+from wave_lang.kernel.wave.utils.general_utils import run_test
+
+
+@run_test
+def test_wide_stores_preshuffle_b_mxfp4():
+    shape = (1024, 3072, 8192)
+    block = (256, 192, 256)
+    kernel, options = get_tagged_mxfp4_gemm_preshuffle_b(
+        shape,
+        block,
+        wave_shape=(2, 2),
+        reorder_workgroups=True,
+        output_dtype=tkl.bf16,
+        wide_stores=True,
+        mfma_variant=ScaledMMAType.F32_16x16x128_F8F6F4,
+    )
+    dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]
+    for sym in dynamic_symbols:
+        del options.subs[sym]
+    options.dynamic_symbols = dynamic_symbols
+    schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
+    options.use_buffer_ops = True
+    options.compile_to_mlir = True
+    options.device = "hip"
+    options.target = "gfx950"
+    result = wave_compile(options, kernel, schedule)
+    print(result.asm)
+
+    # CHECK-LABEL: test_wide_stores_preshuffle_b_mxfp4
+
+    # 1. Dynamic index arguments for M, N, K in function signature.
+    # CHECK: func.func @gemm(%arg0: {{.*}}, %arg1: {{.*}}, %arg2: {{.*}}, %arg3: {{.*}}, %arg4: {{.*}}, %arg5: index, %arg6: index, %arg7: index)
+
+    # 2. f32 -> bf16 conversion in the epilogue.
+    # CHECK: arith.truncf %{{.*}} : vector<4xf32> to vector<4xbf16>
+
+    # 3. vector.bitcast from bf16 to i32 for permlane swap.
+    # CHECK: vector.bitcast %{{.*}} : vector<4xbf16> to vector<2xi32>
+
+    # 4. rocdl.permlane16.swap for lane exchange.
+    # CHECK: rocdl.permlane16.swap
+
+    # 5. llvm.extractvalue to get the swapped value.
+    # CHECK: llvm.extractvalue %{{.*}}[0]
+
+    # 6. arith.select to choose between original and swapped values.
+    # CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+
+    # 7. vector.from_elements to pack 4 i32 into vector<4xi32>.
+    # CHECK: vector.from_elements %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : vector<4xi32>
+
+    # 8. vector.bitcast from i32 to bf16 for the wide store.
+    # CHECK: vector.bitcast %{{.*}} : vector<4xi32> to vector<8xbf16>
+
+    # 9. Wide store of 8 bf16 values.
+    # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<{{.*}}xbf16, {{.*}}>, vector<8xbf16>

--- a/tests/kernel/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave_gemm_mxfp_test.py
@@ -360,9 +360,9 @@ def testScaledBatchedGemmMXFP4Codegen(use_water_backend: bool, tmp_path: Path):
     # We encode the exact registers and wait counts as we want to know if
     # they suddenly change due to backend or upstream MLIR changes.
     if use_water_backend:
-        vgpr_count = 172
+        vgpr_count = 164
         vgpr_spill_count = 0
-        sgpr_count = 61
+        sgpr_count = 57
         sgpr_spill_count = 0
         waitcounts = [
             "s_waitcnt lgkmcnt(0)",
@@ -1023,6 +1023,64 @@ def testScaledGemmMXFP4PreshuffleBDynamicWaveRuntime(
     w_scales_ps = e8m0_shuffle(w_scales)
 
     out = device_zeros(x.shape[0], w_t_ps.shape[0], dtype=torch.float32)
+    gemm(x, x_scales_ps, w_t_ps, w_scales_ps, out)
+
+    torch.testing.assert_close(torch_out, out, check_dtype=False)
+
+
+@require_e2e
+@require_cdna4
+@pytest.mark.timeout(900)
+@pytest.mark.parametrize(
+    "shape",
+    [(1024, 3072, 8192)],
+)
+@pytest.mark.parametrize(
+    "block_shape,wave_shape",
+    [((256, 192, 256), (2, 2))],
+)
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [ScaledMMAType.F32_16x16x128_F8F6F4],
+)
+def testScaledGemmMXFP4PreshuffleBWideStores(
+    shape: tuple[int, int, int],
+    block_shape: tuple[int, int, int],
+    wave_shape: tuple[int, int],
+    mfma_variant: ScaledMMAType,
+):
+    """End-to-end test for MXFP4 GEMM with wide epilogue stores (dwordx4).
+
+    Uses wide_stores=True to swap MFMA operands and emit buffer_store_dwordx4
+    via v_permlane16_swap_b32 for bf16 output.
+    """
+    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(
+        shape,
+        block_shape,
+        wave_shape=wave_shape,
+        mfma_variant=mfma_variant,
+        reorder_workgroups=True,
+        output_dtype=tkl.bf16,
+        wide_stores=True,
+    )
+    dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]
+    for sym in dynamic_symbols:
+        del options.subs[sym]
+    options.dynamic_symbols = dynamic_symbols
+    schedule = get_mxfp4_asymmetric_schedule(is_bscale_shuffled=True)
+    options.use_buffer_ops = True
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm, schedule)
+
+    x, w, x_scales, w_scales = generate_gemm_afp4wfp4_inputs(shape)
+    torch_out = torchScaledGemmMXFP4(x, w, x_scales, w_scales)
+
+    w_t = w.T.contiguous()
+    w_t_ps = b_preshuffle(w_t)
+    x_scales_ps = e8m0_shuffle(x_scales)
+    w_scales_ps = e8m0_shuffle(w_scales)
+
+    out = device_zeros(x.shape[0], w_t_ps.shape[0], dtype=torch.bfloat16)
     gemm(x, x_scales_ps, w_t_ps, w_scales_ps, out)
 
     torch.testing.assert_close(torch_out, out, check_dtype=False)

--- a/tests/kernel/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave_gemm_mxfp_test.py
@@ -360,9 +360,9 @@ def testScaledBatchedGemmMXFP4Codegen(use_water_backend: bool, tmp_path: Path):
     # We encode the exact registers and wait counts as we want to know if
     # they suddenly change due to backend or upstream MLIR changes.
     if use_water_backend:
-        vgpr_count = 164
+        vgpr_count = 172
         vgpr_spill_count = 0
-        sgpr_count = 57
+        sgpr_count = 61
         sgpr_spill_count = 0
         waitcounts = [
             "s_waitcnt lgkmcnt(0)",

--- a/tests/kernel/wave_gemm_mxfp_test.py
+++ b/tests/kernel/wave_gemm_mxfp_test.py
@@ -29,6 +29,7 @@ from wave_lang.kernel.wave.constraints import (
 from wave_lang.kernel.wave.templates import (
     get_tagged_mxfp4_gemm,
     get_tagged_mxfp4_gemm_preshuffle_b,
+    get_tagged_mxfp4_gemm_preshuffle_b_wide_store,
     get_tagged_mxfp4_gemm_preshuffle_scales,
     get_tagged_mxfp4_gemm_preshuffle_scales_and_B,
 )
@@ -1051,17 +1052,15 @@ def testScaledGemmMXFP4PreshuffleBWideStores(
 ):
     """End-to-end test for MXFP4 GEMM with wide epilogue stores (dwordx4).
 
-    Uses wide_stores=True to swap MFMA operands and emit buffer_store_dwordx4
-    via v_permlane16_swap_b32 for bf16 output.
+    Uses the wide_store variant to swap MFMA operands and emit
+    buffer_store_dwordx4 via v_permlane16_swap_b32 for bf16 output.
     """
-    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b(
+    gemm, options = get_tagged_mxfp4_gemm_preshuffle_b_wide_store(
         shape,
         block_shape,
         wave_shape=wave_shape,
         mfma_variant=mfma_variant,
         reorder_workgroups=True,
-        output_dtype=tkl.bf16,
-        wide_stores=True,
     )
     dynamic_symbols = [tkl.sym.M, tkl.sym.N, tkl.sym.K]
     for sym in dynamic_symbols:

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -117,7 +117,7 @@ def _split_index(
     # Compute thread-independent index as `orig_index - thread_dependent_index`
     # All thread symbols and dynamic should cancel-out in the result.
     diff = src - thread_dependent_index
-    # Avoid sympy.simplify on Piecewise expressions — it recurses into boolean
+    # Avoid sympy.simplify on Piecewise expressions : it recurses into boolean
     # condition simplification and can hang for complex dynamic-shape indices.
     # expand() handles basic polynomial cancellation and is O(fast).
     if isinstance(diff, sympy.Basic) and diff.has(sympy.Piecewise):
@@ -575,7 +575,7 @@ def _cast_buffer_and_encode_stride(
         stride_int = _get_constant_value(stride_candidate)
         # Emit swizzle stride for both static and dynamic cases.
         # Static: only if stride fits in signed i14 (max 8192).
-        # Dynamic: always emit — the SRD swizzle encoding is constant
+        # Dynamic: always emit : the SRD swizzle encoding is constant
         # (0x40400000 + 0x27000) regardless of the actual stride value.
         if stride_int is None or stride_int <= 8192:
             swizzle_stride = arith_d.index_cast(uint14, stride_candidate)
@@ -1326,18 +1326,49 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
     if getattr(node, "_permlane_pack_global", False):
         is_shared = get_custom(memory).type.address_space == SHARED_ADDRESS_SPACE
         if not is_shared and isinstance(element_type, BF16Type):
-            _write_permlane_pack_to_global(
-                emitter,
-                insert_vector,
-                kb_dest,
-                output_shape,
-                start_indices,
-                start_indices_wg,
-                start_indices_th,
-                get_custom(memory),
-                index,
+            role = getattr(node, "_permlane_pack_role", "unpaired")
+
+            if role == "first":
+                node._stashed_codegen = {
+                    "insert_vector": insert_vector,
+                    "kb_dest": kb_dest,
+                    "output_shape": output_shape,
+                    "start_indices": start_indices,
+                    "start_indices_wg": start_indices_wg,
+                    "start_indices_th": start_indices_th,
+                    "memory_custom": get_custom(memory),
+                    "index": index,
+                }
+                return
+
+            if role == "second":
+                partner = node._permlane_partner
+                s = partner._stashed_codegen
+                _write_permlane_pair_to_global(
+                    emitter,
+                    s["insert_vector"],
+                    insert_vector,
+                    s["kb_dest"],
+                    kb_dest,
+                    s["output_shape"],
+                    output_shape,
+                    s["start_indices"],
+                    s["start_indices_wg"],
+                    s["start_indices_th"],
+                    start_indices,
+                    start_indices_wg,
+                    start_indices_th,
+                    s["memory_custom"],
+                    get_custom(memory),
+                    s["index"],
+                    index,
+                )
+                return
+
+            assert False, (
+                "Unexpected unpaired wide-store write. "
+                "coalesce_wide_stores should pair all eligible writes."
             )
-            return
 
     if use_llvm_store:
         _create_llvm_read_write(
@@ -1360,52 +1391,58 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
         )
 
 
-def _write_permlane_pack_to_global(
+def _write_permlane_pair_to_global(
     emitter: WaveEmitter,
-    insert_vector: Value,
-    kb_dest: Value,
-    output_shape: tuple,
-    start_indices: tuple,
-    start_indices_wg: tuple,
-    start_indices_th: tuple,
-    memory_custom,
-    index: dict,
+    vec_a: Value,
+    vec_b: Value,
+    kb_dest_a: Value,
+    kb_dest_b: Value,
+    output_shape_a: tuple,
+    output_shape_b: tuple,
+    start_indices_a: tuple,
+    start_indices_wg_a: tuple,
+    start_indices_th_a: tuple,
+    start_indices_b: tuple,
+    start_indices_wg_b: tuple,
+    start_indices_th_b: tuple,
+    memory_custom_a,
+    memory_custom_b,
+    index_a: dict,
+    index_b: dict,
 ):
-    """Pack two lanes' bf16 values via permlane16_swap for wide global stores.
+    """Pair two tile groups via permlane16_swap for duplicate-free wide stores.
 
-    Uses ``v_permlane16_swap_b32`` to exchange each thread's 4 bf16 values
-    (packed as 2 i32 dwords) with a partner lane 16 positions apart.
-    The result is 8 consecutive bf16 values per lane, written as a single
-    ``buffer_store_dwordx4`` (128 bits).
+    Pairs tile A and tile B by passing them as separate ``old_dst`` /
+    ``src`` operands to ``v_permlane16_swap_b32``.  Both outputs of the
+    swap carry distinct data, so each lane writes a *different* tile
+    group's wide store : no duplicate stores:
 
-    Both lane halves write identical data to the same address (benign
-    duplicate store), avoiding divergent control flow. The buffer
-    descriptor's ``valid_bytes`` handles out-of-bounds suppression.
+    * Lower lane (lane % 32 < 16) writes tile A:
+      ``[own_A_lo, own_A_hi, partner_A_lo, partner_A_hi]``
+    * Upper lane (lane % 32 >= 16) writes tile B:
+      ``[partner_B_lo, partner_B_hi, own_B_lo, own_B_hi]``
 
-    TODO: Eliminate duplicate stores by using both outputs of
-    ``permlane16_swap``, letting each lane write the partner's assembled
-    data to the partner's destination address so every lane performs a
-    unique store.
+    This halves both the ``permlane16_swap`` count and the global store
+    count compared to the single-write approach.
 
-    Preconditions:
-      - The kernel must use swapped MFMA operands (B as LHS, A as RHS)
-        so the accumulator's 4-contiguous values align with the output
-        memory's stride-1 dimension.
-      - The Write node must be tagged with ``_permlane_pack_global=True``
-        by the ``coalesce_wide_stores`` pass.
+    Preconditions (same as ``_write_permlane_pack_to_global``):
+      - Swapped MFMA operands, F32_16x16x128_F8F6F4 layout, bf16 output.
+      - Both Write nodes tagged by ``coalesce_wide_stores``.
 
     .. note::
-        Currently assumes F32_16x16x128_F8F6F4 MMA layout (4 values
-        along MMA-M per thread, 16-lane groups). Generalizing to other
-        MMA types requires parameterizing the lane group size and
-        elements per thread.
+        The store is emitted using tile A's ``output_shape``,
+        ``memory_custom``, ``kb_dest``, and ``index``.  This is correct
+        when both tiles target the same output buffer with identical
+        shape and buffer descriptor (the standard MXFP4 GEMM case).
+        If the two tiles ever target different buffers, the
+        ``_create_vec_read_write`` call would need to be split into
+        two lane-divergent stores.
     """
-    vec_type = insert_vector.type
-    num_elems = vec_type.shape[0] if hasattr(vec_type, "shape") else 1
-    assert num_elems == 4, (
-        f"_write_permlane_pack_to_global expects 4 bf16 elements per thread "
-        f"(F32_16x16x128_F8F6F4 MMA layout), got {num_elems}. "
-        f"Other MMA types are not yet supported."
+    num_elems_a = vec_a.type.shape[0] if hasattr(vec_a.type, "shape") else 1
+    num_elems_b = vec_b.type.shape[0] if hasattr(vec_b.type, "shape") else 1
+    assert num_elems_a == 4 and num_elems_b == 4, (
+        f"_write_permlane_pair_to_global expects 4 bf16 elements per thread "
+        f"per tile, got {num_elems_a} and {num_elems_b}."
     )
 
     bf16_type = BF16Type.get()
@@ -1415,17 +1452,24 @@ def _write_permlane_pack_to_global(
     v4i32_type = VectorType.get([4], i32_type)
     v8bf16_type = VectorType.get([8], bf16_type)
 
-    i32_vec = vector_d.bitcast(v2i32_type, insert_vector)
-    own_lo = vector_d.extract(i32_vec, static_position=[0], dynamic_position=[])
-    own_hi = vector_d.extract(i32_vec, static_position=[1], dynamic_position=[])
+    i32_a = vector_d.bitcast(v2i32_type, vec_a)
+    a_lo = vector_d.extract(i32_a, static_position=[0], dynamic_position=[])
+    a_hi = vector_d.extract(i32_a, static_position=[1], dynamic_position=[])
+
+    i32_b = vector_d.bitcast(v2i32_type, vec_b)
+    b_lo = vector_d.extract(i32_b, static_position=[0], dynamic_position=[])
+    b_hi = vector_d.extract(i32_b, static_position=[1], dynamic_position=[])
 
     swap_type = llvm_d.StructType.get_literal([i32_type, i32_type])
-    partner_lo = llvm_d.extractvalue(
-        i32_type, rocdl_d.permlane16_swap(swap_type, own_lo, own_lo, False, False), [0]
-    )
-    partner_hi = llvm_d.extractvalue(
-        i32_type, rocdl_d.permlane16_swap(swap_type, own_hi, own_hi, False, False), [0]
-    )
+
+    # old_dst = a, src = b  →  result[0] = partner's b, result[1] = partner's a
+    swap_lo = rocdl_d.permlane16_swap(swap_type, a_lo, b_lo, False, False)
+    swap_hi = rocdl_d.permlane16_swap(swap_type, a_hi, b_hi, False, False)
+
+    partner_b_lo = llvm_d.extractvalue(i32_type, swap_lo, [0])
+    partner_a_lo = llvm_d.extractvalue(i32_type, swap_lo, [1])
+    partner_b_hi = llvm_d.extractvalue(i32_type, swap_hi, [0])
+    partner_a_hi = llvm_d.extractvalue(i32_type, swap_hi, [1])
 
     lane_in_wave = arith_d.remui(emitter.thread_ids[0], arith_d.constant(idx_type, 64))
     half_pos = arith_d.remui(lane_in_wave, arith_d.constant(idx_type, 32))
@@ -1433,39 +1477,61 @@ def _write_permlane_pack_to_global(
         arith_d.CmpIPredicate.ult, half_pos, arith_d.constant(idx_type, 16)
     )
 
-    d0 = arith_d.select(is_lower, own_lo, partner_lo)
-    d1 = arith_d.select(is_lower, own_hi, partner_hi)
-    d2 = arith_d.select(is_lower, partner_lo, own_lo)
-    d3 = arith_d.select(is_lower, partner_hi, own_hi)
+    # Lower lane: [own_A_lo, own_A_hi, partner_A_lo, partner_A_hi]
+    # Upper lane: [partner_B_lo, partner_B_hi, own_B_lo, own_B_hi]
+    d0 = arith_d.select(is_lower, a_lo, partner_b_lo)
+    d1 = arith_d.select(is_lower, a_hi, partner_b_hi)
+    d2 = arith_d.select(is_lower, partner_a_lo, b_lo)
+    d3 = arith_d.select(is_lower, partner_a_hi, b_hi)
 
     wide_i32 = vector_d.from_elements(v4i32_type, [d0, d1, d2, d3])
     wide_vec = vector_d.bitcast(v8bf16_type, wide_i32)
 
-    elems_per_thread = arith_d.constant(idx_type, num_elems)
+    elems_per_thread = arith_d.constant(idx_type, 4)
 
-    adj_th = list(start_indices_th)
-    adj_th[-1] = arith_d.select(
-        is_lower, adj_th[-1], arith_d.subi(adj_th[-1], elems_per_thread)
-    )
+    # Lower lane uses tile A's address; upper lane uses tile B's address.
+    # Upper lane subtracts elems_per_thread from the last dim to align
+    # to the lower lane's column position (same as the single-write path).
+    adj_th = list(start_indices_th_a)
+    adj_full = list(start_indices_a)
+    for dim_idx in range(len(adj_th)):
+        if dim_idx == len(adj_th) - 1:
+            adj_b_th = arith_d.subi(start_indices_th_b[-1], elems_per_thread)
+            adj_b_full = arith_d.subi(start_indices_b[-1], elems_per_thread)
+            adj_th[dim_idx] = arith_d.select(is_lower, adj_th[dim_idx], adj_b_th)
+            adj_full[dim_idx] = arith_d.select(is_lower, adj_full[dim_idx], adj_b_full)
+        else:
+            adj_th[dim_idx] = arith_d.select(
+                is_lower, start_indices_th_a[dim_idx], start_indices_th_b[dim_idx]
+            )
+            adj_full[dim_idx] = arith_d.select(
+                is_lower, start_indices_a[dim_idx], start_indices_b[dim_idx]
+            )
 
-    adj_full = list(start_indices)
-    adj_full[-1] = arith_d.select(
-        is_lower, adj_full[-1], arith_d.subi(adj_full[-1], elems_per_thread)
-    )
+    adj_wg = list(start_indices_wg_a)
+    for dim_idx in range(len(adj_wg)):
+        adj_wg[dim_idx] = arith_d.select(
+            is_lower, start_indices_wg_a[dim_idx], start_indices_wg_b[dim_idx]
+        )
+
+    sel_output_shape = output_shape_a
+    sel_memory_custom = memory_custom_a
+    sel_kb_dest = kb_dest_a
+    sel_index = index_a
 
     _create_vec_read_write(
         emitter,
-        output_shape,
-        kb_dest,
+        sel_output_shape,
+        sel_kb_dest,
         wide_vec,
         None,
         tuple(adj_full),
-        start_indices_wg,
+        tuple(adj_wg),
         tuple(adj_th),
         8,
-        memory_custom,
+        sel_memory_custom,
         None,
-        node_index=index,
+        node_index=sel_index,
     )
 
 

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -689,7 +689,16 @@ def _create_vec_read_write(
     else:
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in stride_values]
 
-    no_masked_load_store_ops = buffer_ops_enabled
+    # With the waveasm backend (non-water path), allow masked loads even
+    # with buffer ops.  The mask computation may fail to translate
+    # (vector<Nxindex> ops are unsupported), but the backend loads
+    # unconditionally in that case, relying on hardware OOB checking
+    # (SRD boundsCheck) to return zero.  The water+waveasm path goes
+    # through TranslateFromLLVMDialect which lacks vector op support,
+    # so masked loads must stay disabled there.
+    no_masked_load_store_ops = buffer_ops_enabled and (
+        emitter.options.backend != "asm" or emitter.options.use_water_backend
+    )
 
     mask_splat = _get_splat_input(mask)
     splatted_mask = mask_splat is not None
@@ -1378,7 +1387,7 @@ def _write_permlane_pack_to_global(
         so the accumulator's 4-contiguous values align with the output
         memory's stride-1 dimension.
       - The Write node must be tagged with ``_permlane_pack_global=True``
-        by the ``coalesce_epilogue_stores`` pass.
+        by the ``coalesce_wide_stores`` pass.
 
     .. note::
         Currently assumes F32_16x16x128_F8F6F4 MMA layout (4 values
@@ -1386,6 +1395,14 @@ def _write_permlane_pack_to_global(
         MMA types requires parameterizing the lane group size and
         elements per thread.
     """
+    vec_type = insert_vector.type
+    num_elems = vec_type.shape[0] if hasattr(vec_type, "shape") else 1
+    assert num_elems == 4, (
+        f"_write_permlane_pack_to_global expects 4 bf16 elements per thread "
+        f"(F32_16x16x128_F8F6F4 MMA layout), got {num_elems}. "
+        f"Other MMA types are not yet supported."
+    )
+
     bf16_type = BF16Type.get()
     i32_type = IntegerType.get_signless(32)
     idx_type = IndexType.get()

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -1436,14 +1436,16 @@ def _write_permlane_pack_to_global(
     wide_i32 = vector_d.from_elements(v4i32_type, [d0, d1, d2, d3])
     wide_vec = vector_d.bitcast(v8bf16_type, wide_i32)
 
-    four = arith_d.constant(idx_type, 4)
+    elems_per_thread = arith_d.constant(idx_type, num_elems)
 
     adj_th = list(start_indices_th)
-    adj_th[-1] = arith_d.select(is_lower, adj_th[-1], arith_d.subi(adj_th[-1], four))
+    adj_th[-1] = arith_d.select(
+        is_lower, adj_th[-1], arith_d.subi(adj_th[-1], elems_per_thread)
+    )
 
     adj_full = list(start_indices)
     adj_full[-1] = arith_d.select(
-        is_lower, adj_full[-1], arith_d.subi(adj_full[-1], four)
+        is_lower, adj_full[-1], arith_d.subi(adj_full[-1], elems_per_thread)
     )
 
     _create_vec_read_write(

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -5,15 +5,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import functools
+import math
 from typing import Any, Optional
 
-import math
 import sympy
 import torch.fx as fx
 
 from wave_lang.kernel.wave.utils.graph_utils import propagate_loop_carried_vars
 from wave_lang.support.ir_imports import (
     Attribute,
+    BF16Type,
     DenseElementsAttr,
     IndexType,
     InsertionPoint,
@@ -31,10 +32,8 @@ from wave_lang.support.ir_imports import (
     gpu_d,
     llvm_d,
     memref_d,
+    rocdl_d,
     vector_d,
-)
-from .ir_utils import (
-    is_float_type,
 )
 
 from ..._support.indexing import (
@@ -44,28 +43,30 @@ from ..._support.indexing import (
     IndexSymbol,
     subs_idxc,
 )
-from ..base import ValidationError
-from ..builder import IRProxyValue
-from ..utils import (
-    strides_from_symbolic_shape,
-    symbolic_strides_match_physical_memory as _symbolic_strides_match_physical,
-)
 from ...lang.global_symbols import *
 from ...lang.wave_types import IndexMapping
 from ...ops.wave_ops import (
     CustomOp,
+    MemoryAccessFlags,
     gather_to_lds,
-    tensor_load_to_lds,
     get_custom,
     read,
-    write,
-    scatter_add,
     read_meets_hw_transpose_requirements,
-    MemoryAccessFlags,
+    scatter_add,
+    tensor_load_to_lds,
+    write,
 )
 from ...wave.utils.general_utils import get_fastest_index, infer_dim, linearize_index
 from ...wave.utils.mapping_utils import transform_index_on_mapping
 from ...wave.utils.symbol_utils import safe_subs, simplify
+from ..base import ValidationError
+from ..builder import IRProxyValue
+from ..utils import (
+    strides_from_symbolic_shape,
+)
+from ..utils import (
+    symbolic_strides_match_physical_memory as _symbolic_strides_match_physical,
+)
 from .emitter import (
     WaveEmitter,
     add_emitter_subs,
@@ -77,6 +78,9 @@ from .emitter import (
     get_constant_attr,
     get_type_or_element_type,
     handle_op,
+)
+from .ir_utils import (
+    is_float_type,
 )
 
 
@@ -685,16 +689,7 @@ def _create_vec_read_write(
     else:
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in stride_values]
 
-    # With the waveasm backend (non-water path), allow masked loads even
-    # with buffer ops.  The mask computation may fail to translate
-    # (vector<Nxindex> ops are unsupported), but the backend loads
-    # unconditionally in that case, relying on hardware OOB checking
-    # (SRD boundsCheck) to return zero.  The water+waveasm path goes
-    # through TranslateFromLLVMDialect which lacks vector op support,
-    # so masked loads must stay disabled there.
-    no_masked_load_store_ops = buffer_ops_enabled and (
-        emitter.options.backend != "asm" or emitter.options.use_water_backend
-    )
+    no_masked_load_store_ops = buffer_ops_enabled
 
     mask_splat = _get_splat_input(mask)
     splatted_mask = mask_splat is not None
@@ -1318,6 +1313,23 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
     )
 
     use_llvm_store = flags != MemoryAccessFlags.NONE
+
+    if getattr(node, "_permlane_pack_global", False):
+        is_shared = get_custom(memory).type.address_space == SHARED_ADDRESS_SPACE
+        if not is_shared and isinstance(element_type, BF16Type):
+            _write_permlane_pack_to_global(
+                emitter,
+                insert_vector,
+                kb_dest,
+                output_shape,
+                start_indices,
+                start_indices_wg,
+                start_indices_th,
+                get_custom(memory),
+                index,
+            )
+            return
+
     if use_llvm_store:
         _create_llvm_read_write(
             kb_dest, kb_ir_type, start_indices, insert_type, flags, insert_vector
@@ -1337,6 +1349,100 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
             mask,
             node_index=index,
         )
+
+
+def _write_permlane_pack_to_global(
+    emitter: WaveEmitter,
+    insert_vector: Value,
+    kb_dest: Value,
+    output_shape: tuple,
+    start_indices: tuple,
+    start_indices_wg: tuple,
+    start_indices_th: tuple,
+    memory_custom,
+    index: dict,
+):
+    """Pack two lanes' bf16 values via permlane16_swap for wide global stores.
+
+    Uses ``v_permlane16_swap_b32`` to exchange each thread's 4 bf16 values
+    (packed as 2 i32 dwords) with a partner lane 16 positions apart.
+    The result is 8 consecutive bf16 values per lane, written as a single
+    ``buffer_store_dwordx4`` (128 bits).
+
+    Both lane halves write identical data to the same address (benign
+    duplicate store), avoiding divergent control flow. The buffer
+    descriptor's ``valid_bytes`` handles out-of-bounds suppression.
+
+    Preconditions:
+      - The kernel must use swapped MFMA operands (B as LHS, A as RHS)
+        so the accumulator's 4-contiguous values align with the output
+        memory's stride-1 dimension.
+      - The Write node must be tagged with ``_permlane_pack_global=True``
+        by the ``coalesce_epilogue_stores`` pass.
+
+    .. note::
+        Currently assumes F32_16x16x128_F8F6F4 MMA layout (4 values
+        along MMA-M per thread, 16-lane groups). Generalizing to other
+        MMA types requires parameterizing the lane group size and
+        elements per thread.
+    """
+    bf16_type = BF16Type.get()
+    i32_type = IntegerType.get_signless(32)
+    idx_type = IndexType.get()
+    v2i32_type = VectorType.get([2], i32_type)
+    v4i32_type = VectorType.get([4], i32_type)
+    v8bf16_type = VectorType.get([8], bf16_type)
+
+    i32_vec = vector_d.bitcast(v2i32_type, insert_vector)
+    own_lo = vector_d.extract(i32_vec, static_position=[0], dynamic_position=[])
+    own_hi = vector_d.extract(i32_vec, static_position=[1], dynamic_position=[])
+
+    swap_type = llvm_d.StructType.get_literal([i32_type, i32_type])
+    partner_lo = llvm_d.extractvalue(
+        i32_type, rocdl_d.permlane16_swap(swap_type, own_lo, own_lo, False, False), [0]
+    )
+    partner_hi = llvm_d.extractvalue(
+        i32_type, rocdl_d.permlane16_swap(swap_type, own_hi, own_hi, False, False), [0]
+    )
+
+    lane_in_wave = arith_d.remui(emitter.thread_ids[0], arith_d.constant(idx_type, 64))
+    half_pos = arith_d.remui(lane_in_wave, arith_d.constant(idx_type, 32))
+    is_lower = arith_d.cmpi(
+        arith_d.CmpIPredicate.ult, half_pos, arith_d.constant(idx_type, 16)
+    )
+
+    d0 = arith_d.select(is_lower, own_lo, partner_lo)
+    d1 = arith_d.select(is_lower, own_hi, partner_hi)
+    d2 = arith_d.select(is_lower, partner_lo, own_lo)
+    d3 = arith_d.select(is_lower, partner_hi, own_hi)
+
+    wide_i32 = vector_d.from_elements(v4i32_type, [d0, d1, d2, d3])
+    wide_vec = vector_d.bitcast(v8bf16_type, wide_i32)
+
+    four = arith_d.constant(idx_type, 4)
+
+    adj_th = list(start_indices_th)
+    adj_th[-1] = arith_d.select(is_lower, adj_th[-1], arith_d.subi(adj_th[-1], four))
+
+    adj_full = list(start_indices)
+    adj_full[-1] = arith_d.select(
+        is_lower, adj_full[-1], arith_d.subi(adj_full[-1], four)
+    )
+
+    _create_vec_read_write(
+        emitter,
+        output_shape,
+        kb_dest,
+        wide_vec,
+        None,
+        tuple(adj_full),
+        start_indices_wg,
+        tuple(adj_th),
+        8,
+        memory_custom,
+        None,
+        node_index=index,
+    )
 
 
 def assume_index_subgroup_uniform(value: Value, element_type: IrType) -> Value:

--- a/wave_lang/kernel/compiler/wave_codegen/read_write.py
+++ b/wave_lang/kernel/compiler/wave_codegen/read_write.py
@@ -1382,6 +1382,11 @@ def _write_permlane_pack_to_global(
     duplicate store), avoiding divergent control flow. The buffer
     descriptor's ``valid_bytes`` handles out-of-bounds suppression.
 
+    TODO: Eliminate duplicate stores by using both outputs of
+    ``permlane16_swap``, letting each lane write the partner's assembled
+    data to the partner's destination address so every lane performs a
+    unique store.
+
     Preconditions:
       - The kernel must use swapped MFMA operands (B as LHS, A as RHS)
         so the accumulator's 4-contiguous values align with the output

--- a/wave_lang/kernel/wave/compile.py
+++ b/wave_lang/kernel/wave/compile.py
@@ -1,21 +1,19 @@
-import glob
-from itertools import chain
-from typing import Any, Optional, Callable, Sequence
-
-import sympy
-from sympy.utilities.lambdify import lambdastr
-import torch
 import ctypes
+import glob
 from ctypes import py_object
+from itertools import chain
+from typing import Any, Callable, Optional, Sequence
+
+import iree.runtime as rt
+import sympy
+import torch
+from sympy.utilities.lambdify import lambdastr
+
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.runtime.launch import Launchable
+from wave_lang.runtime.multi_device_launch import MultiDeviceLaunchable
 
 from ...support.ir_imports import (
-    Module,
-    stream_d,
-    Context,
-    Operation,
-    Location,
-    InsertionPoint,
-    builtin_d,
     Block,
     BlockArgument,
     Context,
@@ -30,6 +28,17 @@ from ...support.ir_imports import (
     builtin_d,
     stream_d,
 )
+from ...support.location_config import LocationCaptureLevel
+
+# Support.
+from .._support.indexing import IndexingContext, safe_subs
+from .._support.tracing import CapturedTrace
+from ..compiler import builder, dispatch_codegen, host_codegen, kernel_codegen
+from ..compiler.wave_codegen import WaveEmitter
+from ..lang import IndexSymbol
+from ..lang.grid import Grid
+from .analysis.annotate_iv_strides import annotate_iv_strides
+from .analysis.flatten_read_indices import flatten_read_indices
 
 # Passes
 from .analysis.index_sequence_analysis import (
@@ -37,8 +46,6 @@ from .analysis.index_sequence_analysis import (
     set_node_indices_water_checked,
     set_post_expansion_indices,
 )
-from .analysis.annotate_iv_strides import annotate_iv_strides
-from .analysis.flatten_read_indices import flatten_read_indices
 from .analysis.partition_strided_operators import (
     merge_contiguous_reads,
     partition_gather_like_ops,
@@ -47,12 +54,18 @@ from .analysis.partition_strided_operators import (
     simplify_indices,
 )
 from .barriers import add_shared_memory_barriers
+from .cache import (
+    get_cache_manager,
+    get_temp_binary_dir,
+    is_cache_enabled,
+)
 from .cluster_barriers import add_cluster_barriers
+from .compile_options import WaveCompileOptions
 from .construct_index_mapping import construct_index_mapping
 from .debug_log_hoist import (
+    DebugArgInfo,
     debug_log_hoist,
     debug_log_write_replace,
-    DebugArgInfo,
 )
 from .decompose_dot_mma import decompose_dot_mma
 from .decompose_reduce_ops import decompose_reduce_ops
@@ -68,11 +81,14 @@ from .global_to_shared_gathers import global_to_shared_gathers
 from .hardware_transpose import mark_hardware_transpose_candidates
 from .hoisting import hoist_loop_invariant_ops
 from .in_thread_transpose import in_thread_transpose
+from .iree_utils import warn_iree_is_too_old
 from .location_check_pass import location_check_pass
 from .memory_analysis.minimize_shared_allocs import minimize_shared_allocs
 from .minimize_global_loads import minimize_global_loads
-from .preshuffle_scale_to_shared import preshuffle_scale_to_shared
 from .multicast import multicast
+from .opsel_scaled_mfma import apply_opsel_scaled_mfma
+from .preshuffle_scale_to_shared import preshuffle_scale_to_shared
+from .profiling import benchmark_module
 from .promotion import compute_shared_memory_usage, promote_placeholders
 from .region_canonicalization import (
     RegionFormat,
@@ -90,16 +106,12 @@ from .shared_memory_indexing import apply_shared_memory_indexing_corrections
 from .specialize import specialize_kernel
 from .tensor_load_to_shared import tensor_load_to_shared
 from .type_inference import infer_types
-from .wave_schedule import WaveSchedule
-from .workgroup_reordering import reorder_workgroups
-from .opsel_scaled_mfma import apply_opsel_scaled_mfma
 
 # Utilities.
-from .utils.compile_utils import canonicalize_module, apply_transform, compile_to_vmfb
+from .utils.compile_utils import apply_transform, canonicalize_module, compile_to_vmfb
 from .utils.general_utils import (
     get_hardware_constraint,
     partial,
-    remove_files_with_extension,
     remove_files_with_extension,
     wave_dtype_to_torch,
 )
@@ -108,46 +120,21 @@ from .utils.graph_utils import (
     remove_chained_extractslice,
     remove_chained_getresult,
 )
-from .utils.run_utils import (
-    write_file,
-    print_bench_result,
-    invoke_with_wave_runtime,
-    get_benchmark_flags,
-)
 from .utils.print_utils import print_trace, try_apply_pass
-
-# Support.
-from .._support.indexing import IndexingContext, safe_subs
-from ...support.location_config import LocationCaptureLevel
-from .._support.tracing import CapturedTrace
-
-
-from ..compiler import host_codegen, kernel_codegen, builder, dispatch_codegen
-from ..compiler.wave_codegen import WaveEmitter
-from .compile_options import WaveCompileOptions
-from .cache import (
-    get_cache_manager,
-    get_temp_binary_dir,
-    is_cache_enabled,
+from .utils.run_utils import (
+    get_benchmark_flags,
+    invoke_with_wave_runtime,
+    print_bench_result,
+    write_file,
 )
-
 from .water import (
     water_leak_in_bounds_check,
     water_lowering_pipeline,
     water_waveasm_lowering_pipeline,
 )
-from wave_lang.runtime.launch import Launchable
-from wave_lang.runtime.multi_device_launch import MultiDeviceLaunchable
 from .wave import LaunchableWave
-from wave_lang.kernel.lang.global_symbols import *
-from .profiling import benchmark_module
-from .debug_log_hoist import DebugArgInfo
-
-from ..lang import IndexSymbol
-from ..lang.grid import Grid
-from .iree_utils import warn_iree_is_too_old
-
-import iree.runtime as rt
+from .wave_schedule import WaveSchedule
+from .workgroup_reordering import reorder_workgroups
 
 
 class WaveKernel:
@@ -542,6 +529,10 @@ def build_graph_passes(
         partial(decompose_scan_ops, trace, launchable.constraints),
         partial(decompose_topk_ops, trace, launchable.constraints),
     ]
+
+    from .wide_store_coalescing import coalesce_wide_stores
+
+    graph_passes.append(partial(coalesce_wide_stores, trace))
 
     graph_passes += [
         partial(simplify_indices, trace, launchable.constraints),
@@ -1294,9 +1285,11 @@ def _generate_asm_code(mb, options):
     import os
     import subprocess
     import tempfile
-    from wave_lang.support.ir_imports import Context, Module, func_d
+
     from wave_lang.support.detect_waveasm import get_waveasm_translate
-    from .utils.mlir_analysis import walk_ops_recursively, should_skip_function
+    from wave_lang.support.ir_imports import Context, Module, func_d
+
+    from .utils.mlir_analysis import should_skip_function, walk_ops_recursively
 
     mlir_asm = mb.module_op.get_asm(
         enable_debug_info=options.location_capture_config.level
@@ -1430,9 +1423,10 @@ def _generate_asm_code(mb, options):
 
 def _compile_asm_to_binary(asm_code, options):
     """Compile AMDGCN assembly to binary using clang++."""
-    import tempfile
     import os
     import subprocess
+    import tempfile
+
     from wave_lang.support.detect_waveasm import get_clang
 
     clang = get_clang()

--- a/wave_lang/kernel/wave/templates/__init__.py
+++ b/wave_lang/kernel/wave/templates/__init__.py
@@ -9,6 +9,7 @@ from .tagged_attention import get_tagged_bshd_attention_kernel
 from .tagged_mxfp4_gemm import (
     get_tagged_mxfp4_gemm,
     get_tagged_mxfp4_gemm_preshuffle_b,
+    get_tagged_mxfp4_gemm_preshuffle_b_wide_store,
     get_tagged_mxfp4_gemm_preshuffle_scales,
     get_tagged_mxfp4_gemm_preshuffle_scales_and_B,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "get_tagged_bshd_attention_kernel",
     "get_tagged_mxfp4_gemm",
     "get_tagged_mxfp4_gemm_preshuffle_b",
+    "get_tagged_mxfp4_gemm_preshuffle_b_wide_store",
     "get_tagged_mxfp4_gemm_preshuffle_scales",
     "get_tagged_mxfp4_gemm_preshuffle_scales_and_B",
 ]

--- a/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
+++ b/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
@@ -17,7 +17,7 @@ Required tags: k_loop, read_a, read_a_scale, read_b, read_b_scale,
 bitcast_a, bitcast_a_scale, bitcast_b, bitcast_b_scale, scaled_mma.
 """
 
-from sympy import Eq, Piecewise, ceiling, floor, Max
+from sympy import Eq, Max, Piecewise, ceiling, floor
 
 import wave_lang.kernel.lang as tkl
 import wave_lang.kernel.wave as tkw
@@ -387,6 +387,7 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
     reorder_workgroups=True,
     group_size_n=32,
     output_dtype=tkl.f32,
+    wide_stores: bool = False,
 ):
     """Return a tagged MXFP4 scaled GEMM kernel with preshuffled B and B_scale.
 
@@ -419,6 +420,10 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
     K_PACKED = tkl.sym.K_PACKED
     K_SCALE_SHUFFLED = tkl.sym.K_SCALE_SHUFFLED
 
+    if wide_stores:
+        m_symbol = tkl.sym.m_symbol
+        n_symbol = tkl.sym.n_symbol
+
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K)]
@@ -435,6 +440,9 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
 
     # K is always large enough for software pipelining.
     constraints += [tkw.Assumption(K > BLOCK_K * 6)]
+
+    if wide_stores:
+        constraints += [tkw.IteratorBindings({m_symbol: M, n_symbol: N})]
 
     if reorder_workgroups:
         new_wg0, new_wg1 = _reorder_mxfp4_workgroups(
@@ -516,6 +524,11 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
         outputs={K: k_s, N: n_s},
     )
 
+    if wide_stores:
+        reg_dim_0, reg_dim_1 = N, M
+    else:
+        reg_dim_0, reg_dim_1 = M, N
+
     @tkw.wave(constraints)
     def gemm(
         a: tkl.Memory[M, K / 2, A_ADDRESS_SPACE, tkl.i8],
@@ -524,12 +537,12 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
         b_scale: tkl.Memory[N, K / 32, GLOBAL_ADDRESS_SPACE, tkl.i8],
         c: tkl.Memory[M, N, C_ADDRESS_SPACE, output_dtype],
     ):
-        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+        c_reg = tkl.Register[reg_dim_0, reg_dim_1, tkl.f32](0.0)
 
         @tkw.iterate(K, init_args=[c_reg], tag="k_loop")
         def repeat(
-            acc: tkl.Register[M, N, tkl.f32],
-        ) -> tkl.Register[M, N, tkl.f32]:
+            acc: tkl.Register[reg_dim_0, reg_dim_1, tkl.f32],
+        ) -> tkl.Register[reg_dim_0, reg_dim_1, tkl.f32]:
             a_reg = tkw.read(a, tag="read_a")
             a_reg = tkw.bitcast(a_reg, tkl.f4e2m1fn, tag="bitcast_a")
             a_scale_reg = tkw.read(a_scale, mapping=a_scale_mapping, tag="read_a_scale")
@@ -538,14 +551,25 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
             b_reg = tkw.bitcast(b_reg, tkl.f4e2m1fn, tag="bitcast_b")
             b_scale_reg = tkw.read(b_scale, mapping=b_scale_mapping, tag="read_b_scale")
             b_scale_reg = tkw.bitcast(b_scale_reg, tkl.f8e8m0fnu, tag="bitcast_b_scale")
-            acc = tkw.scaled_mma(
-                a_reg, a_scale_reg, b_reg, b_scale_reg, acc, tag="scaled_mma"
-            )
+            if wide_stores:
+                acc = tkw.scaled_mma(
+                    b_reg, b_scale_reg, a_reg, a_scale_reg, acc, tag="scaled_mma"
+                )
+            else:
+                acc = tkw.scaled_mma(
+                    a_reg, a_scale_reg, b_reg, b_scale_reg, acc, tag="scaled_mma"
+                )
             return acc
 
         if output_dtype == tkl.bf16:
             repeat = tkw.cast(repeat, tkl.bf16)
-        tkw.write(repeat, c)
+
+        if wide_stores:
+            tkw.write(
+                repeat, c, source=(n_symbol, m_symbol), target=(m_symbol, n_symbol)
+            )
+        else:
+            tkw.write(repeat, c)
 
     hyperparams = {
         A_ADDRESS_SPACE: a_address_space,

--- a/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
+++ b/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
@@ -10,8 +10,9 @@ Tagged MXFP4 Scaled GEMM kernel templates for CDNA4 (GFX950).
 All ops are tagged for use with MXFP4 schedule functions (e.g. get_mxfp4_dbuf_schedule).
 
 Provides:
-  - get_tagged_mxfp4_gemm:                  vanilla (A, B via LDS)
-  - get_tagged_mxfp4_gemm_preshuffle_b:     B + B_scale preshuffled (direct global reads)
+  - get_tagged_mxfp4_gemm:                           vanilla (A, B via LDS)
+  - get_tagged_mxfp4_gemm_preshuffle_b:              B + B_scale preshuffled (direct global reads)
+  - get_tagged_mxfp4_gemm_preshuffle_b_wide_store:   same + wide epilogue stores via permlane swap
 
 Required tags: k_loop, read_a, read_a_scale, read_b, read_b_scale,
 bitcast_a, bitcast_a_scale, bitcast_b, bitcast_b_scale, scaled_mma.
@@ -377,37 +378,20 @@ def get_tagged_mxfp4_gemm_preshuffle_scales_and_B(
     )
 
 
-def get_tagged_mxfp4_gemm_preshuffle_b(
-    shape: tuple[int, int, int] = (1024, 1024, 8192),
-    block_shape: tuple[int, int, int] = (256, 256, 256),
-    wave_shape: tuple[int, int] = (2, 2),
-    mfma_variant: ScaledMMAType = ScaledMMAType.F32_16x16x128_F8F6F4,
-    a_address_space: tkl.AddressSpace = SHARED_ADDRESS_SPACE,
+def _get_tagged_mxfp4_gemm_preshuffle_b_impl(
+    shape: tuple[int, int, int],
+    block_shape: tuple[int, int, int],
+    wave_shape: tuple[int, int],
+    mfma_variant: ScaledMMAType,
+    a_address_space: tkl.AddressSpace,
+    *,
     a_scale_preshuffle: bool = True,
-    reorder_workgroups=True,
-    group_size_n=32,
+    reorder_workgroups: bool = True,
+    group_size_n: int = 32,
     output_dtype=tkl.f32,
     wide_stores: bool = False,
 ):
-    """Return a tagged MXFP4 scaled GEMM kernel with preshuffled B and B_scale.
-
-    B data is read directly from global memory using a preshuffle mapping
-    (aiter shuffle_weight permutation).  B scales are also read from global
-    memory using an e8m0 scale preshuffle mapping.  A and A_scale go through
-    shared memory (LDS) as usual.
-
-    All ops are tagged for use with MXFP4 schedule functions.
-
-    Args:
-        shape: (M, N, K) problem dimensions.
-        block_shape: (BLOCK_M, BLOCK_N, BLOCK_K) tile sizes.
-        wave_shape: (WAVE_M, WAVE_N) waves per workgroup.
-        mfma_variant: Scaled MMA instruction type.
-        a_address_space: Address space for A and A_scale (typically SHARED).
-
-    Returns:
-        (kernel_function, WaveCompileOptions)
-    """
+    """Shared implementation for preshuffle-B MXFP4 GEMM with optional wide stores."""
     M = tkl.sym.M
     N = tkl.sym.N
     K = tkl.sym.K
@@ -597,6 +581,94 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
     )
 
     return gemm, options
+
+
+def get_tagged_mxfp4_gemm_preshuffle_b(
+    shape: tuple[int, int, int] = (1024, 1024, 8192),
+    block_shape: tuple[int, int, int] = (256, 256, 256),
+    wave_shape: tuple[int, int] = (2, 2),
+    mfma_variant: ScaledMMAType = ScaledMMAType.F32_16x16x128_F8F6F4,
+    a_address_space: tkl.AddressSpace = SHARED_ADDRESS_SPACE,
+    a_scale_preshuffle: bool = True,
+    reorder_workgroups=True,
+    group_size_n=32,
+    output_dtype=tkl.f32,
+):
+    """Return a tagged MXFP4 scaled GEMM kernel with preshuffled B and B_scale.
+
+    B data is read directly from global memory using a preshuffle mapping
+    (aiter shuffle_weight permutation).  B scales are also read from global
+    memory using an e8m0 scale preshuffle mapping.  A and A_scale go through
+    shared memory (LDS) as usual.
+
+    All ops are tagged for use with MXFP4 schedule functions.
+
+    Args:
+        shape: (M, N, K) problem dimensions.
+        block_shape: (BLOCK_M, BLOCK_N, BLOCK_K) tile sizes.
+        wave_shape: (WAVE_M, WAVE_N) waves per workgroup.
+        mfma_variant: Scaled MMA instruction type.
+        a_address_space: Address space for A and A_scale (typically SHARED).
+
+    Returns:
+        (kernel_function, WaveCompileOptions)
+    """
+    return _get_tagged_mxfp4_gemm_preshuffle_b_impl(
+        shape,
+        block_shape,
+        wave_shape,
+        mfma_variant,
+        a_address_space,
+        a_scale_preshuffle=a_scale_preshuffle,
+        reorder_workgroups=reorder_workgroups,
+        group_size_n=group_size_n,
+        output_dtype=output_dtype,
+        wide_stores=False,
+    )
+
+
+def get_tagged_mxfp4_gemm_preshuffle_b_wide_store(
+    shape: tuple[int, int, int] = (1024, 1024, 8192),
+    block_shape: tuple[int, int, int] = (256, 256, 256),
+    wave_shape: tuple[int, int] = (2, 2),
+    mfma_variant: ScaledMMAType = ScaledMMAType.F32_16x16x128_F8F6F4,
+    a_address_space: tkl.AddressSpace = SHARED_ADDRESS_SPACE,
+    a_scale_preshuffle: bool = True,
+    reorder_workgroups=True,
+    group_size_n=32,
+    output_dtype=tkl.bf16,
+):
+    """Return a tagged MXFP4 scaled GEMM kernel with preshuffled B, B_scale, and wide stores.
+
+    Like :func:`get_tagged_mxfp4_gemm_preshuffle_b` but swaps MFMA operands
+    (B as LHS, A as RHS) so the accumulator's 4-contiguous values align with
+    the output memory's stride-1 dimension.  The ``coalesce_wide_stores`` pass
+    emits ``v_permlane16_swap_b32`` + ``buffer_store_dwordx4`` (8 bf16 per
+    store) instead of scalar ``buffer_store_short``.
+
+    Args:
+        shape: (M, N, K) problem dimensions.
+        block_shape: (BLOCK_M, BLOCK_N, BLOCK_K) tile sizes.
+        wave_shape: (WAVE_M, WAVE_N) waves per workgroup.
+        mfma_variant: Scaled MMA instruction type.
+        a_address_space: Address space for A and A_scale (typically SHARED).
+        output_dtype: Output element type (default bf16).
+
+    Returns:
+        (kernel_function, WaveCompileOptions)
+    """
+    return _get_tagged_mxfp4_gemm_preshuffle_b_impl(
+        shape,
+        block_shape,
+        wave_shape,
+        mfma_variant,
+        a_address_space,
+        a_scale_preshuffle=a_scale_preshuffle,
+        reorder_workgroups=reorder_workgroups,
+        group_size_n=group_size_n,
+        output_dtype=output_dtype,
+        wide_stores=True,
+    )
 
 
 def _reorder_mxfp4_workgroups(m, n, block_m, block_n, group_size_n):

--- a/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
+++ b/wave_lang/kernel/wave/templates/tagged_mxfp4_gemm.py
@@ -443,6 +443,8 @@ def get_tagged_mxfp4_gemm_preshuffle_b(
 
     if wide_stores:
         constraints += [tkw.IteratorBindings({m_symbol: M, n_symbol: N})]
+        constraints += [tkw.Assumption(Eq(M % BLOCK_M, 0))]
+        constraints += [tkw.Assumption(Eq(N % BLOCK_N, 0))]
 
     if reorder_workgroups:
         new_wg0, new_wg1 = _reorder_mxfp4_workgroups(

--- a/wave_lang/kernel/wave/wide_store_coalescing.py
+++ b/wave_lang/kernel/wave/wide_store_coalescing.py
@@ -13,6 +13,11 @@ remapping pattern (indicating swapped operands) and tags them so the
 codegen emits v_permlane16_swap_b32 + buffer_store_dwordx4 instead of
 scalar buffer_store_short.
 
+Eligible writes are paired so that each lane in a (lane, lane+16)
+pair writes a *different* tile group's wide store, eliminating the
+duplicate stores that occur when both lanes write the same data.
+The number of eligible writes must be even (asserted).
+
 Only tags writes that satisfy ALL conditions:
   1. Target memory is global address space
   2. Output dtype is bf16
@@ -34,11 +39,16 @@ def coalesce_wide_stores(trace: CapturedTrace):
     pattern (swapped MFMA operands, as produced by the wide_store kernel
     variant). Writes without source/target are left untouched, making
     this pass safe to run unconditionally.
+
+    Writes are paired for register-only deduplication: the first node
+    in each pair stashes its codegen state, and the second triggers a
+    paired ``permlane16_swap`` that lets each lane emit a unique store.
     """
     import wave_lang.kernel.lang as tkl
 
     root_graph = trace.get_root_graph()
 
+    eligible_writes = []
     for node in root_graph.nodes:
         if node.op != "call_function":
             continue
@@ -52,4 +62,23 @@ def coalesce_wide_stores(trace: CapturedTrace):
             subs_idxc(mem_type.address_space) == GLOBAL_ADDRESS_SPACE
             and mem_type.dtype == tkl.bf16
         ):
-            node._permlane_pack_global = True
+            eligible_writes.append(node)
+
+    # TODO: Add a fallback path for odd number of writes.
+    assert len(eligible_writes) % 2 == 0, (
+        f"Expected even number of eligible wide-store writes, "
+        f"got {len(eligible_writes)}."
+    )
+
+    # Pair adjacent writes so the codegen can pass both tiles as
+    # separate old_dst / src operands to a single permlane16_swap.
+    # The "first" node stashes its codegen state; the "second" node
+    # retrieves it and emits one unique store per lane (lower lane
+    # writes tile A, upper lane writes tile B) — no duplicate stores.
+    for first, second in zip(eligible_writes[0::2], eligible_writes[1::2]):
+        first._permlane_pack_global = True
+        first._permlane_pack_role = "first"
+        first._permlane_partner = second
+        second._permlane_pack_global = True
+        second._permlane_pack_role = "second"
+        second._permlane_partner = first

--- a/wave_lang/kernel/wave/wide_store_coalescing.py
+++ b/wave_lang/kernel/wave/wide_store_coalescing.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Graph pass that tags eligible epilogue bf16 stores for wide store coalescing.
+
+When a kernel uses swapped MFMA operands (wide_stores=True), the
+accumulator's 4-contiguous values align with the output's stride-1
+dimension. This pass identifies Write nodes that use the source/target
+dimension remapping pattern (indicating swapped operands) and tags them
+so the codegen emits v_permlane16_swap_b32 + buffer_store_dwordx4
+instead of scalar buffer_store_short.
+
+Only tags writes that satisfy ALL conditions:
+  1. Target memory is global address space
+  2. Output dtype is bf16
+  3. Write uses source/target syntax (swapped-operand layout)
+"""
+
+from .._support.tracing import CapturedTrace
+from ..lang.global_symbols import GLOBAL_ADDRESS_SPACE
+from ..ops.wave_ops import Write, get_custom
+from .region_canonicalization import RegionFormat, requires_region_format
+from .utils.symbol_utils import subs_idxc
+
+
+@requires_region_format(RegionFormat.SCHEDULE_SIGNATURE_PLACEHOLDERS)
+def coalesce_wide_stores(trace: CapturedTrace):
+    """Tag eligible bf16 global writes for permlane16_swap wide stores.
+
+    Only tags Write nodes that use the source/target dimension remapping
+    pattern, which indicates the kernel was built with ``wide_stores=True``
+    (swapped MFMA operands). Writes without source/target are left
+    untouched, making this pass safe to run unconditionally.
+    """
+    import wave_lang.kernel.lang as tkl
+
+    root_graph = trace.get_root_graph()
+
+    for node in root_graph.nodes:
+        if node.op != "call_function":
+            continue
+        custom = get_custom(node)
+        if not isinstance(custom, Write):
+            continue
+        if custom.source is None or custom.target is None:
+            continue
+        mem_type = custom.memory_type
+        if (
+            subs_idxc(mem_type.address_space) == GLOBAL_ADDRESS_SPACE
+            and mem_type.dtype == tkl.bf16
+        ):
+            node._permlane_pack_global = True

--- a/wave_lang/kernel/wave/wide_store_coalescing.py
+++ b/wave_lang/kernel/wave/wide_store_coalescing.py
@@ -5,12 +5,13 @@
 """
 Graph pass that tags eligible epilogue bf16 stores for wide store coalescing.
 
-When a kernel uses swapped MFMA operands (wide_stores=True), the
-accumulator's 4-contiguous values align with the output's stride-1
-dimension. This pass identifies Write nodes that use the source/target
-dimension remapping pattern (indicating swapped operands) and tags them
-so the codegen emits v_permlane16_swap_b32 + buffer_store_dwordx4
-instead of scalar buffer_store_short.
+When a kernel uses swapped MFMA operands (e.g.
+``get_tagged_mxfp4_gemm_preshuffle_b_wide_store``), the accumulator's
+4-contiguous values align with the output's stride-1 dimension. This
+pass identifies Write nodes that use the source/target dimension
+remapping pattern (indicating swapped operands) and tags them so the
+codegen emits v_permlane16_swap_b32 + buffer_store_dwordx4 instead of
+scalar buffer_store_short.
 
 Only tags writes that satisfy ALL conditions:
   1. Target memory is global address space
@@ -30,9 +31,9 @@ def coalesce_wide_stores(trace: CapturedTrace):
     """Tag eligible bf16 global writes for permlane16_swap wide stores.
 
     Only tags Write nodes that use the source/target dimension remapping
-    pattern, which indicates the kernel was built with ``wide_stores=True``
-    (swapped MFMA operands). Writes without source/target are left
-    untouched, making this pass safe to run unconditionally.
+    pattern (swapped MFMA operands, as produced by the wide_store kernel
+    variant). Writes without source/target are left untouched, making
+    this pass safe to run unconditionally.
     """
     import wave_lang.kernel.lang as tkl
 


### PR DESCRIPTION
## Wide epilogue stores for bf16 MXFP4 GEMM via `v_permlane16_swap`

In MXFP4 GEMM kernels with bf16 output, the MMA accumulator layout (`F32_16x16x128_F8F6F4`) distributes results across threads in a non-contiguous pattern each thread holds 4 values spanning 4 rows but only 1 column. Without optimization, the epilogue emits 192 scalar `buffer_store_short` (2 bytes each), underutilizing memory bandwidth.

This PR adds a `wide_stores` that swaps MFMA operands (B as LHS, A as RHS) and uses `v_permlane16_swap_b32` to coalesce epilogue stores into `buffer_store_dwordx4` (16 bytes each), reducing store count from 192 to 48.

### How it works
**Swapped MFMA operands (`wide_stores=True`):** The kernel computes C^T = B × A^T (and stores C) instead of C = A × B^T, making the accumulator's 4-contiguous values align with the output memory's stride-1 dimension. The source/target write syntax maps `Register[N, M]` to `Memory[M, N]` so the output is C [M, N] directly.

**`wide_store_coalescing` pass:** An always-on graph pass that identifies eligible bf16 global Write nodes using the source/target dimension remapping pattern (indicating swapped operands). Only tags writes that satisfy all conditions: global address space, bf16 dtype, and source/target syntax. Safe to run unconditionally, non-`wide_stores` kernels are unaffected.

**`_write_permlane_pack_to_global` codegen:** At code generation time, tagged writes emit `v_permlane16_swap_b32` to exchange each thread's 4 bf16 values (packed as 2 i32 dwords) with a partner lane 16 positions apart. Both lane halves write identical 8-bf16 vectors to the same address (benign duplicate store), avoiding divergent control flow. The buffer descriptor's `valid_bytes` handles out-of-bounds suppression for dynamic shapes.

### Assembly comparison (shape 1024×3072×8192, block 256×192×256)

| Instruction | Baseline | Wide Stores | Change |
|---|---|---|---|
| `buffer_store_short` | 192 | 0 | eliminated |
| `buffer_store_dwordx4` | 0 | 48 | 16B/store |
| `v_permlane16_swap` | 0 | 96 | lane exchange |
| `v_cvt_pk_bf16_f32` | 192 | 96 | 2x reduction |
| Total asm lines | 12,115 | 9,322 | 23% fewer |

LLVM now emits `v_cvt_pk_bf16_f32` natively (bf16 softening has been fixed upstream), so the paired f32->bf16 conversion is a single instruction.

Compute-bound shapes (large K) show 6-9% gains; small-K shapes show 13-27% gains

| Shape (M, N, K) | Baseline TFLOPS | Wide Stores TFLOPS | Speedup |
|---|---|---|---|
| (315904, 384, 1792) | 1169.51 | 1557.86 | 1.332x |
| (20480, 1152, 28928) | 2714.36 | 3015.93 | 1.111x |
| (5888, 1920, 3328) | 1582.35 | 2104.81 | 1.330x |
| (46336, 2688, 8448) | 2495.16 | 2940.50 | 1.179x |
| (512, 3072, 428288) | 590.71 | 648.15 | 1.097x |
| (256, 4224, 102656) | 409.79 | 458.95 | 1.120x |
| (512, 4224, 55808) | 794.47 | 893.25 | 1.124x |
| (4864, 4608, 2560) | 1435.43 | 2123.30 | 1.479x |
| (4864, 4608, 5888) | 2083.50 | 2669.39 | 1.281x |
| (4608, 4992, 7424) | 2227.52 | 2813.12 | 1.263x |
| (2048, 5376, 63232) | 3112.73 | 3405.23 | 1.094x |
| (2048, 5760, 6400) | 2230.97 | 2690.92 | 1.206x |
| (3584, 6912, 548608) | 3272.81 | 3531.95 | 1.079x |
| (4864, 7680, 7936) | 2406.89 | 3036.57 | 1.262x |
| (13056, 10368, 15360) | 2936.09 | 3352.67 | 1.142x |
| (14848, 12672, 10496) | 2781.61 | 3254.58 | 1.170x |
| (1792, 19968, 60928) | 3115.72 | 3392.02 | 1.089x |