### PR TITLE
[water] Add --mlir-edit-ir-{before,after,all} pass instrumentation

### DIFF
--- a/water/include/water/Transforms/EditIR.h
+++ b/water/include/water/Transforms/EditIR.h
@@ -1,0 +1,43 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef WATER_TRANSFORMS_EDITIR_H
+#define WATER_TRANSFORMS_EDITIR_H
+
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/PassInstrumentation.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <functional>
+#include <memory>
+
+namespace mlir::water {
+
+/// Write the IR of `op` to a temporary file, open it in an editor, block
+/// until the user presses Enter, then re-parse the file and replace the
+/// operation's regions and attributes with the edited content.
+///
+/// `editor` overrides the editor command; when empty, $EDITOR is used.
+/// `passLabel` is used in the prompt to identify which pass triggered the
+/// edit.
+///
+/// Returns failure if any step (temp file, parse, region replacement) fails.
+LogicalResult editIRInteractively(Operation *op, llvm::StringRef editor = "",
+                                  llvm::StringRef passLabel = "");
+
+using PassFilter = std::function<bool(Pass *, Operation *)>;
+
+/// Create a PassInstrumentation that calls `editIRInteractively` before/after
+/// passes matched by the respective filter. Either filter may be null to
+/// skip that hook.
+std::unique_ptr<PassInstrumentation>
+createEditIRInstrumentation(PassFilter shouldEditBefore,
+                            PassFilter shouldEditAfter,
+                            llvm::StringRef editor = "");
+
+} // namespace mlir::water
+
+#endif // WATER_TRANSFORMS_EDITIR_H

--- a/water/lib/Transforms/CMakeLists.txt
+++ b/water/lib/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRWaterTransforms
   AssembleISA.cpp
   CheckStaticAssertions.cpp
   DropTransformOps.cpp
+  EditIR.cpp
   GPUModuleToBinary.cpp
   GPUToGPURuntime.cpp
   MemrefDecomposition.cpp
@@ -26,6 +27,7 @@ add_mlir_dialect_library(MLIRWaterTransforms
   MLIRIR
   MLIRLLVMDialect
   MLIRMemRefDialect
+  MLIRParser
   MLIRPass
   MLIRRewrite
   MLIRROCDLTarget

--- a/water/lib/Transforms/EditIR.cpp
+++ b/water/lib/Transforms/EditIR.cpp
@@ -85,54 +85,66 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
   if (!editorCmd.empty())
     tryOpenInEditor(editorCmd, tmpPath, op);
 
-  // Prompt the user and wait for Enter (or EOF).
   llvm::outs() << "=== water-edit-ir";
   if (!passLabel.empty())
     llvm::outs() << " " << passLabel;
   llvm::outs() << " ===\n"
                << "IR written to: " << tmpPath << "\n"
-               << "Edit the file, then press Enter to continue "
-                  "compilation...\n";
+               << "Press Enter to continue, or 'q' to abort compilation...\n";
   llvm::outs().flush();
 
-  // fgets instead of std::cin to avoid pulling in <iostream> (static
-  // initializers). Buffer only needs to hold '\n' + '\0'.
-  char buf[2];
-  (void)std::fgets(buf, sizeof(buf), stdin);
+  while (true) {
+    int first = std::getchar();
+    if (first == EOF || first == 'q' || first == 'Q')
+      return failure();
+    // Drain the rest of the line so nothing leaks into the next iteration.
+    for (int c = first; c != '\n' && c != EOF;)
+      c = std::getchar();
 
-  // Re-parse the (potentially edited) file.
-  auto fileOrErr = llvm::MemoryBuffer::getFile(tmpPath);
-  if (!fileOrErr)
-    return op->emitError() << "failed to read edited file: "
-                           << fileOrErr.getError().message();
+    auto fileOrErr = llvm::MemoryBuffer::getFile(tmpPath);
+    if (!fileOrErr)
+      return op->emitError() << "failed to read edited file: "
+                             << fileOrErr.getError().message();
 
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
-  SourceMgrDiagnosticHandler diagHandler(sourceMgr, context);
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
 
-  OwningOpRef<Operation *> parsedOp =
-      parseSourceFile<Operation *>(sourceMgr, context);
-  if (!parsedOp)
-    return failure(); // Parser already emitted diagnostics.
+    std::string diagStr;
+    llvm::raw_string_ostream diagOS(diagStr);
+    SourceMgrDiagnosticHandler diagHandler(sourceMgr, context, diagOS);
 
-  if (op->getName() != (*parsedOp)->getName())
-    return op->emitError()
-           << "edited IR has a different top-level operation ('"
-           << (*parsedOp)->getName() << "' vs '" << op->getName() << "')";
+    OwningOpRef<Operation *> parsedOp =
+        parseSourceFile<Operation *>(sourceMgr, context);
 
-  // Replace the operation's regions, attributes, and properties.
-  unsigned numRegions = op->getNumRegions();
-  for (unsigned i = 0; i < numRegions; ++i) {
-    Region &existing = op->getRegion(i);
-    Region &parsed = (*parsedOp)->getRegion(i);
+    if (parsedOp) {
+      if (op->getName() != (*parsedOp)->getName())
+        return op->emitError()
+               << "edited IR has a different top-level operation ('"
+               << (*parsedOp)->getName() << "' vs '" << op->getName() << "')";
 
-    existing.getBlocks().clear();
-    existing.getBlocks().splice(existing.getBlocks().end(), parsed.getBlocks());
+      unsigned numRegions = op->getNumRegions();
+      for (unsigned i = 0; i < numRegions; ++i) {
+        Region &existing = op->getRegion(i);
+        Region &parsed = (*parsedOp)->getRegion(i);
+        existing.getBlocks().clear();
+        existing.getBlocks().splice(existing.getBlocks().end(),
+                                    parsed.getBlocks());
+      }
+      op->setAttrs((*parsedOp)->getAttrDictionary());
+      op->copyProperties((*parsedOp)->getPropertiesStorage());
+      return success();
+    }
+
+    // Parse failed -- print diagnostics and re-prompt.
+    // The file is left untouched so that line numbers remain correct.
+    llvm::outs() << "Failed to parse edited IR:\n"
+                 << diagStr
+                 << "Press Enter to retry, or 'q' to abort compilation...\n";
+    llvm::outs().flush();
+
+    if (!editorCmd.empty())
+      tryOpenInEditor(editorCmd, tmpPath, op);
   }
-
-  op->setAttrs((*parsedOp)->getAttrDictionary());
-  op->copyProperties((*parsedOp)->getPropertiesStorage());
-  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/water/lib/Transforms/EditIR.cpp
+++ b/water/lib/Transforms/EditIR.cpp
@@ -77,7 +77,7 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
              << "failed to open temporary file for writing: " << ec.message();
     if (!passLabel.empty())
       tmpFile << "// -----// IR Edit " << passLabel << " //----- //\n";
-    op->print(tmpFile);
+    op->print(tmpFile, OpPrintingFlags().enableDebugInfo());
     tmpFile << '\n';
   }
 

--- a/water/lib/Transforms/EditIR.cpp
+++ b/water/lib/Transforms/EditIR.cpp
@@ -10,7 +10,6 @@
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
 
-#include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -21,8 +20,6 @@
 
 #include <cstdio>
 #include <string>
-
-#define DEBUG_TYPE "edit-ir"
 
 using namespace mlir;
 
@@ -42,11 +39,12 @@ static std::string resolveEditor(StringRef editorOverride) {
 
 /// Try to open `path` in `editorCmd`. Failures are non-fatal (the user can
 /// always open the file manually via the printed path).
-static void tryOpenInEditor(StringRef editorCmd, StringRef path) {
+static void tryOpenInEditor(StringRef editorCmd, StringRef path,
+                            Operation *op) {
   auto program = llvm::sys::findProgramByName(editorCmd);
-  if (!program) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "edit-ir: editor '" << editorCmd << "' not found in PATH\n");
+  if (std::error_code ec = program.getError()) {
+    op->emitWarning() << "could not find editor '" << editorCmd
+                      << "': " << ec.message();
     return;
   }
 
@@ -55,8 +53,7 @@ static void tryOpenInEditor(StringRef editorCmd, StringRef path) {
   llvm::sys::ExecuteNoWait(*program, args, /*Env=*/std::nullopt,
                            /*Redirects=*/{}, /*MemoryLimit=*/0, &errMsg);
   if (!errMsg.empty())
-    LLVM_DEBUG(llvm::dbgs()
-               << "edit-ir: failed to launch editor: " << errMsg << "\n");
+    op->emitWarning() << "failed to launch editor: " << errMsg;
 }
 
 LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
@@ -73,7 +70,7 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
 
   llvm::FileRemover tmpFileRemover(tmpPath);
 
-  {
+  { // Scope ensures the file is flushed and closed before the editor opens it.
     llvm::raw_fd_ostream tmpFile(tmpPath, ec);
     if (ec)
       return op->emitError()
@@ -86,20 +83,21 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
 
   std::string editorCmd = resolveEditor(editor);
   if (!editorCmd.empty())
-    tryOpenInEditor(editorCmd, tmpPath);
+    tryOpenInEditor(editorCmd, tmpPath, op);
 
   // Prompt the user and wait for Enter (or EOF).
-  llvm::errs() << "=== mlir-edit-ir";
+  llvm::outs() << "=== water-edit-ir";
   if (!passLabel.empty())
-    llvm::errs() << " " << passLabel;
-  llvm::errs() << " ===\n"
+    llvm::outs() << " " << passLabel;
+  llvm::outs() << " ===\n"
                << "IR written to: " << tmpPath << "\n"
                << "Edit the file, then press Enter to continue "
                   "compilation...\n";
+  llvm::outs().flush();
 
   // fgets instead of std::cin to avoid pulling in <iostream> (static
-  // initializers).
-  char buf[64];
+  // initializers). Buffer only needs to hold '\n' + '\0'.
+  char buf[2];
   (void)std::fgets(buf, sizeof(buf), stdin);
 
   // Re-parse the (potentially edited) file.
@@ -115,10 +113,16 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
   OwningOpRef<Operation *> parsedOp =
       parseSourceFile<Operation *>(sourceMgr, context);
   if (!parsedOp)
-    return op->emitError("failed to parse edited IR");
+    return failure(); // Parser already emitted diagnostics.
 
-  // Replace the operation's regions and attributes with the parsed content.
-  for (unsigned i = 0; i < op->getNumRegions(); ++i) {
+  if (op->getName() != (*parsedOp)->getName())
+    return op->emitError()
+           << "edited IR has a different top-level operation ('"
+           << (*parsedOp)->getName() << "' vs '" << op->getName() << "')";
+
+  // Replace the operation's regions, attributes, and properties.
+  unsigned numRegions = op->getNumRegions();
+  for (unsigned i = 0; i < numRegions; ++i) {
     Region &existing = op->getRegion(i);
     Region &parsed = (*parsedOp)->getRegion(i);
 
@@ -127,11 +131,12 @@ LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
   }
 
   op->setAttrs((*parsedOp)->getAttrDictionary());
+  op->copyProperties((*parsedOp)->getPropertiesStorage());
   return success();
 }
 
 //===----------------------------------------------------------------------===//
-// PassInstrumentation for --mlir-edit-ir-{before,after}
+// PassInstrumentation for --water-edit-ir-{before,after}
 //===----------------------------------------------------------------------===//
 
 namespace {

--- a/water/lib/Transforms/EditIR.cpp
+++ b/water/lib/Transforms/EditIR.cpp
@@ -1,0 +1,174 @@
+// Copyright 2026 The Wave Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "water/Transforms/EditIR.h"
+
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdio>
+#include <string>
+
+#define DEBUG_TYPE "edit-ir"
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Shared helpers
+//===----------------------------------------------------------------------===//
+
+/// Resolve which editor command to use: the explicit override if non-empty,
+/// otherwise $EDITOR. Returns an empty string when neither is available.
+static std::string resolveEditor(StringRef editorOverride) {
+  if (!editorOverride.empty())
+    return editorOverride.str();
+  if (auto env = llvm::sys::Process::GetEnv("EDITOR"))
+    return *env;
+  return "";
+}
+
+/// Try to open `path` in `editorCmd`. Failures are non-fatal (the user can
+/// always open the file manually via the printed path).
+static void tryOpenInEditor(StringRef editorCmd, StringRef path) {
+  auto program = llvm::sys::findProgramByName(editorCmd);
+  if (!program) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "edit-ir: editor '" << editorCmd << "' not found in PATH\n");
+    return;
+  }
+
+  SmallVector<StringRef> args = {editorCmd, path};
+  std::string errMsg;
+  llvm::sys::ExecuteNoWait(*program, args, /*Env=*/std::nullopt,
+                           /*Redirects=*/{}, /*MemoryLimit=*/0, &errMsg);
+  if (!errMsg.empty())
+    LLVM_DEBUG(llvm::dbgs()
+               << "edit-ir: failed to launch editor: " << errMsg << "\n");
+}
+
+LogicalResult mlir::water::editIRInteractively(Operation *op, StringRef editor,
+                                               StringRef passLabel) {
+  MLIRContext *context = op->getContext();
+
+  // Write the current IR to a temporary file.
+  SmallString<128> tmpPath;
+  std::error_code ec =
+      llvm::sys::fs::createTemporaryFile("water-edit", "mlir", tmpPath);
+  if (ec)
+    return op->emitError() << "failed to create temporary file: "
+                           << ec.message();
+
+  llvm::FileRemover tmpFileRemover(tmpPath);
+
+  {
+    llvm::raw_fd_ostream tmpFile(tmpPath, ec);
+    if (ec)
+      return op->emitError()
+             << "failed to open temporary file for writing: " << ec.message();
+    if (!passLabel.empty())
+      tmpFile << "// -----// IR Edit " << passLabel << " //----- //\n";
+    op->print(tmpFile);
+    tmpFile << '\n';
+  }
+
+  std::string editorCmd = resolveEditor(editor);
+  if (!editorCmd.empty())
+    tryOpenInEditor(editorCmd, tmpPath);
+
+  // Prompt the user and wait for Enter (or EOF).
+  llvm::errs() << "=== mlir-edit-ir";
+  if (!passLabel.empty())
+    llvm::errs() << " " << passLabel;
+  llvm::errs() << " ===\n"
+               << "IR written to: " << tmpPath << "\n"
+               << "Edit the file, then press Enter to continue "
+                  "compilation...\n";
+
+  // fgets instead of std::cin to avoid pulling in <iostream> (static
+  // initializers).
+  char buf[64];
+  (void)std::fgets(buf, sizeof(buf), stdin);
+
+  // Re-parse the (potentially edited) file.
+  auto fileOrErr = llvm::MemoryBuffer::getFile(tmpPath);
+  if (!fileOrErr)
+    return op->emitError() << "failed to read edited file: "
+                           << fileOrErr.getError().message();
+
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
+  SourceMgrDiagnosticHandler diagHandler(sourceMgr, context);
+
+  OwningOpRef<Operation *> parsedOp =
+      parseSourceFile<Operation *>(sourceMgr, context);
+  if (!parsedOp)
+    return op->emitError("failed to parse edited IR");
+
+  // Replace the operation's regions and attributes with the parsed content.
+  for (unsigned i = 0; i < op->getNumRegions(); ++i) {
+    Region &existing = op->getRegion(i);
+    Region &parsed = (*parsedOp)->getRegion(i);
+
+    existing.getBlocks().clear();
+    existing.getBlocks().splice(existing.getBlocks().end(), parsed.getBlocks());
+  }
+
+  op->setAttrs((*parsedOp)->getAttrDictionary());
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PassInstrumentation for --mlir-edit-ir-{before,after}
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class EditIRInstrumentation : public PassInstrumentation {
+public:
+  EditIRInstrumentation(water::PassFilter shouldEditBefore,
+                        water::PassFilter shouldEditAfter, StringRef editor)
+      : shouldEditBefore(std::move(shouldEditBefore)),
+        shouldEditAfter(std::move(shouldEditAfter)), editor(editor.str()) {}
+
+  void runBeforePass(Pass *pass, Operation *op) override {
+    if (!shouldEditBefore || !shouldEditBefore(pass, op))
+      return;
+    std::string label = ("before " + pass->getArgument()).str();
+    if (failed(water::editIRInteractively(op, editor, label)))
+      signalPassFailure(pass);
+  }
+
+  void runAfterPass(Pass *pass, Operation *op) override {
+    if (!shouldEditAfter || !shouldEditAfter(pass, op))
+      return;
+    std::string label = ("after " + pass->getArgument()).str();
+    if (failed(water::editIRInteractively(op, editor, label)))
+      signalPassFailure(pass);
+  }
+
+private:
+  water::PassFilter shouldEditBefore;
+  water::PassFilter shouldEditAfter;
+  std::string editor;
+};
+
+} // namespace
+
+std::unique_ptr<PassInstrumentation> mlir::water::createEditIRInstrumentation(
+    PassFilter shouldEditBefore, PassFilter shouldEditAfter, StringRef editor) {
+  return std::make_unique<EditIRInstrumentation>(
+      std::move(shouldEditBefore), std::move(shouldEditAfter), editor);
+}

--- a/water/test/Transforms/edit-ir.mlir
+++ b/water/test/Transforms/edit-ir.mlir
@@ -1,52 +1,52 @@
-// Test --mlir-edit-ir-{before,after}[-all] instrumentation.
+// Test --water-edit-ir-{before,after}[-all] instrumentation.
 //
 // When stdin is empty / EOF, the interactive prompt returns immediately and
 // the IR round-trips through write-to-file / re-parse / replace unchanged.
 
-// --- 1. --mlir-edit-ir-after fires only for the named pass ----------------
+// --- 1. --water-edit-ir-after fires only for the named pass ----------------
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
-// RUN:   --mlir-edit-ir-after=canonicalize -o /dev/null 2>&1 \
+// RUN:   --water-edit-ir-after=canonicalize -o /dev/null \
 // RUN:   | FileCheck -check-prefix=AFTER %s
 
-// AFTER-NOT: === mlir-edit-ir before
-// AFTER:     === mlir-edit-ir after canonicalize ===
-// AFTER-NOT: === mlir-edit-ir after cse ===
+// AFTER-NOT: === water-edit-ir before
+// AFTER:     === water-edit-ir after canonicalize ===
+// AFTER-NOT: === water-edit-ir after cse ===
 
-// --- 2. --mlir-edit-ir-before fires only for the named pass ---------------
+// --- 2. --water-edit-ir-before fires only for the named pass ---------------
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
-// RUN:   --mlir-edit-ir-before=cse -o /dev/null 2>&1 \
+// RUN:   --water-edit-ir-before=cse -o /dev/null \
 // RUN:   | FileCheck -check-prefix=BEFORE %s
 
-// BEFORE-NOT: === mlir-edit-ir before canonicalize ===
-// BEFORE:     === mlir-edit-ir before cse ===
-// BEFORE-NOT: === mlir-edit-ir after
+// BEFORE-NOT: === water-edit-ir before canonicalize ===
+// BEFORE:     === water-edit-ir before cse ===
+// BEFORE-NOT: === water-edit-ir after
 
-// --- 3. --mlir-edit-ir-after-all fires for every pass ---------------------
+// --- 3. --water-edit-ir-after-all fires for every pass ---------------------
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
-// RUN:   --mlir-edit-ir-after-all -o /dev/null 2>&1 \
+// RUN:   --water-edit-ir-after-all -o /dev/null \
 // RUN:   | FileCheck -check-prefix=AFTER_ALL %s
 
-// AFTER_ALL-NOT: === mlir-edit-ir before
-// AFTER_ALL:     === mlir-edit-ir after canonicalize ===
-// AFTER_ALL:     === mlir-edit-ir after cse ===
+// AFTER_ALL-NOT: === water-edit-ir before
+// AFTER_ALL:     === water-edit-ir after canonicalize ===
+// AFTER_ALL:     === water-edit-ir after cse ===
 
-// --- 4. --mlir-edit-ir-before-all fires for every pass --------------------
+// --- 4. --water-edit-ir-before-all fires for every pass --------------------
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
-// RUN:   --mlir-edit-ir-before-all -o /dev/null 2>&1 \
+// RUN:   --water-edit-ir-before-all -o /dev/null \
 // RUN:   | FileCheck -check-prefix=BEFORE_ALL %s
 
-// BEFORE_ALL-NOT: === mlir-edit-ir after
-// BEFORE_ALL:     === mlir-edit-ir before canonicalize ===
-// BEFORE_ALL:     === mlir-edit-ir before cse ===
+// BEFORE_ALL-NOT: === water-edit-ir after
+// BEFORE_ALL:     === water-edit-ir before canonicalize ===
+// BEFORE_ALL:     === water-edit-ir before cse ===
 
 // --- 5. Round-trip: pipeline result is identical with and without edit -----
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
-// RUN:   --mlir-edit-ir-after=canonicalize \
+// RUN:   --water-edit-ir-after=canonicalize \
 // RUN:   | FileCheck -check-prefix=ROUNDTRIP %s
 
 // ROUNDTRIP-LABEL: func.func @foo

--- a/water/test/Transforms/edit-ir.mlir
+++ b/water/test/Transforms/edit-ir.mlir
@@ -1,0 +1,61 @@
+// Test --mlir-edit-ir-{before,after}[-all] instrumentation.
+//
+// When stdin is empty / EOF, the interactive prompt returns immediately and
+// the IR round-trips through write-to-file / re-parse / replace unchanged.
+
+// --- 1. --mlir-edit-ir-after fires only for the named pass ----------------
+// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --mlir-edit-ir-after=canonicalize -o /dev/null 2>&1 \
+// RUN:   | FileCheck -check-prefix=AFTER %s
+
+// AFTER-NOT: === mlir-edit-ir before
+// AFTER:     === mlir-edit-ir after canonicalize ===
+// AFTER-NOT: === mlir-edit-ir after cse ===
+
+// --- 2. --mlir-edit-ir-before fires only for the named pass ---------------
+// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --mlir-edit-ir-before=cse -o /dev/null 2>&1 \
+// RUN:   | FileCheck -check-prefix=BEFORE %s
+
+// BEFORE-NOT: === mlir-edit-ir before canonicalize ===
+// BEFORE:     === mlir-edit-ir before cse ===
+// BEFORE-NOT: === mlir-edit-ir after
+
+// --- 3. --mlir-edit-ir-after-all fires for every pass ---------------------
+// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --mlir-edit-ir-after-all -o /dev/null 2>&1 \
+// RUN:   | FileCheck -check-prefix=AFTER_ALL %s
+
+// AFTER_ALL-NOT: === mlir-edit-ir before
+// AFTER_ALL:     === mlir-edit-ir after canonicalize ===
+// AFTER_ALL:     === mlir-edit-ir after cse ===
+
+// --- 4. --mlir-edit-ir-before-all fires for every pass --------------------
+// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --mlir-edit-ir-before-all -o /dev/null 2>&1 \
+// RUN:   | FileCheck -check-prefix=BEFORE_ALL %s
+
+// BEFORE_ALL-NOT: === mlir-edit-ir after
+// BEFORE_ALL:     === mlir-edit-ir before canonicalize ===
+// BEFORE_ALL:     === mlir-edit-ir before cse ===
+
+// --- 5. Round-trip: pipeline result is identical with and without edit -----
+// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --mlir-edit-ir-after=canonicalize \
+// RUN:   | FileCheck -check-prefix=ROUNDTRIP %s
+
+// ROUNDTRIP-LABEL: func.func @foo
+// ROUNDTRIP-NEXT:    return %arg0 : i32
+
+module {
+  func.func @foo(%arg0: i32) -> i32 {
+    %c0 = arith.constant 0 : i32
+    %add = arith.addi %arg0, %c0 : i32
+    return %add : i32
+  }
+}

--- a/water/test/Transforms/edit-ir.mlir
+++ b/water/test/Transforms/edit-ir.mlir
@@ -1,7 +1,8 @@
 // Test --water-edit-ir-{before,after}[-all] instrumentation.
 //
-// When stdin is empty / EOF, the interactive prompt returns immediately and
-// the IR round-trips through write-to-file / re-parse / replace unchanged.
+// Each edit-IR stop reads one line from stdin; pressing Enter (or a piped
+// newline) continues, 'q' or EOF aborts. The -all tests pipe two newlines
+// because the pipeline has two passes.
 
 // --- 1. --water-edit-ir-after fires only for the named pass ----------------
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
@@ -24,7 +25,7 @@
 // BEFORE-NOT: === water-edit-ir after
 
 // --- 3. --water-edit-ir-after-all fires for every pass ---------------------
-// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN: printf '\n\n' | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
 // RUN:   --water-edit-ir-after-all -o /dev/null \
 // RUN:   | FileCheck -check-prefix=AFTER_ALL %s
@@ -34,7 +35,7 @@
 // AFTER_ALL:     === water-edit-ir after cse ===
 
 // --- 4. --water-edit-ir-before-all fires for every pass --------------------
-// RUN: echo "" | water-opt %s -mlir-disable-threading=true \
+// RUN: printf '\n\n' | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
 // RUN:   --water-edit-ir-before-all -o /dev/null \
 // RUN:   | FileCheck -check-prefix=BEFORE_ALL %s
@@ -43,7 +44,16 @@
 // BEFORE_ALL:     === water-edit-ir before canonicalize ===
 // BEFORE_ALL:     === water-edit-ir before cse ===
 
-// --- 5. Round-trip: pipeline result is identical with and without edit -----
+// --- 5. Abort: 'q' at the first stop aborts the rest of the pipeline ------
+// RUN: echo "q" | not water-opt %s -mlir-disable-threading=true \
+// RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
+// RUN:   --water-edit-ir-after-all -o /dev/null 2>&1 \
+// RUN:   | FileCheck -check-prefix=ABORT %s
+
+// ABORT:     === water-edit-ir after canonicalize ===
+// ABORT-NOT: === water-edit-ir after cse ===
+
+// --- 6. Round-trip: pipeline result is identical with and without edit -----
 // RUN: echo "" | water-opt %s -mlir-disable-threading=true \
 // RUN:   -pass-pipeline='builtin.module(canonicalize,cse)' \
 // RUN:   --water-edit-ir-after=canonicalize \

--- a/water/tools/water-opt/WaterOptMain.cpp
+++ b/water/tools/water-opt/WaterOptMain.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "water/Tools/water-opt/WaterOptMain.h"
+#include "water/Transforms/EditIR.h"
 
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Debug/CLOptionsSetup.h"
@@ -25,6 +26,7 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Support/FileUtilities.h"
@@ -49,6 +51,64 @@
 
 using namespace mlir;
 using namespace llvm;
+
+//===----------------------------------------------------------------------===//
+// --mlir-edit-ir-{before,after} CLI options
+//===----------------------------------------------------------------------===//
+
+static cl::opt<bool> editIRBeforeAll(
+    "mlir-edit-ir-before-all",
+    cl::desc("Open the IR for interactive editing before each pass"),
+    cl::init(false));
+
+static cl::opt<std::string> editIRBefore(
+    "mlir-edit-ir-before",
+    cl::desc("Open the IR for interactive editing before a specific pass "
+             "(pass argument name, e.g. 'canonicalize')"),
+    cl::init(""));
+
+static cl::opt<bool> editIRAfterAll(
+    "mlir-edit-ir-after-all",
+    cl::desc("Open the IR for interactive editing after each pass"),
+    cl::init(false));
+
+static cl::opt<std::string> editIRAfter(
+    "mlir-edit-ir-after",
+    cl::desc("Open the IR for interactive editing after a specific pass "
+             "(pass argument name, e.g. 'canonicalize')"),
+    cl::init(""));
+
+static cl::opt<std::string> editIREditor(
+    "mlir-edit-ir-editor",
+    cl::desc("Editor command for --mlir-edit-ir-{before,after}[-all] "
+             "(default: $EDITOR)"),
+    cl::init(""));
+
+/// Build a pass filter from an -all bool flag and a single-pass string flag.
+static water::PassFilter buildEditFilter(bool all, const std::string &name) {
+  if (all)
+    return [](Pass *, Operation *) { return true; };
+  if (!name.empty()) {
+    return
+        [name](Pass *pass, Operation *) { return pass->getArgument() == name; };
+  }
+  return nullptr;
+}
+
+/// If any --mlir-edit-ir-* flags are set, attach the edit-IR
+/// instrumentation to `pm`.
+static void addEditIRInstrumentation(PassManager &pm) {
+  auto beforeFilter = buildEditFilter(editIRBeforeAll, editIRBefore);
+  auto afterFilter = buildEditFilter(editIRAfterAll, editIRAfter);
+
+  if (!beforeFilter && !afterFilter)
+    return;
+
+  pm.addInstrumentation(water::createEditIRInstrumentation(
+      std::move(beforeFilter), std::move(afterFilter), editIREditor));
+}
+
+//===----------------------------------------------------------------------===//
 
 /// Unrolls a call site containing other call site locations as callers (call
 /// stack) into a flat list of callee locations.
@@ -340,6 +400,7 @@ performActions(raw_ostream &os,
   pm.enableVerifier(config.shouldVerifyPasses());
   if (failed(applyPassManagerCLOptions(pm)))
     return failure();
+  addEditIRInstrumentation(pm);
   pm.enableTiming(timing);
   if (config.shouldRunReproducer() && failed(reproOptions.apply(pm)))
     return failure();

--- a/water/tools/water-opt/WaterOptMain.cpp
+++ b/water/tools/water-opt/WaterOptMain.cpp
@@ -53,39 +53,39 @@ using namespace mlir;
 using namespace llvm;
 
 //===----------------------------------------------------------------------===//
-// --mlir-edit-ir-{before,after} CLI options
+// --water-edit-ir-{before,after} CLI options
 //===----------------------------------------------------------------------===//
 
 static cl::opt<bool> editIRBeforeAll(
-    "mlir-edit-ir-before-all",
+    "water-edit-ir-before-all",
     cl::desc("Open the IR for interactive editing before each pass"),
     cl::init(false));
 
 static cl::opt<std::string> editIRBefore(
-    "mlir-edit-ir-before",
+    "water-edit-ir-before",
     cl::desc("Open the IR for interactive editing before a specific pass "
              "(pass argument name, e.g. 'canonicalize')"),
     cl::init(""));
 
 static cl::opt<bool> editIRAfterAll(
-    "mlir-edit-ir-after-all",
+    "water-edit-ir-after-all",
     cl::desc("Open the IR for interactive editing after each pass"),
     cl::init(false));
 
 static cl::opt<std::string> editIRAfter(
-    "mlir-edit-ir-after",
+    "water-edit-ir-after",
     cl::desc("Open the IR for interactive editing after a specific pass "
              "(pass argument name, e.g. 'canonicalize')"),
     cl::init(""));
 
 static cl::opt<std::string> editIREditor(
-    "mlir-edit-ir-editor",
-    cl::desc("Editor command for --mlir-edit-ir-{before,after}[-all] "
+    "water-edit-ir-editor",
+    cl::desc("Editor command for --water-edit-ir-{before,after}[-all] "
              "(default: $EDITOR)"),
     cl::init(""));
 
 /// Build a pass filter from an -all bool flag and a single-pass string flag.
-static water::PassFilter buildEditFilter(bool all, const std::string &name) {
+static water::PassFilter buildEditFilter(bool all, StringRef name) {
   if (all)
     return [](Pass *, Operation *) { return true; };
   if (!name.empty()) {
@@ -95,7 +95,7 @@ static water::PassFilter buildEditFilter(bool all, const std::string &name) {
   return nullptr;
 }
 
-/// If any --mlir-edit-ir-* flags are set, attach the edit-IR
+/// If any --water-edit-ir-* flags are set, attach the edit-IR
 /// instrumentation to `pm`.
 static void addEditIRInstrumentation(PassManager &pm) {
   auto beforeFilter = buildEditFilter(editIRBeforeAll, editIRBefore);

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -125,19 +125,19 @@ class WaveCompileOptions:
         return self.wave_runtime
 
     # === Interactive editing ===
-    mlir_edit_ir_before: Optional[str] = None
-    mlir_edit_ir_after: Optional[str] = None
-    mlir_edit_ir_before_all: bool = False
-    mlir_edit_ir_after_all: bool = False
+    edit_ir_before: Optional[str] = None
+    edit_ir_after: Optional[str] = None
+    edit_ir_before_all: bool = False
+    edit_ir_after_all: bool = False
 
     @property
-    def mlir_edit_ir_interactive(self) -> bool:
-        """True when any `--mlir-edit-ir-*` option is set."""
+    def edit_ir_interactive(self) -> bool:
+        """True when any `--water-edit-ir-*` option is set."""
         return (
-            self.mlir_edit_ir_before is not None
-            or self.mlir_edit_ir_after is not None
-            or self.mlir_edit_ir_before_all
-            or self.mlir_edit_ir_after_all
+            self.edit_ir_before is not None
+            or self.edit_ir_after is not None
+            or self.edit_ir_before_all
+            or self.edit_ir_after_all
         )
 
     # === Print options ===

--- a/wave_lang/kernel/wave/compile_options.py
+++ b/wave_lang/kernel/wave/compile_options.py
@@ -124,6 +124,22 @@ class WaveCompileOptions:
     def dynamic_strides(self) -> bool:
         return self.wave_runtime
 
+    # === Interactive editing ===
+    mlir_edit_ir_before: Optional[str] = None
+    mlir_edit_ir_after: Optional[str] = None
+    mlir_edit_ir_before_all: bool = False
+    mlir_edit_ir_after_all: bool = False
+
+    @property
+    def mlir_edit_ir_interactive(self) -> bool:
+        """True when any `--mlir-edit-ir-*` option is set."""
+        return (
+            self.mlir_edit_ir_before is not None
+            or self.mlir_edit_ir_after is not None
+            or self.mlir_edit_ir_before_all
+            or self.mlir_edit_ir_after_all
+        )
+
     # === Print options ===
     mlir_print_ir_after_all: bool = False
     print_ir_after: list[str] = field(default_factory=list)

--- a/wave_lang/kernel/wave/water.py
+++ b/wave_lang/kernel/wave/water.py
@@ -35,6 +35,58 @@ from wave_lang.support.ir_imports import (
 )
 
 
+def _edit_ir_flags(options: "WaveCompileOptions") -> list[str]:
+    """Return `--mlir-edit-ir-*` CLI flags for the given options."""
+    flags = []
+    if options.mlir_edit_ir_before_all:
+        flags.append("--mlir-edit-ir-before-all")
+    elif options.mlir_edit_ir_before is not None:
+        flags.append(f"--mlir-edit-ir-before={options.mlir_edit_ir_before}")
+    if options.mlir_edit_ir_after_all:
+        flags.append("--mlir-edit-ir-after-all")
+    elif options.mlir_edit_ir_after is not None:
+        flags.append(f"--mlir-edit-ir-after={options.mlir_edit_ir_after}")
+    return flags
+
+
+def _run_water_opt(
+    args: list[str], mlir_input: str, tool_name: str, interactive: bool
+) -> str:
+    """Run `water-opt` (or similar), returning stdout as a string.
+
+    When interactive is True the input IR is written to a temp file and stdin
+    is inherited from the terminal so that `--mlir-edit-ir-*` prompts work.
+    Stderr flows to the terminal in that case (needed for edit-IR prompts).
+    """
+    if interactive:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+            f.write(mlir_input)
+            input_path = f.name
+        try:
+            result = subprocess.run(
+                [*args, input_path], stdout=subprocess.PIPE, text=True
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"{tool_name} failed with return code {result.returncode}."
+                )
+            return result.stdout
+        finally:
+            os.unlink(input_path)
+    else:
+        try:
+            return subprocess.check_output(
+                args, input=mlir_input, stderr=subprocess.PIPE, text=True
+            )
+        except subprocess.CalledProcessError as e:
+            error_msg = (
+                f"{tool_name} subprocess failed with return code {e.returncode}."
+            )
+            if e.stderr:
+                error_msg += f" Error: {e.stderr}"
+            raise RuntimeError(error_msg) from e
+
+
 def _find_single_nested(name: str, parent: Operation) -> Operation:
     """Find a single operation with the specified name in a single-block parent operation.
 
@@ -420,25 +472,16 @@ def water_waveasm_lowering_pipeline(
         *add_opt(canonicalize_cse),
     ]
 
-    def run_subprocess(args, input_text, tool_name):
-        try:
-            result = subprocess.run(
-                args, input=input_text, text=True, capture_output=True
-            )
-            if result.returncode != 0:
-                raise RuntimeError(
-                    f"{tool_name} failed (rc={result.returncode}):\n{result.stderr}"
-                )
-            return result.stdout
-        except RuntimeError:
-            raise
-        except Exception as e:
-            raise RuntimeError(f"{tool_name} failed: {e}") from e
-
     water_args = [water_opt, make_linear_pass_pipeline(lowering_pipeline)]
     if options.mlir_print_ir_after_all:
         water_args.append("--mlir-print-ir-after-all")
-    lowered_mlir = run_subprocess(water_args, mlir_asm, "water-opt (lowering)")
+    water_args.extend(_edit_ir_flags(options))
+    lowered_mlir = _run_water_opt(
+        water_args,
+        mlir_asm,
+        "water-opt (lowering)",
+        options.mlir_edit_ir_interactive,
+    )
 
     if options.print_mlir:
         print("=== After water-opt lowering ===")
@@ -467,7 +510,7 @@ def water_waveasm_lowering_pipeline(
     ]
     if options.mlir_print_ir_after_all:
         waveasm_args.append("--mlir-print-ir-after-all")
-    binary_mlir = run_subprocess(waveasm_args, lowered_mlir, "waveasm-translate")
+    binary_mlir = _run_water_opt(waveasm_args, lowered_mlir, "waveasm-translate", False)
 
     if options.print_mlir:
         print("=== After waveasm-translate ===")
@@ -482,7 +525,13 @@ def water_waveasm_lowering_pipeline(
     host_args = [water_opt, make_linear_pass_pipeline(host_pipeline)]
     if options.mlir_print_ir_after_all:
         host_args.append("--mlir-print-ir-after-all")
-    final_mlir = run_subprocess(host_args, binary_mlir, "water-opt (host)")
+    host_args.extend(_edit_ir_flags(options))
+    final_mlir = _run_water_opt(
+        host_args,
+        binary_mlir,
+        "water-opt (host)",
+        options.mlir_edit_ir_interactive,
+    )
 
     if options.print_mlir:
         print("=== After water-opt host ===")
@@ -579,23 +628,20 @@ def water_lowering_pipeline(module: Module, options: WaveCompileOptions) -> Modu
     args = [binary, make_linear_pass_pipeline(pipeline)]
     if options.mlir_print_ir_after_all:
         args.append("--mlir-print-ir-after-all")
-
-    try:
-        result = subprocess.check_output(
-            args,
-            input=mlir_asm,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        error_msg = f"Subprocess failed with return code {e.returncode}."
-        raise RuntimeError(error_msg) from e
+    args.extend(_edit_ir_flags(options))
+    result = _run_water_opt(
+        args, mlir_asm, "water-opt", options.mlir_edit_ir_interactive
+    )
 
     with module.context:
         return Module.parse(result)
 
 
 def apply_water_middle_end_passes(
-    mlir_text: str, *, print_local_scope: bool = False
+    mlir_text: str,
+    options: "WaveCompileOptions | None" = None,
+    *,
+    print_local_scope: bool = False,
 ) -> str:
     """Apply Water middle-end pipeline using subprocess water-opt.
 
@@ -606,6 +652,11 @@ def apply_water_middle_end_passes(
 
     Args:
         mlir_text: Input Wave dialect MLIR as string
+        options: Optional compile options. When any ``mlir_edit_ir_*``
+            field is set, the corresponding flag is forwarded to
+            ``water-opt`` and stdin is inherited from the terminal.
+        print_local_scope: Append ``--mlir-print-local-scope`` to the
+            water-opt invocation.
 
     Returns:
         Optimized MLIR as string after applying the passes
@@ -614,25 +665,11 @@ def apply_water_middle_end_passes(
         RuntimeError: If water-opt is not available or passes fail
     """
     binary = get_water_opt()
-
-    try:
-        command = [
-            binary,
-            "--allow-unregistered-dialect",
-            "--water-middle-end-lowering",
-        ]
-        if print_local_scope:
-            command.append("--mlir-print-local-scope")
-        result = subprocess.check_output(
-            command,
-            input=mlir_text,
-            text=True,
-        )
-
-        return result
-
-    except subprocess.CalledProcessError as e:
-        error_msg = f"water-opt subprocess failed with return code {e.returncode}."
-        if e.stderr:
-            error_msg += f" Error: {e.stderr}"
-        raise RuntimeError(error_msg) from e
+    args = [binary, "--allow-unregistered-dialect", "--water-middle-end-lowering"]
+    if print_local_scope:
+        args.append("--mlir-print-local-scope")
+    interactive = False
+    if options is not None:
+        args.extend(_edit_ir_flags(options))
+        interactive = options.mlir_edit_ir_interactive
+    return _run_water_opt(args, mlir_text, "water-opt", interactive)

--- a/wave_lang/kernel/wave/water.py
+++ b/wave_lang/kernel/wave/water.py
@@ -36,16 +36,16 @@ from wave_lang.support.ir_imports import (
 
 
 def _edit_ir_flags(options: "WaveCompileOptions") -> list[str]:
-    """Return `--mlir-edit-ir-*` CLI flags for the given options."""
+    """Return `--water-edit-ir-*` CLI flags for the given options."""
     flags = []
-    if options.mlir_edit_ir_before_all:
-        flags.append("--mlir-edit-ir-before-all")
-    elif options.mlir_edit_ir_before is not None:
-        flags.append(f"--mlir-edit-ir-before={options.mlir_edit_ir_before}")
-    if options.mlir_edit_ir_after_all:
-        flags.append("--mlir-edit-ir-after-all")
-    elif options.mlir_edit_ir_after is not None:
-        flags.append(f"--mlir-edit-ir-after={options.mlir_edit_ir_after}")
+    if options.edit_ir_before_all:
+        flags.append("--water-edit-ir-before-all")
+    elif options.edit_ir_before is not None:
+        flags.append(f"--water-edit-ir-before={options.edit_ir_before}")
+    if options.edit_ir_after_all:
+        flags.append("--water-edit-ir-after-all")
+    elif options.edit_ir_after is not None:
+        flags.append(f"--water-edit-ir-after={options.edit_ir_after}")
     return flags
 
 
@@ -55,7 +55,7 @@ def _run_water_opt(
     """Run `water-opt` (or similar), returning stdout as a string.
 
     When interactive is True the input IR is written to a temp file and stdin
-    is inherited from the terminal so that `--mlir-edit-ir-*` prompts work.
+    is inherited from the terminal so that `--water-edit-ir-*` prompts work.
     Stderr flows to the terminal in that case (needed for edit-IR prompts).
     """
     if interactive:
@@ -480,7 +480,7 @@ def water_waveasm_lowering_pipeline(
         water_args,
         mlir_asm,
         "water-opt (lowering)",
-        options.mlir_edit_ir_interactive,
+        options.edit_ir_interactive,
     )
 
     if options.print_mlir:
@@ -530,7 +530,7 @@ def water_waveasm_lowering_pipeline(
         host_args,
         binary_mlir,
         "water-opt (host)",
-        options.mlir_edit_ir_interactive,
+        options.edit_ir_interactive,
     )
 
     if options.print_mlir:
@@ -629,9 +629,7 @@ def water_lowering_pipeline(module: Module, options: WaveCompileOptions) -> Modu
     if options.mlir_print_ir_after_all:
         args.append("--mlir-print-ir-after-all")
     args.extend(_edit_ir_flags(options))
-    result = _run_water_opt(
-        args, mlir_asm, "water-opt", options.mlir_edit_ir_interactive
-    )
+    result = _run_water_opt(args, mlir_asm, "water-opt", options.edit_ir_interactive)
 
     with module.context:
         return Module.parse(result)
@@ -652,7 +650,7 @@ def apply_water_middle_end_passes(
 
     Args:
         mlir_text: Input Wave dialect MLIR as string
-        options: Optional compile options. When any ``mlir_edit_ir_*``
+        options: Optional compile options. When any ``edit_ir_*``
             field is set, the corresponding flag is forwarded to
             ``water-opt`` and stdin is inherited from the terminal.
         print_local_scope: Append ``--mlir-print-local-scope`` to the
@@ -671,5 +669,5 @@ def apply_water_middle_end_passes(
     interactive = False
     if options is not None:
         args.extend(_edit_ir_flags(options))
-        interactive = options.mlir_edit_ir_interactive
+        interactive = options.edit_ir_interactive
     return _run_water_opt(args, mlir_text, "water-opt", interactive)

--- a/wave_lang/kernel/wave/water.py
+++ b/wave_lang/kernel/wave/water.py
@@ -52,27 +52,30 @@ def _edit_ir_flags(options: "WaveCompileOptions") -> list[str]:
 def _run_water_opt(
     args: list[str], mlir_input: str, tool_name: str, interactive: bool
 ) -> str:
-    """Run `water-opt` (or similar), returning stdout as a string.
+    """Run `water-opt` (or similar), returning the compiled IR as a string.
 
-    When interactive is True the input IR is written to a temp file and stdin
-    is inherited from the terminal so that `--water-edit-ir-*` prompts work.
-    Stderr flows to the terminal in that case (needed for edit-IR prompts).
+    When interactive is True the input IR is written to a temp file, the
+    compiled output is directed to a separate temp file via `-o`, and
+    stdout/stderr/stdin are inherited from the terminal so that
+    `--water-edit-ir-*` prompts are visible and interactive.
     """
     if interactive:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
             f.write(mlir_input)
             input_path = f.name
+        output_path = tempfile.mktemp(suffix=".mlir")
         try:
-            result = subprocess.run(
-                [*args, input_path], stdout=subprocess.PIPE, text=True
-            )
+            result = subprocess.run([*args, input_path, "-o", output_path])
             if result.returncode != 0:
                 raise RuntimeError(
                     f"{tool_name} failed with return code {result.returncode}."
                 )
-            return result.stdout
+            with open(output_path) as out_f:
+                return out_f.read()
         finally:
             os.unlink(input_path)
+            if os.path.exists(output_path):
+                os.unlink(output_path)
     else:
         try:
             return subprocess.check_output(


### PR DESCRIPTION
Add interactive IR editing via PassInstrumentation. After (or before) a specified pass, the current IR is written to a temporary file and compilation blocks until the user presses Enter, allowing manual edits to the IR mid-pipeline.

- `--mlir-edit-ir-after=<pass>` / `--mlir-edit-ir-before=<pass>` for a specific pass
- `--mlir-edit-ir-after-all` / `--mlir-edit-ir-before-all` for every pass
- `--mlir-edit-ir-editor=<cmd>` to specify the editor to auto-open the file (default: `$EDITOR`)
- Python `WaveCompileOptions` extended with matching fields
- Lit test covering selective firing, all-pass variants, and IR round-trip

Fixes #1291 